### PR TITLE
Quench Processing: updating quench tests and how GUI launches

### DIFF
--- a/applications/quench_processing/quench_gui.py
+++ b/applications/quench_processing/quench_gui.py
@@ -49,9 +49,9 @@ class QuenchGUI(Display):
 
         self.add_selectors()
 
-        self.cm_combobox.addItems(ALL_CRYOMODULES)
-        self.cav_combobox.addItems(map(str, range(1, 9)))
-        self.decarad_combobox.addItems(["1", "2"])
+        self.cm_combobox.addItems([""] + ALL_CRYOMODULES)
+        self.cav_combobox.addItems([""] + list(map(str, range(1, 9))))
+        self.decarad_combobox.addItems(["", "1", "2"])
 
         widget_hlayout: QHBoxLayout = QHBoxLayout()
         self.controls_vlayout: QVBoxLayout = QVBoxLayout()
@@ -115,9 +115,6 @@ class QuenchGUI(Display):
 
         self.decarads: Dict[str, Decarad] = {"1": Decarad(1), "2": Decarad(2)}
         self.current_decarad: Optional[Decarad] = None
-
-        self.update_cm()
-        self.update_decarad()
 
         self.quench_worker: Optional[QuenchWorker] = None
 
@@ -274,6 +271,9 @@ class QuenchGUI(Display):
             )
 
     def update_decarad(self):
+        if not self.decarad_combobox.currentText():
+            return
+
         self.current_decarad = self.decarads[self.decarad_combobox.currentText()]
 
         self.update_timeplot()
@@ -287,6 +287,9 @@ class QuenchGUI(Display):
         self.decarad_voltage_readback.channel = self.current_decarad.voltage_readback_pv
 
     def update_cm(self):
+        if not self.cm_combobox.currentText() or not self.cav_combobox.currentText():
+            return
+
         self.clear_all_connections()
 
         self.current_cm: Cryomodule = QUENCH_MACHINE.cryomodules[

--- a/applications/quench_processing/quench_gui.py
+++ b/applications/quench_processing/quench_gui.py
@@ -241,6 +241,12 @@ class QuenchGUI(Display):
             self.clear_connections(signal)
 
     def update_timeplot(self):
+        if (
+            not self.cm_combobox.currentText()
+            or not self.cav_combobox.currentText()
+            or not self.decarad_combobox.currentText()
+        ):
+            return
         self.amp_rad_timeplot.clearCurves()
 
         self.current_decarad = self.decarads[self.decarad_combobox.currentText()]

--- a/applications/quench_processing/quench_gui.py
+++ b/applications/quench_processing/quench_gui.py
@@ -247,6 +247,7 @@ class QuenchGUI(Display):
             or not self.decarad_combobox.currentText()
         ):
             return
+
         self.amp_rad_timeplot.clearCurves()
 
         self.current_decarad = self.decarads[self.decarad_combobox.currentText()]

--- a/tests/applications/quench_processing/test_quench_gui.py
+++ b/tests/applications/quench_processing/test_quench_gui.py
@@ -1,43 +1,53 @@
-from random import choice
+from random import choice, randint
 from unittest.mock import MagicMock, call
 
+import pytest
 from PyQt5.QtGui import QColor
 from pytestqt.qtbot import QtBot
 
 from applications.quench_processing.quench_gui import QuenchGUI
-from applications.quench_processing.quench_linac import QUENCH_MACHINE
+from applications.quench_processing.quench_linac import (
+    QuenchCavity,
+    QuenchCryomodule,
+)
 from applications.quench_processing.quench_worker import QuenchWorker
 from utils.qt import make_rainbow
 from utils.sc_linac.decarad import Decarad
+from utils.sc_linac.linac import Machine
+from utils.sc_linac.linac_utils import ALL_CRYOMODULES
 
-non_hl_iterator = QUENCH_MACHINE.non_hl_iterator
 
-
-def populate_gui(gui: QuenchGUI):
+@pytest.fixture
+def gui():
+    gui = QuenchGUI()
+    gui.rf_controls = MagicMock()
     gui.status_label.setText = MagicMock()
     gui.status_label.setStyleSheet = MagicMock()
     gui.start_button.setEnabled = MagicMock()
