### PR TITLE
Refactor microphonics plots to use shared PlotTooltip utility

### DIFF
--- a/src/sc_linac_physics/applications/microphonics/plots/base_plot.py
+++ b/src/sc_linac_physics/applications/microphonics/plots/base_plot.py
@@ -116,13 +116,13 @@ class BasePlot(QWidget):
         if "y_range" in config:
             widget.setYRange(*config["y_range"])
 
-        self.tooltip = PlotTooltip(self.plot_widget, self.get_formatter())
+        self.tooltip = PlotTooltip(widget, self.get_formatter())
 
         return widget
 
     def get_formatter(self):
         """Override in subclasses for custom tooltip formatting."""
-        return lambda x, y: f"X: {x:.2f}, Y: {y:.2f}"
+        return None
 
     def _get_cavity_pen(self, cavity_num):
         """

--- a/src/sc_linac_physics/applications/microphonics/plots/fft_plot.py
+++ b/src/sc_linac_physics/applications/microphonics/plots/fft_plot.py
@@ -67,18 +67,9 @@ class FFTPlot(BasePlot):
                 default_y_range = self.config.get("y_range", (0, 1.5))
                 self.plot_widget.setYRange(*default_y_range)
 
-    def _format_tooltip(self, plot_type, x, y):
-        """Format tooltip text for FFT plot
-
-        Args:
-            plot_type: Type of plot (unused in this implementation)
-            x: X coordinate (frequency in Hz)
-            y: Y coordinate (amplitude)
-
-        Returns:
-            str: Formatted tooltip text
-        """
-        return f"Frequency: {x:.1f} Hz\nAmplitude: {y:.3f}"
+    def get_formatter(self):
+        """Tooltip formatter for FFT plot."""
+        return lambda x, y: f"Frequency: {x:.1f} Hz\nAmplitude: {y:.3f}"
 
     def update_plot(self, cavity_num, cavity_channel_data):
         """Update FFT plot w/ new data

