### PR TITLE
feat(microphonics): add Select All CMs button with multi-CM guard

### DIFF
--- a/src/sc_linac_physics/applications/microphonics/gui/main_window.py
+++ b/src/sc_linac_physics/applications/microphonics/gui/main_window.py
@@ -59,7 +59,7 @@ class MicrophonicsGUI(Display):
 
         # Main Layout
         main_layout = QHBoxLayout()
-        main_layout.setContentsMargins(5, 5, 5, 5)
+        main_layout.setContentsMargins(5, 2, 5, 5)
         main_layout.setSpacing(5)
         # Setting layout on display widget
         self.setLayout(main_layout)
@@ -68,7 +68,7 @@ class MicrophonicsGUI(Display):
         left_panel = QWidget()
         left_layout = QVBoxLayout(left_panel)
         left_layout.setContentsMargins(2, 2, 2, 2)
-        left_layout.setSpacing(5)
+        left_layout.setSpacing(2)
 
         right_panel = QWidget()
         right_layout = QVBoxLayout(right_panel)
@@ -222,7 +222,16 @@ class MicrophonicsGUI(Display):
                     is_modal=False,
                 )
                 return
-            self.plot_panel.clear_plots()  # Clear old plots before starting new measurement
+            selected_cm_count = self.config_panel.get_selected_cm_count()
+            if selected_cm_count > 1:
+                QMessageBox.warning(
+                    self,
+                    "Feature Not Implemented",
+                    "Multi-CM measurement visualization is not yet implemented. "
+                    "Please select one cryomodule at a time.",
+                )
+                return
+            self.plot_panel.clear_plots()
 
             # Check for cross CM cavity selection
             low_cm = any(c <= 4 for c in selected_cavities)

--- a/tests/applications/microphonics/gui/test_main_window.py
+++ b/tests/applications/microphonics/gui/test_main_window.py
@@ -162,6 +162,7 @@ def test_measurement_start_stop(gui):
         "buffer_count": 1,
     }
     gui.config_panel.mock.get_config.return_value = mock_config
+    gui.config_panel.mock.get_selected_cm_count.return_value = 1
 
     # Start measurement
     gui.start_measurement()


### PR DESCRIPTION
## Summary
Adds a "Select All CMs" toggle button to the Cryomodule Selection area, making it easier to select/deselect all cryomodules for a given linac.

## Changes
- New toggle button that switches between "Select All CMs" and "Deselect All CMs"
- Button is disabled until a linac is selected
- Added `get_selected_cm_count()` method to ConfigPanel
- Temporary guard prevents starting measurements with multiple CMs selected (shows warning dialog)
- Fixed cryomodule button layout for L2B and L3B - buttons were overlapping due to tight spacing
- Updated test mocks for the new method

## Why
Users requested a quicker way to select all cryomodules. The multi-CM guard is in place because visualization for multiple CMs isn't implemented yet.

## Testing
- Verified button toggles correctly for all linacs (L0B, L1B, L2B, L3B)
- Confirmed warning dialog appears when trying to start with multiple CMs
- Existing tests updated and passing

## Screenshots
![Image 12-12-25 at 10 27 AM](https://github.com/user-attachments/assets/e500a5c1-1e3c-493c-b1dd-5881192e5528)
![Image 12-12-25 at 10 29 AM](https://github.com/user-attachments/assets/bdca7a55-abdb-47e9-b077-34441e7fb92b)