-    cavity = next(non_hl_iterator)
-    gui.current_cav = cavity
-    gui.current_cm = cavity.cryomodule
-    # gui.cm_combobox.setCurrentText(cavity.cryomodule.name)
-    # gui.cav_combobox.setCurrentText(str(cavity.number))
+    cm = choice(ALL_CRYOMODULES)
+    gui.cm_combobox.currentText = MagicMock(return_value=cm)
+    gui.current_cm = Machine(
+        cavity_class=QuenchCavity, cryomodule_class=QuenchCryomodule
+    ).cryomodules[cm]
+    cavity = randint(1, 8)
+    gui.current_cav = gui.current_cm.cavities[cavity]
+    gui.cav_combobox.currentText = MagicMock(return_value=str(cavity))
+    decarad = choice([1, 2])
+    gui.decarad_combobox.currentText = MagicMock(return_value=str(decarad))
+    gui.current_decarad = Decarad(decarad)
+    return gui
 
 
-def test_handle_status(qtbot: QtBot):
-    gui = QuenchGUI()
+def test_handle_status(qtbot: QtBot, gui):
     qtbot.addWidget(gui)
-    populate_gui(gui)
     msg = "Testing handle status"
     gui.handle_status(msg)
     gui.status_label.setStyleSheet.assert_called_with("color: blue;")
     gui.status_label.setText.assert_called_with(msg)
 
 
-def test_handle_error(qtbot):
-    gui = QuenchGUI()
+def test_handle_error(qtbot, gui):
     qtbot.addWidget(gui)
-    populate_gui(gui)
     msg = "Testing handle error"
     gui.handle_error(msg)
     gui.status_label.setStyleSheet.assert_called_with("color: red;")
@@ -45,10 +55,8 @@ def test_handle_error(qtbot):
     gui.start_button.setEnabled.assert_called_with(True)
 
 
-def test_handle_finished(qtbot):
-    gui = QuenchGUI()
+def test_handle_finished(qtbot, gui):
     qtbot.addWidget(gui)
-    populate_gui(gui)
     msg = "Testing handle finished"
     gui.handle_finished(msg)
     gui.status_label.setStyleSheet.assert_called_with("color: green;")
@@ -56,10 +64,8 @@ def test_handle_finished(qtbot):
     gui.start_button.setEnabled.assert_called_with(True)
 
 
-def test_process(qtbot):
-    gui = QuenchGUI()
+def test_process(qtbot, gui):
     qtbot.addWidget(gui)
-    populate_gui(gui)
     gui.current_decarad = Decarad(choice([1, 2]))
     gui.make_quench_worker = MagicMock()
     gui.quench_worker = MagicMock()
@@ -70,49 +76,40 @@ def test_process(qtbot):
     gui.quench_worker.start.assert_called()
 
 
-def test_make_quench_worker(qtbot: QtBot):
-    gui = QuenchGUI()
+def test_make_quench_worker(qtbot: QtBot, gui):
     qtbot.addWidget(gui)
-    populate_gui(gui)
     gui.quench_worker = None
     gui.make_quench_worker()
     assert isinstance(gui.quench_worker, QuenchWorker)
 
 
-def test_clear_connections(qtbot: QtBot):
-    gui = QuenchGUI()
+def test_clear_connections(qtbot: QtBot, gui):
     qtbot.addWidget(gui)
-    populate_gui(gui)
     signal = MagicMock()
     gui.clear_connections(signal)
     signal.disconnect.assert_called()
 
 
-def test_clear_all_connections(qtbot: QtBot):
-    gui = QuenchGUI()
+def test_clear_all_connections(qtbot: QtBot, gui):
     qtbot.addWidget(gui)
-    populate_gui(gui)
     gui.rf_controls = MagicMock()
     gui.clear_connections = MagicMock()
     gui.clear_all_connections()
     gui.clear_connections.assert_called_with(gui.decarad_off_button.clicked)
 
 
-def test_update_timeplot(qtbot: QtBot):
-    gui = QuenchGUI()
+def test_update_timeplot(qtbot: QtBot, gui):
     qtbot.addWidget(gui)
-    populate_gui(gui)
     gui.update_cm = MagicMock()
     gui.amp_rad_timeplot = MagicMock()
-    decarad = choice([1, 2])
-    gui.decarad_combobox.setCurrentText(str(decarad))
+    gui.update_decarad = MagicMock()
     gui.update_timeplot()
     gui.amp_rad_timeplot.clearCurves.assert_called()
     gui.amp_rad_timeplot.addYChannel.assert_called()
 
     colors = make_rainbow(num_colors=11)
     channels = [gui.current_cav.aact_pv] + [
-        head.raw_dose_rate_pv for head in Decarad(decarad).heads.values()
+        head.raw_dose_rate_pv for head in gui.current_decarad.heads.values()
     ]
     axes = ["Amplitude"] + ["Radiation" for _ in range(10)]
     calls = []
