### PR TITLE
perf(cavity): make PV put operations non-blocking

### DIFF
--- a/src/sc_linac_physics/utils/sc_linac/cavity.py
+++ b/src/sc_linac_physics/utils/sc_linac/cavity.py
@@ -317,7 +317,7 @@ class Cavity(linac_utils.SCLinacObject):
             self._characterization_start_pv_obj = PV(
                 self.characterization_start_pv
             )
-        self._characterization_start_pv_obj.put(1)
+        self._characterization_start_pv_obj.put(1, wait=False)
 
     @property
     def cw_data_decimation_pv_obj(self) -> PV:
@@ -637,7 +637,7 @@ class Cavity(linac_utils.SCLinacObject):
         return self._calc_probe_q_pv_obj
 
     def calculate_probe_q(self):
-        self.calc_probe_q_pv_obj.put(1)
+        self.calc_probe_q_pv_obj.put(1, wait=False)
 
     def set_chirp_range(self, offset: int):
         offset = abs(offset)
@@ -1112,7 +1112,7 @@ class Cavity(linac_utils.SCLinacObject):
         if not self._interlock_reset_pv_obj:
             self._interlock_reset_pv_obj = PV(self.interlock_reset_pv)
 
-        self._interlock_reset_pv_obj.put(1)
+        self._interlock_reset_pv_obj.put(1, wait=False)
         time.sleep(wait)
 
         self.logger.debug("Checking RF permit status")

--- a/tests/utils/sc_linac/test_cavity.py
+++ b/tests/utils/sc_linac/test_cavity.py
@@ -104,7 +104,7 @@ def test_microsteps_per_hz(cavity):
 def test_start_characterization(cavity):
     cavity._characterization_start_pv_obj = make_mock_pv()
     cavity.start_characterization()
-    cavity._characterization_start_pv_obj.put.assert_called_with(1)
+    cavity._characterization_start_pv_obj.put.assert_called_with(1, wait=False)
 
 
 def test_cw_data_decimation(cavity):
@@ -402,7 +402,7 @@ def test_chirp_freq_stop(cavity):
 def test_calculate_probe_q(cavity):
     cavity._calc_probe_q_pv_obj = make_mock_pv()
     cavity.calculate_probe_q()
-    cavity._calc_probe_q_pv_obj.put.assert_called_with(1)
+    cavity._calc_probe_q_pv_obj.put.assert_called_with(1, wait=False)
 
 
 def test_set_chirp_range(cavity):
@@ -710,7 +710,7 @@ def test_reset_interlocks(cavity):
     with pytest.raises(CavityFaultError):
         cavity.reset_interlocks(attempt=INTERLOCK_RESET_ATTEMPTS)
 
-    cavity._interlock_reset_pv_obj.put.assert_called_with(1)
+    cavity._interlock_reset_pv_obj.put.assert_called_with(1, wait=False)
 
 
 def test_characterization_timestamp(cavity):


### PR DESCRIPTION
Add wait=False parameter to PV.put() calls to prevent blocking on:
- characterization start trigger
- probe Q calculation trigger
- interlock reset trigger

This improves responsiveness by not waiting for callback confirmation.