### PR TITLE
Tightening stepper tolerances

### DIFF
--- a/tests/utils/sc_linac/test_linac_utils.py
+++ b/tests/utils/sc_linac/test_linac_utils.py
@@ -4,7 +4,7 @@ from utils.sc_linac.linac_utils import stepper_tol_factor
 
 
 def test_stepper_tol_factor_low():
-    assert stepper_tol_factor(randint(-50000, 0)) == 10
+    assert stepper_tol_factor(randint(-10000, 0)) == 5
 
 
 def test_stepper_tol_factor_high():
@@ -12,4 +12,4 @@ def test_stepper_tol_factor_high():
 
 
 def test_stepper_tol_factor():
-    assert 1.01 <= stepper_tol_factor(randint(50000, int(50e6))) <= 10
+    assert 1.01 <= stepper_tol_factor(randint(10000, int(50e6))) <= 5

--- a/utils/sc_linac/linac_utils.py
+++ b/utils/sc_linac/linac_utils.py
@@ -177,7 +177,7 @@ def stepper_tol_factor(num_steps) -> float:
     First attempt at making the stepper mover tolerance dependent on the
     steps to move. We have empirically determined that 1.3GHz cavities move
     around 50,000 steps around resonance and 50,000,000 steps for cold landing.
-    We want to allow triple the expected steps around resonance, and 1% of the
+    We want to allow 10x the expected steps around resonance, and 1% of the
     expected steps around cold landing. We also empirically determined that
     this also works to (roughly) triple the steps around resonance for 3.9GHz
     cavities, which are about an order of magnitude lower at resonance (while
@@ -188,11 +188,11 @@ def stepper_tol_factor(num_steps) -> float:
 
     num_steps = abs(num_steps)
 
-    if num_steps <= 50000:
-        return 10
+    if num_steps <= 10000:
+        return 5
 
-    step_tol_des = {50e3: 10, 100e3: 5, 1e6: 1.5, 5e6: 1.1, 10e6: 1.1, 50e6: 1.01}
-    ranges = [(50e3, 100e3), (100e3, 1e6), (1e6, 5e6), (5e6, 50e6)]
+    step_tol_des = {10e3: 5, 100e3: 2.5, 1e6: 1.25, 5e6: 1.1, 10e6: 1.05, 50e6: 1.01}
+    ranges = [(10e3, 100e3), (100e3, 1e6), (1e6, 5e6), (5e6, 50e6)]
 
     for start, end in ranges:
         if end >= num_steps > start:

--- a/utils/sc_linac/linac_utils.py
+++ b/utils/sc_linac/linac_utils.py
@@ -177,7 +177,7 @@ def stepper_tol_factor(num_steps) -> float:
     First attempt at making the stepper mover tolerance dependent on the
     steps to move. We have empirically determined that 1.3GHz cavities move
     around 50,000 steps around resonance and 50,000,000 steps for cold landing.
-    We want to allow 10x the expected steps around resonance, and 1% of the
+    We want to allow 5x the expected steps around resonance, and 1% of the
     expected steps around cold landing. We also empirically determined that
     this also works to (roughly) triple the steps around resonance for 3.9GHz
     cavities, which are about an order of magnitude lower at resonance (while


### PR DESCRIPTION
After the disaster this morning with the 10x tolerance allowing the stepper to move the cavity almost all the way back to cold landing, we're tightening the leash and hoping it doesn't lead to too many "moved more steps than expected" errors in normal auto setup operations. That said, the initial 10x was questionable to begin with 