### PR TITLE
SCLP-69: checking rf control instead of rf state in quench resetter

### DIFF
--- a/applications/quench_processing/quench_resetter.py
+++ b/applications/quench_processing/quench_resetter.py
@@ -23,7 +23,7 @@ def check_cavities(cavity_list: List[QuenchCavity], watcher_pv: PV):
         issued_reset = False
         for quench_cav in cavity_list:
             logger = quench_cav.cryomodule.logger
-            if quench_cav.hw_mode == HW_MODE_ONLINE_VALUE and quench_cav.is_on:
+            if quench_cav.hw_mode == HW_MODE_ONLINE_VALUE and not quench_cav.turned_off:
                 if quench_cav.is_quenched:
                     issued_reset = quench_cav.reset_quench()
 

--- a/tests/applications/quench_processing/test_quench_resetter.py
+++ b/tests/applications/quench_processing/test_quench_resetter.py
@@ -32,7 +32,7 @@ def cavities(monkeypatch):
 
     for cavity in cavity_lst:
         cavity._hw_mode_pv_obj = make_mock_pv(get_val=HW_MODE_ONLINE_VALUE)
-        cavity._rf_state_pv_obj = make_mock_pv(get_val=1)
+        cavity._rf_control_pv_obj = make_mock_pv(get_val=1)
         cavity._quench_latch_pv_obj = make_mock_pv(get_val=0)
         cavity.reset_quench = MagicMock(return_value=False)
 
@@ -40,11 +40,11 @@ def cavities(monkeypatch):
 
 
 def test_check_cavities_quenched(cavities):
-    watcer_pv = make_mock_pv(get_val=0)
+    watcher_pv = make_mock_pv(get_val=0)
     quenched_cav = choice(cavities)
     quenched_cav._quench_latch_pv_obj = make_mock_pv(get_val=1)
 
-    check_cavities(cavities, watcer_pv)
+    check_cavities(cavities, watcher_pv)
     for cavity in cavities:
         if cavity == quenched_cav:
             cavity.reset_quench.assert_called()
@@ -53,7 +53,7 @@ def test_check_cavities_quenched(cavities):
 
 
 def test_check_cavities_not_online(cavities):
-    watcer_pv = make_mock_pv(get_val=0)
+    watcher_pv = make_mock_pv(get_val=0)
 
     for cavity in cavities:
         cavity._quench_latch_pv_obj = make_mock_pv(get_val=1)
@@ -70,7 +70,7 @@ def test_check_cavities_not_online(cavities):
         )
     )
 
-    check_cavities(cavities, watcer_pv)
+    check_cavities(cavities, watcher_pv)
     for cavity in cavities:
         if cavity == not_online_cav:
             cavity.reset_quench.assert_not_called()
@@ -79,15 +79,15 @@ def test_check_cavities_not_online(cavities):
 
 
 def test_check_cavities_not_on(cavities):
-    watcer_pv = make_mock_pv(get_val=0)
+    watcher_pv = make_mock_pv(get_val=0)
 
     for cavity in cavities:
         cavity._quench_latch_pv_obj = make_mock_pv(get_val=1)
 
     not_on_cav = choice(cavities)
-    not_on_cav._rf_state_pv_obj = make_mock_pv(get_val=0)
+    not_on_cav._rf_control_pv_obj = make_mock_pv(get_val=0)
 
-    check_cavities(cavities, watcer_pv)
+    check_cavities(cavities, watcher_pv)
     for cavity in cavities:
         if cavity == not_on_cav:
             cavity.reset_quench.assert_not_called()

--- a/utils/sc_linac/cavity.py
+++ b/utils/sc_linac/cavity.py
@@ -299,9 +299,9 @@ class Cavity(linac_utils.SCLinacObject):
     @property
     def measured_loaded_q_in_tolerance(self) -> bool:
         return (
-                self.loaded_q_lower_limit
-                <= self.measured_loaded_q
-                <= self.loaded_q_upper_limit
+            self.loaded_q_lower_limit
+            <= self.measured_loaded_q
+            <= self.loaded_q_upper_limit
         )
 
     def push_loaded_q(self):
@@ -318,9 +318,9 @@ class Cavity(linac_utils.SCLinacObject):
     @property
     def measured_scale_factor_in_tolerance(self) -> bool:
         return (
-                self.scale_factor_lower_limit
-                <= self.measured_scale_factor
-                <= self.scale_factor_upper_limit
+            self.scale_factor_lower_limit
+            <= self.measured_scale_factor
+            <= self.scale_factor_upper_limit
         )
 
     def push_scale_factor(self):
@@ -337,13 +337,13 @@ class Cavity(linac_utils.SCLinacObject):
     @property
     def characterization_running(self) -> bool:
         return (
-                self.characterization_status == linac_utils.CHARACTERIZATION_RUNNING_VALUE
+            self.characterization_status == linac_utils.CHARACTERIZATION_RUNNING_VALUE
         )
 
     @property
     def characterization_crashed(self) -> bool:
         return (
-                self.characterization_status == linac_utils.CHARACTERIZATION_CRASHED_VALUE
+            self.characterization_status == linac_utils.CHARACTERIZATION_CRASHED_VALUE
         )
 
     @property
@@ -531,8 +531,12 @@ class Cavity(linac_utils.SCLinacObject):
         return self.rf_state_pv_obj.get()
 
     @property
-    def is_on(self):
+    def is_on(self) -> bool:
         return self.rf_state == 1
+
+    @property
+    def turned_off(self) -> bool:
+        return self.rf_control == 0
 
     def delta_piezo(self):
         delta_volts = self.piezo.voltage - linac_utils.PIEZO_CENTER_VOLTAGE
@@ -597,10 +601,10 @@ class Cavity(linac_utils.SCLinacObject):
             return self.detune_best_pv_obj.severity == EPICS_INVALID_VAL
 
     def _auto_tune(
-            self,
-            delta_hz_func: Callable,
-            tolerance: int = 50,
-            reset_signed_steps: bool = False,
+        self,
+        delta_hz_func: Callable,
+        tolerance: int = 50,
+        reset_signed_steps: bool = False,
     ):
         if self.detune_invalid:
             raise linac_utils.DetuneError(f"{self} detune invalid")


### PR DESCRIPTION
cavities were not being checked for quenches when the RF was reporting off