### PR TITLE
fix(cli): apply stylesheets to child windows in PyDM launcher

### DIFF
--- a/src/sc_linac_physics/cli/launchers.py
+++ b/src/sc_linac_physics/cli/launchers.py
@@ -44,9 +44,7 @@ def launch_python_display(display_class, *args, standalone=True):
     if standalone:
         # Standalone mode: use PyDM's open method
         app = PyDMApplication(command_line_args=list(args))
-        app.main_window.open(
-            display_file, macros=None
-        )  # Remove command_line_args
+        app.main_window.open(display_file, macros=None)
         app.main_window.show()
         sys.exit(app.exec())
     else:
@@ -61,7 +59,12 @@ def launch_python_display(display_class, *args, standalone=True):
 
         # Create a new main window for this display
         window = PyDMMainWindow()
-        window.open(display_file, macros=None)  # Remove command_line_args
+
+        # Apply the same stylesheet as the main application
+        if app.main_window and app.main_window.styleSheet():
+            window.setStyleSheet(app.main_window.styleSheet())
+
+        window.open(display_file, macros=None)
         window.show()
 
         return window


### PR DESCRIPTION
## Problem
Child windows created with `standalone=False` were not inheriting the application's stylesheet, causing inconsistent UI appearance compared to standalone windows.

## Solution
Copy the main application window's stylesheet to new child windows before opening the display file.

## Changes
- Added stylesheet inheritance check in `launch_python_display()` for child window mode
- Ensures `PyDMMainWindow` instances created with `standalone=False` match the styling of the main application

## Testing
Tested by launching child windows from a parent display and verifying that PyDMLabel widgets (and other styled components) appear consistently in both standalone and child window modes.

**Before:** Child windows had default/inconsistent styling
**After:** Child windows match main application styling

<img width="619" height="184" alt="image" src="https://github.com/user-attachments/assets/addb3cf3-cffc-4c40-81fb-87220c595a7d" />