@@ -128,18 +125,17 @@ def test_update_timeplot(qtbot: QtBot):
     gui.amp_rad_timeplot.addYChannel.assert_has_calls(calls, any_order=True)
 
 
-def test_update_decarad(qtbot: QtBot):
-    gui = QuenchGUI()
+def test_update_decarad(qtbot: QtBot, gui):
     qtbot.addWidget(gui)
-    populate_gui(gui)
     gui.update_timeplot = MagicMock()
     gui.clear_connections = MagicMock()
     gui.decarad_on_button.clicked = MagicMock()
     gui.decarad_off_button.clicked = MagicMock()
+    gui.decarad_combobox.currentText = MagicMock(return_value="1")
 
     gui.update_decarad()
 
-    assert gui.current_decarad == Decarad(int(gui.decarad_combobox.currentText()))
+    assert gui.current_decarad == Decarad(1)
     gui.update_timeplot.assert_called()
     gui.clear_connections.assert_called()
     gui.decarad_on_button.clicked.connect.assert_called_with(
@@ -154,46 +150,39 @@ def test_update_decarad(qtbot: QtBot):
     )
 
 
-# TODO figure out why this test is causing problems
-"""pydm.widgets.enum_combo_box:enum_combo_box.py:179
-   Can not change value to 'ACCL:L0B:0110:RFMODECTRL-6'.
-   Not an option in PyDMComboBox"""
+def test_update_cm(qtbot: QtBot, gui):
+    qtbot.addWidget(gui)
+    gui.clear_all_connections = MagicMock()
+    gui.update_timeplot = MagicMock()
+    gui.waveform_updater.updatePlot = MagicMock()
+    gui.rf_controls.ssa_on_button = MagicMock()
+    gui.rf_controls.ssa_off_button = MagicMock()
+    gui.rf_controls.rf_on_button = MagicMock()
+    gui.rf_controls.rf_off_button = MagicMock()
+    gui.start_button = MagicMock()
+    gui.abort_button = MagicMock()
 
-# def test_update_cm(qtbot: QtBot):
-#     gui = QuenchGUI()
-#     qtbot.addWidget(gui)
-#     populate_gui(gui)
-#     gui.clear_all_connections = MagicMock()
-#     gui.update_timeplot = MagicMock()
-#     gui.waveform_updater.updatePlot = MagicMock()
-#     gui.rf_controls.ssa_on_button = MagicMock()
-#     gui.rf_controls.ssa_off_button = MagicMock()
-#     gui.rf_controls.rf_on_button = MagicMock()
-#     gui.rf_controls.rf_off_button = MagicMock()
-#     gui.start_button = MagicMock()
-#     gui.abort_button = MagicMock()
-#
-#     gui.update_cm()
-#     gui.clear_all_connections.assert_called()
-#     gui.update_timeplot.assert_called()
-#     gui.waveform_updater.updatePlot.assert_called()
-#     cavity = gui.current_cav
-#     gui.rf_controls.ssa_on_button.clicked.connect.assert_called_with(cavity.ssa.turn_on)
-#     gui.rf_controls.ssa_off_button.clicked.connect.assert_called_with(
-#         cavity.ssa.turn_off
-#     )
-#     assert gui.rf_controls.ssa_readback_label.channel == cavity.ssa.status_pv
-#
-#     assert gui.rf_controls.rf_mode_combobox.channel == cavity.rf_mode_ctrl_pv
-#     assert gui.rf_controls.rf_mode_readback_label.channel == cavity.rf_mode_pv
-#     gui.rf_controls.rf_on_button.clicked.connect.assert_called_with(cavity.turn_on)
-#     gui.rf_controls.rf_off_button.clicked.connect.assert_called_with(cavity.turn_off)
-#     assert gui.rf_controls.rf_status_readback_label.channel == cavity.rf_state_pv
-#
-#     assert gui.rf_controls.ades_spinbox.channel == cavity.ades_pv
-#     assert gui.rf_controls.aact_readback_label.channel == cavity.aact_pv
-#     assert gui.rf_controls.srf_max_spinbox.channel == cavity.srf_max_pv
-#     assert gui.rf_controls.srf_max_readback_label.channel == cavity.srf_max_pv
-#
-#     gui.start_button.clicked.connect.assert_called_with(gui.process)
-#     gui.abort_button.clicked.connect.assert_called_with(cavity.request_abort)
+    gui.update_cm()
+    gui.clear_all_connections.assert_called()
+    gui.update_timeplot.assert_called()
+    gui.waveform_updater.updatePlot.assert_called()
+    cavity = gui.current_cav
+    gui.rf_controls.ssa_on_button.clicked.connect.assert_called_with(cavity.ssa.turn_on)
+    gui.rf_controls.ssa_off_button.clicked.connect.assert_called_with(
+        cavity.ssa.turn_off
+    )
+    assert gui.rf_controls.ssa_readback_label.channel == cavity.ssa.status_pv
+
+    assert gui.rf_controls.rf_mode_combobox.channel == cavity.rf_mode_ctrl_pv
+    assert gui.rf_controls.rf_mode_readback_label.channel == cavity.rf_mode_pv
+    gui.rf_controls.rf_on_button.clicked.connect.assert_called_with(cavity.turn_on)
+    gui.rf_controls.rf_off_button.clicked.connect.assert_called_with(cavity.turn_off)
+    assert gui.rf_controls.rf_status_readback_label.channel == cavity.rf_state_pv
+
+    assert gui.rf_controls.ades_spinbox.channel == cavity.ades_pv
+    assert gui.rf_controls.aact_readback_label.channel == cavity.aact_pv
+    assert gui.rf_controls.srf_max_spinbox.channel == cavity.srf_max_pv
+    assert gui.rf_controls.srf_max_readback_label.channel == cavity.srf_max_pv
+
+    gui.start_button.clicked.connect.assert_called_with(gui.process)
+    gui.abort_button.clicked.connect.assert_called_with(cavity.request_abort)

