### PR TITLE
SCLP 50: Making yellow warning faults more ledgible

### DIFF
--- a/displays/cavity_display/frontend/cavity_widget.py
+++ b/displays/cavity_display/frontend/cavity_widget.py
@@ -17,7 +17,7 @@ from pydm.widgets.drawing import PyDMDrawingPolygon
 from qtpy.QtCore import Property as qtProperty, Qt, Slot
 
 GREEN_FILL_COLOR = QColor(9, 141, 0)
-YELLOW_FILL_COLOR = QColor(244, 230, 67, 180)
+YELLOW_FILL_COLOR = QColor(244, 230, 67, 120)
 RED_FILL_COLOR = QColor(150, 0, 0)
 PURPLE_FILL_COLOR = QColor(131, 61, 235)
 GRAY_FILL_COLOR = QColor(127, 127, 127)

--- a/displays/cavity_display/frontend/cavity_widget.py
+++ b/displays/cavity_display/frontend/cavity_widget.py
@@ -17,7 +17,7 @@ from pydm.widgets.drawing import PyDMDrawingPolygon
 from qtpy.QtCore import Property as qtProperty, Qt, Slot
 
 GREEN_FILL_COLOR = QColor(9, 141, 0)
-YELLOW_FILL_COLOR = QColor(244, 230, 67, 120)
+YELLOW_FILL_COLOR = QColor(240, 202, 40, 200)
 RED_FILL_COLOR = QColor(150, 0, 0)
 PURPLE_FILL_COLOR = QColor(131, 61, 235)
 GRAY_FILL_COLOR = QColor(127, 127, 127)

--- a/displays/cavity_display/frontend/cavity_widget.py
+++ b/displays/cavity_display/frontend/cavity_widget.py
@@ -17,7 +17,7 @@ from pydm.widgets.drawing import PyDMDrawingPolygon
 from qtpy.QtCore import Property as qtProperty, Qt, Slot
 
 GREEN_FILL_COLOR = QColor(9, 141, 0)
-YELLOW_FILL_COLOR = QColor(240, 202, 40, 200)
+YELLOW_FILL_COLOR = QColor(255, 191, 0, 200)
 RED_FILL_COLOR = QColor(150, 0, 0)
 PURPLE_FILL_COLOR = QColor(131, 61, 235)
 GRAY_FILL_COLOR = QColor(127, 127, 127)

--- a/displays/cavity_display/frontend/cavity_widget.py
+++ b/displays/cavity_display/frontend/cavity_widget.py
@@ -17,7 +17,7 @@ from pydm.widgets.drawing import PyDMDrawingPolygon
 from qtpy.QtCore import Property as qtProperty, Qt, Slot
 
 GREEN_FILL_COLOR = QColor(9, 141, 0)
-YELLOW_FILL_COLOR = QColor(244, 230, 67)
+YELLOW_FILL_COLOR = QColor(244, 230, 67, 180)
 RED_FILL_COLOR = QColor(150, 0, 0)
 PURPLE_FILL_COLOR = QColor(131, 61, 235)
 GRAY_FILL_COLOR = QColor(127, 127, 127)

--- a/displays/cavity_display/frontend/cavity_widget.py
+++ b/displays/cavity_display/frontend/cavity_widget.py
@@ -17,7 +17,7 @@ from pydm.widgets.drawing import PyDMDrawingPolygon
 from qtpy.QtCore import Property as qtProperty, Qt, Slot
 
 GREEN_FILL_COLOR = QColor(9, 141, 0)
-YELLOW_FILL_COLOR = QColor(255, 191, 0, 200)
+YELLOW_FILL_COLOR = QColor(255, 165, 0, 200)
 RED_FILL_COLOR = QColor(150, 0, 0)
 PURPLE_FILL_COLOR = QColor(131, 61, 235)
 GRAY_FILL_COLOR = QColor(127, 127, 127)


### PR DESCRIPTION
![yellow_original](https://github.com/user-attachments/assets/71038222-6e21-42b4-896f-36f17d0c4ad5)
![yellow_orange](https://github.com/user-attachments/assets/aa1e3b65-3e81-44f3-bad3-627b55b0a5a6)

Using a different shade of yellow and adjusting alpha (transparency) to make white fault text more ledgible on yellow background