### PR TITLE
feat(cavity-display): add settings persistence and status bar

### DIFF
--- a/src/sc_linac_physics/displays/cavity_display/cavity_display.py
+++ b/src/sc_linac_physics/displays/cavity_display/cavity_display.py
@@ -246,30 +246,42 @@ class CavityDisplayGUI(Display):
         super().closeEvent(event)
 
     def update_status(self):
-        """Update status bar with summary"""
+        """Update status bar with summary.
+
+        Severity codes:
+        - 0: No alarm (OK)
+        - 1: Minor alarm (WARNING)
+        - 2: Major alarm (ALARM)
+        - 3: Invalid (disconnected/error)
+        """
         total = 0
         alarms = 0
         warnings = 0
         ok = 0
+        invalid = 0
 
         for linac in self.gui_machine.linacs:
             for cm in linac.cryomodules.values():
                 for cavity in cm.cavities.values():
                     total += 1
+
                     severity = getattr(
                         cavity.cavity_widget, "_last_severity", None
                     )
-                    if severity == 2:
+
+                    if severity == 3:  # Invalid
+                        invalid += 1
+                    elif severity == 2:  # Alarm
                         alarms += 1
-                    elif severity == 1:
+                    elif severity == 1:  # Warning
                         warnings += 1
-                    else:
+                    else:  # OK or None
                         ok += 1
 
         # Build status message
-        self._update_status_display(total, alarms, warnings, ok)
+        self._update_status_display(total, alarms, warnings, ok, invalid)
 
-    def _update_status_display(self, total, alarms, warnings, ok):
+    def _update_status_display(self, total, alarms, warnings, ok, invalid):
         """Update the status bar display with counts."""
         status_parts = []
 
@@ -284,6 +296,12 @@ class CavityDisplayGUI(Display):
             )
 
         status_parts.append(f"✓ {ok} OK")
+
+        if invalid > 0:
+            status_parts.append(
+                f"<span style='color: rgb(200, 100, 255);'>🟣 {invalid} INVALID</span>"
+            )
+
         status_parts.append(f"Total: {total}")
 
         status_text = " | ".join(status_parts)
@@ -293,6 +311,8 @@ class CavityDisplayGUI(Display):
             bg_color = "rgb(150, 0, 0)"
         elif warnings > 0:
             bg_color = "rgb(200, 120, 0)"
+        elif invalid > 0:
+            bg_color = "rgb(100, 50, 150)"  # Purple for invalid
         else:
             bg_color = "rgb(0, 100, 0)"
 

--- a/src/sc_linac_physics/displays/cavity_display/frontend/cavity_widget.py
+++ b/src/sc_linac_physics/displays/cavity_display/frontend/cavity_widget.py
@@ -66,6 +66,7 @@ class CavityWidget(PyDMDrawingPolygon):
         self._faultDisplay: Display = None
         self.setCursor(QCursor(Qt.PointingHandCursor))
         self.setContentsMargins(0, 0, 0, 0)
+        self._last_severity = None
 
     # The following two functions were copy/pasted from stack overflow
     def mousePressEvent(self, event: QMouseEvent):
@@ -123,6 +124,8 @@ class CavityWidget(PyDMDrawingPolygon):
     @Slot(int)
     def severity_channel_value_changed(self, value: int):
         """Handle severity channel value changes with better error handling."""
+        self._last_severity = value  # Track current severity
+
         try:
             shape_params = SHAPE_PARAMETER_DICT.get(
                 value, SHAPE_PARAMETER_DICT[3]


### PR DESCRIPTION
## Summary
Adds foundational infrastructure for window state persistence and a live status bar showing cavity health at a glance.

## Changes
- ✅ **Window state persistence**: Window geometry saved/restored via QSettings ("SLAC"/"CavityDisplay")
- ✅ **Status bar**: Real-time summary showing alarm/warning/OK counts
- ✅ **Dynamic styling**: Status bar color changes based on severity
  - 🔴 Red background when alarms present
  - 🟡 Yellow/orange background for warnings only
  - 🟢 Green background when all OK
- ✅ **Auto-refresh**: Updates every 5 seconds
- ✅ **Bug fix**: Remove duplicate `showLabels = False` on heartbeat indicator

## Screenshots
_Before:_
- No status summary
- Window position/size not saved

<img width="1312" height="940" alt="image" src="https://github.com/user-attachments/assets/6b10110a-f0aa-4101-bdd8-b3b44591286d" />


_After:_
- Status bar shows: "🔴 2 ALARMS | 🟡 3 WARNINGS | ✓ 120 OK | Total: 125"
- Window reopens at same position/size

<img width="1268" height="896" alt="image" src="https://github.com/user-attachments/assets/b0afea2e-686c-4150-af28-62f76dd7dc68" />



## Testing Checklist
- [x] Window position/size persists across application restarts
- [x] Status bar updates automatically every 5 seconds
- [x] Status bar colors match severity levels
- [x] Total count matches actual cavity count
- [x] No duplicate property assignments in heartbeat indicator

## Technical Notes
- Uses `QSettings` with organization="SLAC", application="CavityDisplay"
- Settings stored in platform-specific location:
  - Linux: `~/.config/SLAC/CavityDisplay.conf`
  - Windows: Registry under `HKEY_CURRENT_USER\Software\SLAC\CavityDisplay`
  - macOS: `~/Library/Preferences/com.SLAC.CavityDisplay.plist`

## Dependencies
None - this is foundational infrastructure for future PRs.