### PR TITLE
refactor(cli): auto-discover launchers with decorators

### DIFF
--- a/src/sc_linac_physics/launchers.py
+++ b/src/sc_linac_physics/launchers.py
@@ -3,107 +3,145 @@
 import sys
 
 
-def launch_python_display(module_path: str, class_name: str, *args):
+def display(func):
+    """Decorator to mark a launcher as a display."""
+    func._launcher_category = "display"
+    return func
+
+
+def application(func):
+    """Decorator to mark a launcher as an application."""
+    func._launcher_category = "application"
+    return func
+
+
+def launch_python_display(display_class, *args, standalone=True):
     """Launch a Python-based PyDM display.
 
     Parameters
     ----------
-    module_path : str
-        Full module path
-    class_name : str
-        Name of the display class
+    display_class : class
+        The display class to instantiate
     *args
         Additional command line arguments
+    standalone : bool, optional
+        If True, creates new application and blocks (for standalone launch).
+        If False, uses existing application (for child windows). Default is True.
     """
-    from pydm import PyDMApplication
-    import importlib
+    if standalone:
+        # Standalone mode: create app and block
+        from pydm import PyDMApplication
 
-    # Import the module and get the class
-    module = importlib.import_module(module_path)
-    display_class = getattr(module, class_name)
-
-    # Create PyDM application and show the display
-    app = PyDMApplication(command_line_args=list(args))
-    main_window = display_class()
-    main_window.show()
-    sys.exit(app.exec())
+        app = PyDMApplication(command_line_args=list(args))
+        main_window = display_class()
+        main_window.show()
+        sys.exit(app.exec())
+    else:
+        # Child window mode: use existing app, return reference
+        main_window = display_class()
+        main_window.show()
+        return main_window
 
 
 # Display launchers
-def launch_srf_home():
+@display
+def launch_srf_home(standalone=True):
     """Launch the SRF home display."""
