### PR TITLE
SCLP-26: removing L1BHL tab in auto setup 

### DIFF
--- a/applications/auto_setup/setup_gui.py
+++ b/applications/auto_setup/setup_gui.py
@@ -119,17 +119,11 @@ class SetupGUI(Display):
                 GUILinac(
                     f"L{linac_idx}B",
                     linac_idx,
-                    linac_utils.LINAC_TUPLES[linac_idx][1],
+                    linac_utils.LINAC_CM_MAP[linac_idx],
                     settings=self.settings,
                     parent=self,
                 )
             )
-        self.linac_widgets.insert(
-            2,
-            GUILinac(
-                "L1BHL", 1, linac_utils.L1BHL, settings=self.settings, parent=self
-            ),
-        )
 
     def connect_buttons(self):
         self.machine_abort_button.setStyleSheet(ERROR_STYLESHEET)


### PR DESCRIPTION
There was no good reason for this split and it was causing problems where requesting L1BHL only target CMs 2 and 3
https://jira.slac.stanford.edu/browse/SCLP-26