### PR TITLE
rounding liquid levels before printing

### DIFF
--- a/applications/q0/q0_linac.py
+++ b/applications/q0/q0_linac.py
@@ -17,6 +17,8 @@ from utils.sc_linac.cavity import Cavity
 from utils.sc_linac.cryomodule import Cryomodule
 from utils.sc_linac.linac import Machine
 
+def round_for_printing(unrounded_number):
+    return np.round(unrounded_number, decimals=3)
 
 class Calibration:
     def __init__(self, time_stamp, cryomodule):
@@ -621,7 +623,8 @@ class Q0Cryomodule(Cryomodule):
             avgLevel > q0_utils.MIN_DS_LL
         ):
             self.check_abort()
-            print(f"Averaged level is {avgLevel}; waiting 10s")
+            avgLevel_rounded = round_for_printing(self.averaged_liquid_level) 
+            print(f"Averaged level is {avgLevel_rounded}; waiting 10s")
             avgLevel = self.averaged_liquid_level
             sleep(10)
 
@@ -822,8 +825,9 @@ class Q0Cryomodule(Cryomodule):
 
         while (desiredLiquidLevel - self.averaged_liquid_level) > 0.01:
             self.check_abort()
+            avgLevel_rounded = round_for_printing(self.averaged_liquid_level)
             print(
-                f"Current averaged level is {self.averaged_liquid_level}; waiting 10 seconds for more data."
+                f"Current averaged level is {avgLevel_rounded}; waiting 10 seconds for more data."
             )
             sleep(10)
 

--- a/applications/q0/q0_linac.py
+++ b/applications/q0/q0_linac.py
@@ -17,8 +17,10 @@ from utils.sc_linac.cavity import Cavity
 from utils.sc_linac.cryomodule import Cryomodule
 from utils.sc_linac.linac import Machine
 
+
 def round_for_printing(unrounded_number):
     return np.round(unrounded_number, decimals=3)
+
 
 class Calibration:
     def __init__(self, time_stamp, cryomodule):
@@ -623,7 +625,7 @@ class Q0Cryomodule(Cryomodule):
             avgLevel > q0_utils.MIN_DS_LL
         ):
             self.check_abort()
-            avgLevel_rounded = round_for_printing(self.averaged_liquid_level) 
+            avgLevel_rounded = round_for_printing(self.averaged_liquid_level)
             print(f"Averaged level is {avgLevel_rounded}; waiting 10s")
             avgLevel = self.averaged_liquid_level
             sleep(10)


### PR DESCRIPTION
## Summary of changes
In `q0_linac.py,` I rounded the average liquid level before sending it to the print statements.
The value used for math calculations is not changed, only the printed value is rounded.

## Other notes
Maybe we can test this during the POMM?