### PR TITLE
Auto setup failing on HWMODE PV not returning valid value

### DIFF
--- a/utils/sc_linac/cavity.py
+++ b/utils/sc_linac/cavity.py
@@ -444,7 +444,7 @@ class Cavity(linac_utils.SCLinacObject):
 
     @property
     def hw_mode(self):
-        return self.hw_mode_pv_obj.get()
+        return self.hw_mode_pv_obj.get(use_caget=False)
 
     @property
     def is_online(self) -> bool:


### PR DESCRIPTION
The problem seems to be with the underlying pyepics cage; changing to using the pyepics pv object get to see if that helps 