-    launch_python_display(
-        "sc_linac_physics.displays.srfhome.srf_home", "SRFHome", *sys.argv[1:]
+    from sc_linac_physics.displays.srfhome.srf_home import SRFHome
+
+    return launch_python_display(
+        display_class=SRFHome, *sys.argv[1:], standalone=standalone
     )
 
 
-def launch_cavity_display():
+@display
+def launch_cavity_display(standalone=True):
     """Launch the cavity control display."""
-    launch_python_display(
-        "sc_linac_physics.displays.cavity_display.cavity_display",
-        "CavityDisplayGUI",
-        *sys.argv[1:],
+    from sc_linac_physics.displays.cavity_display.cavity_display import (
+        CavityDisplayGUI,
+    )
+
+    return launch_python_display(
+        display_class=CavityDisplayGUI, *sys.argv[1:], standalone=standalone
     )
 
 
-def launch_fault_decoder():
+@display
+def launch_fault_decoder(standalone=True):
     """Launch the fault decoder display."""
-    launch_python_display(
-        "sc_linac_physics.displays.cavity_display.frontend.fault_decoder_display",
-        "DecoderDisplay",
-        *sys.argv[1:],
+    from sc_linac_physics.displays.cavity_display.frontend.fault_decoder_display import (
+        DecoderDisplay,
+    )
+
+    return launch_python_display(
+        display_class=DecoderDisplay, *sys.argv[1:], standalone=standalone
     )
 
 
-def launch_fault_count():
+@display
+def launch_fault_count(standalone=True):
     """Launch the fault count display."""
-    launch_python_display(
-        "sc_linac_physics.displays.cavity_display.frontend.fault_count_display",
-        "FaultCountDisplay",
-        *sys.argv[1:],
+    from sc_linac_physics.displays.cavity_display.frontend.fault_count_display import (
+        FaultCountDisplay,
+    )
+
+    return launch_python_display(
+        display_class=FaultCountDisplay, *sys.argv[1:], standalone=standalone
     )
 
 
 # Application launchers
-def launch_quench_processing():
+@application
+def launch_quench_processing(standalone=True):
     """Launch the quench processing GUI."""
-    launch_python_display(
-        "sc_linac_physics.applications.quench_processing.quench_gui",
-        "QuenchGUI",
-        *sys.argv[1:],
+    from sc_linac_physics.applications.quench_processing.quench_gui import (
+        QuenchGUI,
+    )
+
+    return launch_python_display(
+        display_class=QuenchGUI, *sys.argv[1:], standalone=standalone
     )
 
 
-def launch_auto_setup():
+@application
+def launch_auto_setup(standalone=True):
     """Launch the auto setup GUI."""
-    launch_python_display(
-        "sc_linac_physics.applications.auto_setup.setup_gui",
-        "SetupGUI",
-        *sys.argv[1:],
+    from sc_linac_physics.applications.auto_setup.setup_gui import SetupGUI
+
+    return launch_python_display(
+        display_class=SetupGUI, *sys.argv[1:], standalone=standalone
     )
 
 
-def launch_q0_measurement():
+@application
+def launch_q0_measurement(standalone=True):
     """Launch the Q0 measurement GUI."""
-    launch_python_display(
-        "sc_linac_physics.applications.q0.q0_gui", "Q0GUI", *sys.argv[1:]
+    from sc_linac_physics.applications.q0.q0_gui import Q0GUI
+
+    return launch_python_display(
+        display_class=Q0GUI, *sys.argv[1:], standalone=standalone
     )
 
 
-def launch_tuning():
+@application
+def launch_tuning(standalone=True):
     """Launch the tuning GUI."""
-    launch_python_display(
-        "sc_linac_physics.applications.tuning.tuning_gui",
-        "Tuner",
-        *sys.argv[1:],
+    from sc_linac_physics.applications.tuning.tuning_gui import Tuner
+
+    return launch_python_display(
+        display_class=Tuner, *sys.argv[1:], standalone=standalone
     )
 
 
-def launch_microphonics():
-    """launch the microphonics GUI"""
-    launch_python_display(
-        module_path="sc_linac_physics.applications.microphonics.gui.main_window",
-        class_name="MicrophonicsGUI",
+@application
+def launch_microphonics(standalone=True):
+    """Launch the microphonics GUI."""
+    from sc_linac_physics.applications.microphonics.gui.main_window import (
+        MicrophonicsGUI,
+    )
+
+    return launch_python_display(
+        display_class=MicrophonicsGUI, standalone=standalone
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,434 +1,429 @@
-# tests/test_cli.py
+"""Tests for the command-line interface."""
+
 import sys
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from sc_linac_physics import cli
 
 
-class TestDisplaysConfiguration:
-    """Test the DISPLAYS configuration dictionary."""
+class TestDisplayInfo:
+    """Tests for DisplayInfo dataclass."""
 
-    def test_displays_structure(self):
-        """Test that DISPLAYS has the expected structure."""
-        assert isinstance(cli.DISPLAYS, dict)
-        assert len(cli.DISPLAYS) > 0
+    def test_display_info_creation(self):
+        """Test creating a DisplayInfo instance."""
 
-        for name, info in cli.DISPLAYS.items():
-            assert "launcher" in info
-            assert "description" in info
-            assert isinstance(info["launcher"], str)
-            assert isinstance(info["description"], str)
+        def dummy_launcher():
+            pass
 
-    def test_main_displays_present(self):
-        """Test that main displays are configured."""
-        main_displays = ["srf-home", "cavity", "fault-decoder", "fault-count"]
-        for display in main_displays:
-            assert display in cli.DISPLAYS
+        info = cli.DisplayInfo(
+            name="test-display",
+            launcher=dummy_launcher,
+            description="Test description",
+            category="display",
+        )
 
-    def test_applications_present(self):
-        """Test that applications are configured."""
-        applications = ["quench", "setup", "q0", "tuning"]
-        for app in applications:
-            assert app in cli.DISPLAYS
+        assert info.name == "test-display"
+        assert info.launcher == dummy_launcher
+        assert info.description == "Test description"
+        assert info.category == "display"
 
-    def test_launcher_names_format(self):
-        """Test that launcher names follow expected format."""
-        for name, info in cli.DISPLAYS.items():
-            launcher = info["launcher"]
-            assert launcher.startswith("launch_")
-            assert "_" in launcher
+
+class TestHelperFunctions:
+    """Tests for helper functions."""
+
+    def test_extract_description_from_docstring_with_docstring(self):
+        """Test extracting description from function with docstring."""
+
+        def func_with_docstring():
+            """This is a test function.
+
+            With multiple lines.
+            """
+            pass
+
+        result = cli._extract_description_from_docstring(func_with_docstring)
+        assert result == "This is a test function."
+
+    def test_extract_description_from_docstring_no_docstring(self):
+        """Test extracting description from function without docstring."""
+
+        def func_without_docstring():
+            pass
+
+        result = cli._extract_description_from_docstring(func_without_docstring)
+        assert result == "No description available"
+
+    def test_extract_description_from_docstring_empty_docstring(self):
+        """Test extracting description from function with empty docstring."""
+
+        def func_empty_docstring():
+            """"""
+            pass
+
+        result = cli._extract_description_from_docstring(func_empty_docstring)
+        assert result == "No description available"
+
+    def test_extract_description_multiline_formatting(self):
+        """Test extracting description with whitespace handling."""
+
+        def func_whitespace():
+            """
+            Description with leading whitespace.
+            """
+            pass
+
+        result = cli._extract_description_from_docstring(func_whitespace)
+        assert result == "Description with leading whitespace."
+
+    def test_get_display_name_with_launch_prefix(self):
+        """Test converting function name to display name."""
+        result = cli._get_display_name("launch_srf_home")
+        assert result == "srf-home"
+
+    def test_get_display_name_without_launch_prefix(self):
+        """Test converting function name without launch prefix."""
+        result = cli._get_display_name("some_function")
+        assert result == "some_function"
+
+    def test_get_display_name_multiple_underscores(self):
+        """Test converting function name with multiple underscores."""
+        result = cli._get_display_name("launch_fault_count_display")
+        assert result == "fault-count-display"
+
+    def test_get_category_with_decorator(self):
+        """Test getting category from decorated function."""
+
+        def decorated_func():
+            pass
+
+        decorated_func._launcher_category = "display"
+
+        result = cli._get_category(decorated_func)
+        assert result == "display"
+
+    def test_get_category_without_decorator(self):
+        """Test getting category from undecorated function."""
+
+        def undecorated_func():
+            pass
+
+        result = cli._get_category(undecorated_func)
+        assert result == "application"
+
+
+class TestDiscoverLaunchers:
+    """Tests for launcher discovery."""
+
+    @patch("sc_linac_physics.cli.inspect.getmembers")
+    def test_discover_launchers(self, mock_getmembers):
+        """Test automatic launcher discovery."""
+
+        def launch_test_display():
+            """Test display."""
+            pass
+
+        launch_test_display._launcher_category = "display"
+
+        def launch_test_app():
+            """Test application."""
+            pass
+
+        launch_test_app._launcher_category = "application"
+
+        def launch_python_display():
+            """Base function to exclude."""
+            pass
+
+        def not_a_launcher():
+            """Should be excluded."""
+            pass
+
+        mock_getmembers.return_value = [
+            ("launch_test_display", launch_test_display),
+            ("launch_test_app", launch_test_app),
+            ("launch_python_display", launch_python_display),
+            ("not_a_launcher", not_a_launcher),
+        ]
+
+        result = cli._discover_launchers()
+
+        assert len(result) == 2
+        assert any(
+            d.name == "test-display" and d.category == "display" for d in result
+        )
+        assert any(
+            d.name == "test-app" and d.category == "application" for d in result
+        )
+        assert not any(d.name == "python-display" for d in result)
+        assert not any(d.name == "not_a_launcher" for d in result)
 
 
 class TestListDisplays:
-    """Test the list_displays function."""
+    """Tests for list_displays function."""
 
     def test_list_displays_output(self, capsys):
         """Test that list_displays produces expected output."""
-        cli.list_displays()
+        with patch.object(
+            cli,
+            "DISPLAY_LIST",
+            [
+                cli.DisplayInfo(
+                    name="test-display",
+                    launcher=lambda: None,
+                    description="A test display",
+                    category="display",
+                ),
+                cli.DisplayInfo(
+                    name="test-app",
+                    launcher=lambda: None,
+                    description="A test application",
+                    category="application",
+                ),
+            ],
+        ):
+            cli.list_displays()
 
         captured = capsys.readouterr()
         output = captured.out
 
-        # Check header
-        assert "SC Linac Physics" in output
-        assert "Available Applications" in output
+        assert "SC Linac Physics - Available Applications" in output
+        assert "DISPLAYS:" in output
+        assert "APPLICATIONS:" in output
+        assert "test-display" in output
+        assert "A test display" in output
+        assert "test-app" in output
+        assert "A test application" in output
+        assert "Usage: sc-linac <name>" in output
 
-        # Check sections
+    def test_list_displays_empty(self, capsys):
+        """Test list_displays with no displays."""
+        with patch.object(cli, "DISPLAY_LIST", []):
+            cli.list_displays()
+
+        captured = capsys.readouterr()
+        output = captured.out
+
+        assert "SC Linac Physics - Available Applications" in output
         assert "DISPLAYS:" in output
         assert "APPLICATIONS:" in output
 
-        # Check usage instructions
-        assert "Usage:" in output
-        assert "sc-linac" in output
-
-    def test_list_displays_contains_all_displays(self, capsys):
-        """Test that list_displays shows all configured displays."""
-        cli.list_displays()
-
-        captured = capsys.readouterr()
-        output = captured.out
-
-        for name in cli.DISPLAYS.keys():
-            assert name in output
-
-    def test_list_displays_contains_descriptions(self, capsys):
-        """Test that list_displays shows descriptions."""
-        cli.list_displays()
+    def test_list_displays_sorting(self, capsys):
+        """Test that displays are sorted alphabetically."""
+        with patch.object(
+            cli,
+            "DISPLAY_LIST",
+            [
+                cli.DisplayInfo("zebra", lambda: None, "Z", "display"),
+                cli.DisplayInfo("alpha", lambda: None, "A", "display"),
+                cli.DisplayInfo("beta", lambda: None, "B", "display"),
+            ],
+        ):
+            cli.list_displays()
 
         captured = capsys.readouterr()
         output = captured.out
 
-        for info in cli.DISPLAYS.values():
-            assert info["description"] in output
+        # Check that alpha appears before beta and zebra in the output
+        alpha_pos = output.find("alpha")
+        beta_pos = output.find("beta")
+        zebra_pos = output.find("zebra")
 
-    def test_list_displays_formatting(self, capsys):
-        """Test that list_displays has proper formatting."""
-        cli.list_displays()
-
-        captured = capsys.readouterr()
-        output = captured.out
-
-        # Check for separator lines
-        assert "=" * 70 in output
-
-        # Check for proper spacing
-        lines = output.split("\n")
-        assert any(line.strip() == "" for line in lines)  # Has blank lines
+        assert alpha_pos < beta_pos < zebra_pos
 
 
 class TestLaunchDisplay:
-    """Test the launch_display function."""
+    """Tests for launch_display function."""
 
-    def test_launch_display_basic(self):
-        """Test basic display launch."""
-        # Mock the launchers module before it's imported
-        mock_launchers = MagicMock()
-        mock_func = Mock()
-        mock_launchers.launch_srf_home = mock_func
+    def test_launch_display_without_extra_args(self):
+        """Test launching a display without extra arguments."""
+        mock_launcher = MagicMock()
+        display_info = cli.DisplayInfo(
+            name="test",
+            launcher=mock_launcher,
+            description="Test",
+            category="display",
+        )
 
-        with patch.dict(
-            "sys.modules", {"sc_linac_physics.launchers": mock_launchers}
-        ):
-            cli.launch_display("srf-home")
+        with patch.object(cli, "DISPLAYS", {"test": display_info}):
+            cli.launch_display("test")
 
-        mock_func.assert_called_once()
+        mock_launcher.assert_called_once()
 
     def test_launch_display_with_extra_args(self):
-        """Test display launch with extra arguments."""
-        mock_launchers = MagicMock()
-        mock_func = Mock()
-        mock_launchers.launch_cavity_display = mock_func
+        """Test launching a display with extra arguments."""
+        mock_launcher = MagicMock()
+        display_info = cli.DisplayInfo(
+            name="test",
+            launcher=mock_launcher,
+            description="Test",
+            category="display",
+        )
 
         original_argv = sys.argv.copy()
+        with patch.object(cli, "DISPLAYS", {"test": display_info}):
+            cli.launch_display("test", ["--arg1", "--arg2"])
 
-        with patch.dict(
-            "sys.modules", {"sc_linac_physics.launchers": mock_launchers}
-        ):
-            cli.launch_display("cavity", ["--arg1", "value1"])
-
-        # Verify launcher was called
-        mock_func.assert_called_once()
-
-        # Verify sys.argv was restored
+        mock_launcher.assert_called_once()
+        # sys.argv should be restored
         assert sys.argv == original_argv
 
-    def test_launch_display_argv_modification(self):
-        """Test that sys.argv is properly modified during launch."""
-
-        def check_argv():
-            # Should have script name + extra args
-            assert len(sys.argv) == 3
-            assert sys.argv[1] == "--test"
-            assert sys.argv[2] == "value"
-
-        mock_launchers = MagicMock()
-        mock_func = Mock(side_effect=check_argv)
-        mock_launchers.launch_fault_decoder = mock_func
-
-        original_argv = sys.argv.copy()
-
-        with patch.dict(
-            "sys.modules", {"sc_linac_physics.launchers": mock_launchers}
-        ):
-            cli.launch_display("fault-decoder", ["--test", "value"])
-
-        # Verify argv was restored
-        assert sys.argv == original_argv
-
-    def test_launch_display_argv_restored_on_exception(self):
+    def test_launch_display_restores_argv_on_exception(self):
         """Test that sys.argv is restored even if launcher raises exception."""
-        mock_launchers = MagicMock()
-        mock_func = Mock(side_effect=Exception("Launch failed"))
-        mock_launchers.launch_quench_processing = mock_func
+
+        def failing_launcher():
+            raise RuntimeError("Test error")
+
+        display_info = cli.DisplayInfo(
+            name="test",
+            launcher=failing_launcher,
+            description="Test",
+            category="display",
+        )
 
         original_argv = sys.argv.copy()
+        with patch.object(cli, "DISPLAYS", {"test": display_info}):
+            with pytest.raises(RuntimeError, match="Test error"):
+                cli.launch_display("test", ["--arg"])
 
-        with patch.dict(
-            "sys.modules", {"sc_linac_physics.launchers": mock_launchers}
-        ):
-            with pytest.raises(Exception, match="Launch failed"):
-                cli.launch_display("quench")
-
-        # Verify argv was restored despite exception
         assert sys.argv == original_argv
 
-    def test_launch_all_displays(self):
-        """Test launching each configured display."""
-        for display_name, info in cli.DISPLAYS.items():
-            mock_launchers = MagicMock()
-            mock_func = Mock()
-            setattr(mock_launchers, info["launcher"], mock_func)
+    def test_launch_display_default_extra_args(self):
+        """Test launch_display with default None extra_args."""
+        mock_launcher = MagicMock()
+        display_info = cli.DisplayInfo(
+            name="test",
+            launcher=mock_launcher,
+            description="Test",
+            category="display",
+        )
 
-            with patch.dict(
-                "sys.modules", {"sc_linac_physics.launchers": mock_launchers}
-            ):
-                cli.launch_display(display_name)
+        with patch.object(cli, "DISPLAYS", {"test": display_info}):
+            cli.launch_display("test")
 
-            mock_func.assert_called_once()
-
-    def test_launch_display_with_none_args(self):
-        """Test launch_display with None as extra_args."""
-        mock_launchers = MagicMock()
-        mock_func = Mock()
-        mock_launchers.launch_tuning = mock_func
-
-        with patch.dict(
-            "sys.modules", {"sc_linac_physics.launchers": mock_launchers}
-        ):
-            cli.launch_display("tuning", None)
-
-        mock_func.assert_called_once()
+        mock_launcher.assert_called_once()
 
 
 class TestMain:
-    """Test the main CLI entry point."""
+    """Tests for main CLI entry point."""
 
-    @patch("sc_linac_physics.cli.list_displays")
-    def test_main_list_command(self, mock_list):
-        """Test main with 'list' command."""
-        with patch("sys.argv", ["sc-linac", "list"]):
-            cli.main()
+    def test_main_list_command(self, capsys):
+        """Test main with list command."""
+        with patch.object(sys, "argv", ["sc-linac", "list"]):
+            with patch.object(cli, "DISPLAYS", {}):
+                with patch.object(cli, "DISPLAY_LIST", []):
+                    cli.main()
 
-        mock_list.assert_called_once()
+        captured = capsys.readouterr()
+        assert "SC Linac Physics - Available Applications" in captured.out
 
-    @patch("sc_linac_physics.cli.launch_display")
-    def test_main_launch_display(self, mock_launch):
-        """Test main launching a display."""
-        with patch("sys.argv", ["sc-linac", "srf-home"]):
-            cli.main()
-
-        mock_launch.assert_called_once_with("srf-home", [])
-
-    @patch("sc_linac_physics.cli.launch_display")
-    def test_main_with_extra_args(self, mock_launch):
-        """Test main with extra arguments."""
-        # Note: argparse collects these as args, not --arg1 --arg2
-        with patch(
-            "sys.argv", ["sc-linac", "cavity", "arg1", "value1", "arg2"]
-        ):
-            cli.main()
-
-        mock_launch.assert_called_once_with(
-            "cavity", ["arg1", "value1", "arg2"]
+    def test_main_launch_display(self):
+        """Test main with display launch command."""
+        mock_launcher = MagicMock()
+        display_info = cli.DisplayInfo(
+            name="test",
+            launcher=mock_launcher,
+            description="Test",
+            category="display",
         )
+
+        with patch.object(sys, "argv", ["sc-linac", "test"]):
+            with patch.object(cli, "DISPLAYS", {"test": display_info}):
+                with patch.object(cli, "DISPLAY_LIST", [display_info]):
+                    cli.main()
+
+        mock_launcher.assert_called_once()
+
+    @patch("sc_linac_physics.cli.launch_display")
+    def test_main_launch_display_with_args(self, mock_launch):
+        """Test main with display launch and extra arguments."""
+        mock_launcher = MagicMock()
+        display_info = cli.DisplayInfo(
+            name="test",
+            launcher=mock_launcher,
+            description="Test",
+            category="display",
+        )
+
+        with patch.object(sys, "argv", ["sc-linac", "test", "arg1", "arg2"]):
+            with patch.object(cli, "DISPLAYS", {"test": display_info}):
+                with patch.object(cli, "DISPLAY_LIST", [display_info]):
+                    cli.main()
+
+        # Verify launch_display was called with the correct arguments
+        mock_launch.assert_called_once_with("test", ["arg1", "arg2"])
 
     def test_main_invalid_display(self):
         """Test main with invalid display name."""
-        with patch("sys.argv", ["sc-linac", "invalid-display"]):
-            with pytest.raises(SystemExit):
-                cli.main()
+        with patch.object(sys, "argv", ["sc-linac", "nonexistent"]):
+            with patch.object(cli, "DISPLAYS", {}):
+                with patch.object(cli, "DISPLAY_LIST", []):
+                    with pytest.raises(SystemExit):
+                        cli.main()
 
     def test_main_no_arguments(self):
-        """Test main with no arguments."""
-        with patch("sys.argv", ["sc-linac"]):
+        """Test main without any arguments."""
+        with patch.object(sys, "argv", ["sc-linac"]):
             with pytest.raises(SystemExit):
                 cli.main()
 
-    @patch("sc_linac_physics.cli.launch_display")
-    def test_main_all_displays(self, mock_launch):
-        """Test main can launch all configured displays."""
-        for display_name in cli.DISPLAYS.keys():
-            mock_launch.reset_mock()
-
-            with patch("sys.argv", ["sc-linac", display_name]):
-                cli.main()
-
-            mock_launch.assert_called_once_with(display_name, [])
-
-    def test_main_help(self, capsys):
-        """Test main --help output."""
-        with patch("sys.argv", ["sc-linac", "--help"]):
+    def test_main_help_flag(self):
+        """Test main with help flag."""
+        with patch.object(sys, "argv", ["sc-linac", "--help"]):
             with pytest.raises(SystemExit) as exc_info:
                 cli.main()
 
-            assert exc_info.value.code == 0
-
-        captured = capsys.readouterr()
-        output = captured.out
-
-        assert "SC Linac Physics" in output
-        assert "Examples:" in output
-        assert "sc-linac list" in output
+        # --help should exit with code 0
+        assert exc_info.value.code == 0
 
 
-class TestArgumentParsing:
-    """Test argument parsing behavior."""
+class TestModuleLevelVariables:
+    """Tests for module-level variables."""
 
-    def test_parser_accepts_valid_displays(self):
-        """Test that parser accepts all valid display names."""
-        for display_name in cli.DISPLAYS.keys():
-            with patch("sys.argv", ["sc-linac", display_name]):
-                with patch("sc_linac_physics.cli.launch_display"):
-                    # Should not raise
-                    cli.main()
+    def test_display_list_exists(self):
+        """Test that DISPLAY_LIST is populated."""
+        assert isinstance(cli.DISPLAY_LIST, list)
 
-    def test_parser_accepts_list(self):
-        """Test that parser accepts 'list' command."""
-        with patch("sys.argv", ["sc-linac", "list"]):
-            with patch("sc_linac_physics.cli.list_displays"):
-                # Should not raise
-                cli.main()
+    def test_displays_dict_exists(self):
+        """Test that DISPLAYS dictionary is populated."""
+        assert isinstance(cli.DISPLAYS, dict)
 
-    def test_parser_help_examples(self, capsys):
-        """Test that help includes usage examples."""
-        with patch("sys.argv", ["sc-linac", "--help"]):
-            with pytest.raises(SystemExit):
-                cli.main()
-
-        captured = capsys.readouterr()
-        output = captured.out
-
-        # Check for example commands
-        assert "sc-linac srf-home" in output
-        assert "sc-linac cavity" in output
-        assert "sc-linac fault-decoder" in output
-        assert "sc-linac quench" in output
+    def test_displays_dict_matches_list(self):
+        """Test that DISPLAYS dict matches DISPLAY_LIST."""
+        for display in cli.DISPLAY_LIST:
+            assert display.name in cli.DISPLAYS
+            assert cli.DISPLAYS[display.name] == display
 
 
 class TestIntegration:
     """Integration tests."""
 
-    def test_full_workflow_list(self, capsys):
-        """Test complete workflow: list displays."""
-        with patch("sys.argv", ["sc-linac", "list"]):
+    def test_end_to_end_list(self, capsys):
+        """Test end-to-end listing of displays."""
+        with patch.object(sys, "argv", ["sc-linac", "list"]):
             cli.main()
 
         captured = capsys.readouterr()
-        output = captured.out
+        # Should have standard output structure
+        assert "SC Linac Physics" in captured.out
+        assert "DISPLAYS:" in captured.out
+        assert "APPLICATIONS:" in captured.out
 
-        # Verify output contains expected information
-        assert "DISPLAYS:" in output
-        assert "APPLICATIONS:" in output
-
-        for name in cli.DISPLAYS.keys():
-            assert name in output
-
-    def test_full_workflow_launch(self):
-        """Test complete workflow: launch display."""
-        mock_launchers = MagicMock()
-        mock_func = Mock()
-        mock_launchers.launch_srf_home = mock_func
-
-        with patch.dict(
-            "sys.modules", {"sc_linac_physics.launchers": mock_launchers}
-        ):
-            with patch("sys.argv", ["sc-linac", "srf-home", "test-arg"]):
-                cli.main()
-
-        # Verify launcher was called
-        mock_func.assert_called_once()
-
-    def test_full_workflow_with_multiple_args(self):
-        """Test complete workflow with multiple arguments."""
-        mock_launchers = MagicMock()
-        mock_func = Mock()
-        mock_launchers.launch_cavity_display = mock_func
-
-        original_argv = sys.argv.copy()
-
-        with patch.dict(
-            "sys.modules", {"sc_linac_physics.launchers": mock_launchers}
-        ):
-            with patch("sys.argv", ["sc-linac", "cavity", "CM01", "verbose"]):
-                cli.main()
-
-        mock_func.assert_called_once()
-        assert sys.argv == original_argv
-
-
-class TestErrorHandling:
-    """Test error handling scenarios."""
-
-    def test_invalid_display_name_error(self):
-        """Test error handling for invalid display name."""
-        with patch("sys.argv", ["sc-linac", "nonexistent"]):
-            with pytest.raises(SystemExit) as exc_info:
-                cli.main()
-
-            # Should exit with error code
-            assert exc_info.value.code != 0
-
-    def test_launcher_exception_propagates(self):
-        """Test that exceptions from launchers propagate."""
-        mock_launchers = MagicMock()
-        mock_func = Mock(side_effect=RuntimeError("Display error"))
-        mock_launchers.launch_fault_count = mock_func
-
-        with patch.dict(
-            "sys.modules", {"sc_linac_physics.launchers": mock_launchers}
-        ):
-            with patch("sys.argv", ["sc-linac", "fault-count"]):
-                with pytest.raises(RuntimeError, match="Display error"):
-                    cli.main()
-
-    def test_missing_launcher_attribute(self):
-        """Test error when launcher attribute doesn't exist."""
-        mock_launchers = MagicMock()
-        # Make getattr raise AttributeError
-        mock_launchers.launch_q0_measurement = MagicMock(
-            side_effect=AttributeError("No such launcher")
+    def test_end_to_end_launch(self):
+        """Test end-to-end launching."""
+        mock_launcher = MagicMock()
+        display_info = cli.DisplayInfo(
+            name="test-display",
+            launcher=mock_launcher,
+            description="Test",
+            category="display",
         )
 
-        with patch.dict(
-            "sys.modules", {"sc_linac_physics.launchers": mock_launchers}
-        ):
-            with patch("sys.argv", ["sc-linac", "q0"]):
-                with pytest.raises(AttributeError):
+        with patch.object(cli, "DISPLAYS", {"test-display": display_info}):
+            with patch.object(cli, "DISPLAY_LIST", [display_info]):
+                with patch.object(sys, "argv", ["sc-linac", "test-display"]):
                     cli.main()
 
-
-class TestEdgeCases:
-    """Test edge cases and boundary conditions."""
-
-    @patch("sc_linac_physics.cli.launch_display")
-    def test_empty_extra_args(self, mock_launch):
-        """Test with empty extra arguments list."""
-        with patch("sys.argv", ["sc-linac", "setup"]):
-            cli.main()
-
-        mock_launch.assert_called_once_with("setup", [])
-
-    @patch("sc_linac_physics.cli.launch_display")
-    def test_many_extra_args(self, mock_launch):
-        """Test with many extra arguments."""
-        many_args = [f"arg{i}" for i in range(20)]
-
-        with patch("sys.argv", ["sc-linac", "tuning"] + many_args):
-            cli.main()
-
-        mock_launch.assert_called_once_with("tuning", many_args)
-
-    def test_displays_dict_immutability(self):
-        """Test that DISPLAYS dict retains its structure."""
-        original_len = len(cli.DISPLAYS)
-        original_keys = set(cli.DISPLAYS.keys())
-
-        # Verify structure is consistent
-        assert len(cli.DISPLAYS) == original_len
-        assert set(cli.DISPLAYS.keys()) == original_keys
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])
+        # Verify the mock launcher was actually called
+        mock_launcher.assert_called_once()


### PR DESCRIPTION
Auto-discover launcher functions using decorators and enable launching as child windows from SRF home display.

- Add @display and @application decorators
- Auto-discover launchers from module inspection
- Add standalone parameter for child window support
- Replace PyDMRelatedDisplayButton with QPushButton
- Extract descriptions from docstrings
- Import display classes directly vs string paths

properly integrate displays with PyDM main window

- Use PyDMMainWindow.set_display_widget() instead of showing displays directly
- Add runtime error when standalone=False is used without existing app
- Update return type to return PyDMMainWindow instance in non-standalone mode
- Add Returns section to docstring documenting return value
- Import PyDMApplication at module level for reuse