--- a/tests/applications/quench_processing/test_quench_gui.py
+++ b/tests/applications/quench_processing/test_quench_gui.py
@@ -155,10 +155,6 @@ def test_update_cm(qtbot: QtBot, gui):
     gui.clear_all_connections = MagicMock()
     gui.update_timeplot = MagicMock()
     gui.waveform_updater.updatePlot = MagicMock()
-    gui.rf_controls.ssa_on_button = MagicMock()
-    gui.rf_controls.ssa_off_button = MagicMock()
-    gui.rf_controls.rf_on_button = MagicMock()
-    gui.rf_controls.rf_off_button = MagicMock()
     gui.start_button = MagicMock()
     gui.abort_button = MagicMock()
 

--- a/utils/qt.py
+++ b/utils/qt.py
@@ -21,11 +21,13 @@ class RFControls:
         self.rf_status_readback_label: PyDMLabel = PyDMLabel()
 
         self.ades_spinbox: PyDMSpinbox = PyDMSpinbox()
-        self.ades_spinbox.setSingleStep(0.1)
+        self.ades_spinbox.step_exponent = -1
+        self.ades_spinbox.update_step_size()
         self.aact_readback_label: PyDMLabel = PyDMLabel()
 
         self.srf_max_spinbox: PyDMSpinbox = PyDMSpinbox()
-        self.srf_max_spinbox.setSingleStep(0.1)
+        self.srf_max_spinbox.step_exponent = -1
+        self.srf_max_spinbox.update_step_size()
         self.srf_max_readback_label: PyDMLabel = PyDMLabel()
 
         self.rf_control_groupbox: QGroupBox = QGroupBox("RF Controls")

--- a/utils/qt.py
+++ b/utils/qt.py
@@ -21,9 +21,11 @@ class RFControls:
         self.rf_status_readback_label: PyDMLabel = PyDMLabel()
 
         self.ades_spinbox: PyDMSpinbox = PyDMSpinbox()
+        self.ades_spinbox.setSingleStep(0.1)
         self.aact_readback_label: PyDMLabel = PyDMLabel()
 
         self.srf_max_spinbox: PyDMSpinbox = PyDMSpinbox()
+        self.srf_max_spinbox.setSingleStep(0.1)
         self.srf_max_readback_label: PyDMLabel = PyDMLabel()
 
         self.rf_control_groupbox: QGroupBox = QGroupBox("RF Controls")


### PR DESCRIPTION
Given the non zero number of times people have accidentally started a process on CM01, I've changed the cavity selection to be more explicit on launch. I also figured out how to update the step size on the amplitude spin boxes and I fixed the test that was failing