### PR TITLE
Auto Setup: checking for abort flag in ssa while loops

### DIFF
--- a/utils/sc_linac/ssa.py
+++ b/utils/sc_linac/ssa.py
@@ -261,9 +261,17 @@ class SSA(linac_utils.SCLinacObject):
         print(f"{self} reset")
 
     def wait_while_resetting(self):
+        start = datetime.now()
         while self.is_resetting:
             self.cavity.check_abort()
-            time.sleep(1)
+            print(
+                f"{datetime.now().replace(microsecond=0)} Waiting for {self} to finish resetting"
+            )
+            time.sleep(5)
+            if (datetime.now() - start).total_seconds() >= 90:
+                raise linac_utils.SSAFaultError(
+                    f"{self} took too long to reset, inspect and try again"
+                )
 
     def start_calibration(self):
         if not self._calibration_start_pv_obj:

--- a/utils/sc_linac/ssa.py
+++ b/utils/sc_linac/ssa.py
@@ -242,10 +242,12 @@ class SSA(linac_utils.SCLinacObject):
     def reset(self):
         reset_attempt = 0
         while self.is_faulted:
+            self.cavity.check_abort()
             print(f"Resetting {self}...")
             self.reset_pv_obj.put(1)
 
             while self.is_resetting:
+                self.cavity.check_abort()
                 time.sleep(1)
 
             if (

--- a/utils/sc_linac/ssa.py
+++ b/utils/sc_linac/ssa.py
@@ -246,9 +246,7 @@ class SSA(linac_utils.SCLinacObject):
             print(f"Resetting {self}...")
             self.reset_pv_obj.put(1)
 
-            while self.is_resetting:
-                self.cavity.check_abort()
-                time.sleep(1)
+            self.wait_while_resetting()
 
             if (
                 self.is_faulted
@@ -261,6 +259,11 @@ class SSA(linac_utils.SCLinacObject):
             reset_attempt += 1
 
         print(f"{self} reset")
+
+    def wait_while_resetting(self):
+        while self.is_resetting:
+            self.cavity.check_abort()
+            time.sleep(1)
 
     def start_calibration(self):
         if not self._calibration_start_pv_obj:


### PR DESCRIPTION
There were a couple of while loops during SSA reset that didn't check for the abort flag and would therefore never exit if the SSA was having trouble resetting