--- a/src/sc_linac_physics/applications/microphonics/plots/fft_plot.py
+++ b/src/sc_linac_physics/applications/microphonics/plots/fft_plot.py
@@ -7,6 +7,7 @@ from sc_linac_physics.applications.microphonics.utils.constants import (
 from sc_linac_physics.applications.microphonics.utils.data_processing import (
     calculate_fft,
 )
+from sc_linac_physics.utils.plot_tooltip import PlotTooltip
 
 
 class FFTPlot(BasePlot):
@@ -69,7 +70,7 @@ class FFTPlot(BasePlot):
 
     def get_formatter(self):
         """Tooltip formatter for FFT plot."""
-        return lambda x, y: f"Frequency: {x:.1f} Hz\nAmplitude: {y:.3f}"
+        return PlotTooltip.make_formatter("Frequency (Hz)", "Amplitude")
 
     def update_plot(self, cavity_num, cavity_channel_data):
         """Update FFT plot w/ new data

--- a/src/sc_linac_physics/applications/microphonics/plots/histogram_plot.py
+++ b/src/sc_linac_physics/applications/microphonics/plots/histogram_plot.py
@@ -26,18 +26,9 @@ class HistogramPlot(BasePlot):
         self.num_bins = 140  # Default number of bins
         super().__init__(parent, plot_type="histogram", config=config)
 
-    def _format_tooltip(self, plot_type, x, y):
-        """Format tooltip text specifically for histogram plot
-
-        Args:
-            plot_type: Type of plot (unused in this implementation)
-            x: X coordinate (detuning in Hz)
-            y: Y coordinate (count)
-
-        Returns:
-            str: Formatted tooltip text
-        """
-        return f"Detuning: {x:.1f} Hz\nCount: {int(max(1, y))}"
+    def get_formatter(self):
+        """Tooltip formatter for histogram plot."""
+        return lambda x, y: f"Detuning: {x:.1f} Hz\nCount: {int(max(1, y))}"
 
     def _update_data_range(self, df_data):
         """Update data range based on current data."""

--- a/src/sc_linac_physics/applications/microphonics/plots/histogram_plot.py
+++ b/src/sc_linac_physics/applications/microphonics/plots/histogram_plot.py
@@ -4,6 +4,7 @@ from sc_linac_physics.applications.microphonics.plots.base_plot import BasePlot
 from sc_linac_physics.applications.microphonics.utils.data_processing import (
     calculate_histogram,
 )
+from sc_linac_physics.utils.plot_tooltip import PlotTooltip
 
 
 class HistogramPlot(BasePlot):
@@ -28,7 +29,7 @@ class HistogramPlot(BasePlot):
 
     def get_formatter(self):
         """Tooltip formatter for histogram plot."""
-        return lambda x, y: f"Detuning: {x:.1f} Hz\nCount: {int(max(1, y))}"
+        return PlotTooltip.make_formatter("Detuning (Hz)", "Count")
 
     def _update_data_range(self, df_data):
         """Update data range based on current data."""

--- a/src/sc_linac_physics/applications/microphonics/plots/spectrogram_plot.py
+++ b/src/sc_linac_physics/applications/microphonics/plots/spectrogram_plot.py
@@ -33,7 +33,6 @@ class SpectrogramPlot(BasePlot):
         # Colorbar
         self.colormap = pg.colormap.get("viridis")
         self.colorbar = None
-        self.plot_tooltips = {}
 
         # Grid controls
         self.grid_controls_widget = None
@@ -88,9 +87,6 @@ class SpectrogramPlot(BasePlot):
 
     def _refresh_grid_layout(self):
         """Central method to refresh entire grid layout"""
-        for tooltip in self.plot_tooltips.values():
-            tooltip.cleanup()
-        self.plot_tooltips.clear()
         # Clear all
         self.graphics_layout.clear()
         self.plot_items.clear()
@@ -156,18 +152,14 @@ class SpectrogramPlot(BasePlot):
                 plot_item.setXRange(t[0], t[-1], padding=0)
 
             plot_item.setYRange(f[0], f[-1], padding=0)
-            self.plot_tooltips[cavity_num] = PlotTooltip(
-                plot_item,
-                lambda x, y: f"Time: {x:.3f} s\nFrequency: {y:.1f} Hz",
-            )
 
         # Add colorbar
         if visible_cavities:
             self._add_colorbar(num_rows)
 
-    def _show_tooltip(self, plot_type, ev):
-        """Override tooltip behavior"""
-        pass
+    def get_formatter(self):
+        """Tooltip formatter for spectrogram plot."""
+        return PlotTooltip.make_formatter("Time (s)", "Frequency (Hz)")
 
     def update_plot(self, cavity_num, cavity_channel_data):
         df_data, is_valid = self._preprocess_data(
@@ -284,9 +276,5 @@ class SpectrogramPlot(BasePlot):
         self.cavity_data_cache.clear()
         self.cavity_order.clear()
         self.cavity_is_visible_flags.clear()
-
-        for tooltip in self.plot_tooltips.values():
-            tooltip.cleanup()
-        self.plot_tooltips.clear()
 
         self._refresh_grid_layout()

--- a/src/sc_linac_physics/applications/microphonics/plots/spectrogram_plot.py
+++ b/src/sc_linac_physics/applications/microphonics/plots/spectrogram_plot.py
@@ -9,7 +9,6 @@ from sc_linac_physics.applications.microphonics.utils.constants import (
 from sc_linac_physics.applications.microphonics.utils.data_processing import (
     calculate_spectrogram,
 )
-from sc_linac_physics.utils.plot_tooltip import PlotTooltip
 
 
 class SpectrogramPlot(BasePlot):
@@ -156,10 +155,6 @@ class SpectrogramPlot(BasePlot):
         # Add colorbar
         if visible_cavities:
             self._add_colorbar(num_rows)
-
-    def get_formatter(self):
-        """Tooltip formatter for spectrogram plot."""
-        return PlotTooltip.make_formatter("Time (s)", "Frequency (Hz)")
 
     def update_plot(self, cavity_num, cavity_channel_data):
         df_data, is_valid = self._preprocess_data(

--- a/src/sc_linac_physics/applications/microphonics/plots/time_series_plot.py
+++ b/src/sc_linac_physics/applications/microphonics/plots/time_series_plot.py
@@ -39,9 +39,9 @@ class TimeSeriesPlot(BasePlot):
         vb.setLimits(xMin=0)  # Prevent negative time
         vb.sigRangeChangedManually.connect(self._on_range_changed)
 
-    def _format_tooltip(self, plot_type, x, y):
-        """Override base tooltip formatting"""
-        return f"Time: {x:.3f} s\nDetuning: {y:.2f} Hz"
+    def get_formatter(self):
+        """Tooltip formatter for time series plot."""
+        return lambda x, y: f"Time: {x:.3f} s\nDetuning: {y:.2f} Hz"
 
     def _decimate_data(self, times, values, target_points):
         """Decimation that still preserves important features"""

--- a/src/sc_linac_physics/applications/microphonics/plots/time_series_plot.py
+++ b/src/sc_linac_physics/applications/microphonics/plots/time_series_plot.py
@@ -7,6 +7,7 @@ from sc_linac_physics.applications.microphonics.plots.base_plot import BasePlot
 from sc_linac_physics.applications.microphonics.utils.constants import (
     BASE_HARDWARE_SAMPLE_RATE,
 )
+from sc_linac_physics.utils.plot_tooltip import PlotTooltip
 
 
 class TimeSeriesPlot(BasePlot):
@@ -41,7 +42,7 @@ class TimeSeriesPlot(BasePlot):
 
     def get_formatter(self):
         """Tooltip formatter for time series plot."""
-        return lambda x, y: f"Time: {x:.3f} s\nDetuning: {y:.2f} Hz"
+        return PlotTooltip.make_formatter("Time (s)", "Detuning (Hz)")
 
     def _decimate_data(self, times, values, target_points):
         """Decimation that still preserves important features"""

--- a/src/sc_linac_physics/utils/plot_tooltip.py
+++ b/src/sc_linac_physics/utils/plot_tooltip.py
@@ -36,7 +36,7 @@ class PlotTooltip:
             self._container = plot
         else:
             self._plot_item = plot
-            self._container = plot
+            self._container = plot.getViewBox()
 
         self.formatter = formatter or format_default
         self.enabled = True

--- a/src/sc_linac_physics/utils/plot_tooltip.py
+++ b/src/sc_linac_physics/utils/plot_tooltip.py
@@ -101,7 +101,10 @@ class PlotTooltip:
 
     @staticmethod
     def make_formatter(
-        x_label: str, y_label: str
+        x_label: str,
+        y_label: str,
+        x_fmt: str = ".2f",
+        y_fmt: str = ".2f",
     ) -> Callable[[float, float], str]:
-        """Create a formatter from axis labels."""
-        return lambda x, y: f"{x_label}: {x:.2f}\n{y_label}: {y:.2f}"
+        """Create a formatter from axis labels and optional format specs."""
+        return lambda x, y: f"{x_label}: {x:{x_fmt}}\n{y_label}: {y:{y_fmt}}"

--- a/src/sc_linac_physics/utils/plot_tooltip.py
+++ b/src/sc_linac_physics/utils/plot_tooltip.py
@@ -98,3 +98,10 @@ class PlotTooltip:
             self._plot_item.removeItem(self._tooltip)
         except (RuntimeError, AttributeError):
             pass
+
+    @staticmethod
+    def make_formatter(
+        x_label: str, y_label: str
+    ) -> Callable[[float, float], str]:
+        """Create a formatter from axis labels."""
+        return lambda x, y: f"{x_label}: {x:.2f}\n{y_label}: {y:.2f}"

--- a/tests/applications/microphonics/plots/test_time_series_plot.py
+++ b/tests/applications/microphonics/plots/test_time_series_plot.py
@@ -428,11 +428,12 @@ class TestTimeSeriesPlot:
 
     def test_format_tooltip(self, plot_widget):
         """Test tooltip formatting"""
-        tooltip = plot_widget._format_tooltip("time_series", x=5.123, y=123.456)
+        formatter = plot_widget.get_formatter()
+        tooltip = formatter(5.123, 123.456)
 
-        assert "Time:" in tooltip
-        assert "5.123" in tooltip
-        assert "Detuning:" in tooltip
+        assert "Time" in tooltip
+        assert "5.12" in tooltip
+        assert "Detuning" in tooltip
         assert "123.46" in tooltip
 
     # ===== Clear Plot Tests =====


### PR DESCRIPTION
Refactors all microphonics plot classes to use the shared PlotTooltip utility instead of custom tooltip implementations.
