### PR TITLE
feat(tuning): improve error handling and UI layout with resizable splitters

### DIFF
--- a/src/sc_linac_physics/applications/tuning/launcher/srf_cavity_cold_launcher.py
+++ b/src/sc_linac_physics/applications/tuning/launcher/srf_cavity_cold_launcher.py
@@ -10,6 +10,7 @@ from sc_linac_physics.utils.logger import custom_logger
 from sc_linac_physics.utils.sc_linac.linac_utils import (
     ALL_CRYOMODULES,
     CavityAbortError,
+    STATUS_ERROR_VALUE,
 )
 
 logger = custom_logger(
@@ -50,9 +51,13 @@ def detune_cavity(cavity: TuneCavity) -> bool:
         )
         return True
     except CavityAbortError as e:
+        cavity.set_status_message(str(e), level=logging.ERROR)
+        cavity.status = STATUS_ERROR_VALUE
         logger.error(str(e))
         return False
     except Exception as e:
+        cavity.set_status_message(str(e), level=logging.ERROR)
+        cavity.status = STATUS_ERROR_VALUE
         logger.exception(
             f"Error detuning {cavity}",
             extra={


### PR DESCRIPTION
## Summary
Improves error handling in cavity detuning operations and enhances UI flexibility with resizable panels.

## Changes

### Error Handling
- Add explicit error status updates when cavity detuning fails
- Set `cavity.status` to `STATUS_ERROR_VALUE` on exceptions
- Call `cavity.set_status_message()` with error details for both `CavityAbortError` and general exceptions
- Import `STATUS_ERROR_VALUE` from linac_utils

### UI Improvements
- **Tuner class (`__init__`)**: Replaced `QWidget` rack container with `QSplitter` for better resize control
- **Tuner class (`on_cryomodule_changed`)**: 
  - Added rack displays to splitter instead of layout
  - Set equal stretch factors (1:1) for both rack displays
  - Configured splitter with equal initial sizes and visible handle
- **Tuner class (`_clear_rack_displays`)**: Updated to work with splitter instead of layout
- **RackScreen class (`_create_compact_control_panel`)**: 
  - Added minimum width (250px) and size policy constraints
  - Ensures control panels reach optimal size before plots expand
- **RackScreen class (`__init__`)**: Adjusted internal splitter stretch factors for better initial layout

### Behavior
With these changes, window resize now follows this priority:
1. Control panels expand to their maximum width (350px) first
2. Once control panels reach maximum size, additional space is distributed equally to both plots
3. Users can manually adjust the split between racks using the splitter handle

## Benefits
- **Better Error Visibility**: Errors are now properly reflected in cavity status, making failures more visible in the UI
- **Improved UX**: Users can now resize panels to their preference instead of being locked to fixed proportions
- **Responsive Layout**: Panels adapt better to different screen sizes and user workflows

## Testing
- [x] Verify error status updates correctly when detuning fails
- [x] Confirm splitters are draggable and resize smoothly
- [x] Check that minimum/maximum width constraints work as expected
- [x] Validate layout behavior on different screen sizes