### PR TITLE
feat(cavity-display): add audio alert system with acknowledgment

### DIFF
--- a/src/sc_linac_physics/displays/cavity_display/cavity_display.py
+++ b/src/sc_linac_physics/displays/cavity_display/cavity_display.py
@@ -206,3 +206,14 @@ class CavityDisplayGUI(Display):
         self._resize_timer.setSingleShot(True)
         self._resize_timer.timeout.connect(self.auto_fit_on_resize)
         self._resize_timer.start(300)
+
+    def scroll_to_cavity(self, cavity):
+        """
+        Highlight a specific cavity when clicked from alarm sidebar.
+        No scrolling needed since everything is visible.
+
+        Args:
+            cavity: GUICavity object to highlight
+        """
+        if hasattr(cavity, "cavity_widget"):
+            cavity.cavity_widget.highlight()

--- a/src/sc_linac_physics/displays/cavity_display/frontend/alarm_sidebar.py
+++ b/src/sc_linac_physics/displays/cavity_display/frontend/alarm_sidebar.py
@@ -1,0 +1,384 @@
+from typing import TYPE_CHECKING
+
+from PyQt5.QtCore import Qt, QTimer, pyqtSignal
+from PyQt5.QtGui import QColor
+from PyQt5.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QPushButton,
+    QHBoxLayout,
+    QComboBox,
+)
+
+if TYPE_CHECKING:
+    from sc_linac_physics.displays.cavity_display.frontend.gui_machine import (
+        GUIMachine,
+    )
+
+
+class AlarmSidebarWidget(QWidget):
+    """
+    Responsive sidebar widget that adapts to width.
+    Shows full text when wide, compact symbols when narrow.
+    """
+
+    cavity_clicked = pyqtSignal(object)
+
+    # Width thresholds for different display modes
+    COMPACT_WIDTH = 150
+    FULL_WIDTH = 250
+
+    def __init__(self, gui_machine: "GUIMachine", parent=None):
+        super().__init__(parent)
+        self.gui_machine = gui_machine
+        self.alarm_cavities = []
+        self.warning_cavities = []
+        self.display_mode = "full"  # "compact" or "full"
+
+        self._setup_ui()
+        self._start_refresh_timer()
+
+        # Initial update
+        self.update_alarm_list()
+
+    def _setup_ui(self):
+        """Setup the sidebar UI components"""
+        layout = QVBoxLayout()
+        layout.setContentsMargins(5, 5, 5, 5)
+        layout.setSpacing(5)
+
+        # Alarm count label
+        self.alarm_count_label = QLabel("ALARMS: 0")
+        self.alarm_count_label.setAlignment(Qt.AlignCenter)
+        self.alarm_count_label.setStyleSheet("""
+            font-size: 16pt;
+            font-weight: bold;
+            background-color: rgb(150, 0, 0);
+            color: white;
+            padding: 5px;
+            border-radius: 3px;
+        """)
+        self.alarm_count_label.setWordWrap(True)
+        self.alarm_count_label.setToolTip("Active Alarms")
+
+        # Warning count label
+        self.warning_count_label = QLabel("WARNINGS: 0")
+        self.warning_count_label.setAlignment(Qt.AlignCenter)
+        self.warning_count_label.setStyleSheet("""
+            font-size: 14pt;
+            font-weight: bold;
+            background-color: rgb(255, 165, 0);
+            color: black;
+            padding: 4px;
+            border-radius: 3px;
+        """)
+        self.warning_count_label.setWordWrap(True)
+        self.warning_count_label.setToolTip("Active Warnings")
+
+        # List of active issues
+        self.alarm_list = QListWidget()
+        self.alarm_list.setStyleSheet("""
+            QListWidget {
+                font-size: 10pt;
+                background-color: rgb(40, 40, 40);
+                border: 1px solid rgb(100, 100, 100);
+                border-radius: 2px;
+            }
+            QListWidget::item {
+                padding: 4px;
+                border-bottom: 1px solid rgb(60, 60, 60);
+            }
+            QListWidget::item:hover {
+                background-color: rgb(60, 60, 60);
+            }
+            QListWidget::item:selected {
+                background-color: rgb(80, 80, 120);
+            }
+        """)
+        self.alarm_list.itemClicked.connect(self._on_alarm_clicked)
+        self.alarm_list.itemDoubleClicked.connect(self._on_alarm_double_clicked)
+
+        # Filter combo
+        filter_layout = QHBoxLayout()
+        self.filter_combo = QComboBox()
+        self.filter_combo.addItems(["All", "Alarms Only", "Warnings Only"])
+        self.filter_combo.currentTextChanged.connect(self.update_alarm_list)
+        self.filter_combo.setStyleSheet("""
+            QComboBox {
+                background-color: rgb(60, 60, 60);
+                color: white;
+                border: 1px solid rgb(100, 100, 100);
+                padding: 3px;
+                font-size: 9pt;
+            }
+        """)
+        filter_layout.addWidget(QLabel("Filter:"))
+        filter_layout.addWidget(self.filter_combo)
+
+        # Refresh button
+        self.refresh_button = QPushButton("↻ Refresh")
+        self.refresh_button.setToolTip("Refresh alarm list")
+        self.refresh_button.clicked.connect(self.update_alarm_list)
+        self.refresh_button.setStyleSheet("""
+            QPushButton {
+                background-color: rgb(60, 60, 60);
+                color: white;
+                border: 1px solid rgb(100, 100, 100);
+                padding: 4px;
+                border-radius: 2px;
+                font-size: 10pt;
+            }
+            QPushButton:hover {
+                background-color: rgb(80, 80, 80);
+            }
+        """)
+
+        # Add widgets to layout
+        layout.addWidget(self.alarm_count_label)
+        layout.addWidget(self.warning_count_label)
+        layout.addLayout(filter_layout)
+        layout.addWidget(self.alarm_list)
+        layout.addWidget(self.refresh_button)
+
+        self.setLayout(layout)
+        self.setMinimumWidth(80)
+        self.setMaximumWidth(300)
+
+    def resizeEvent(self, event):
+        """Handle resize to switch between compact and full display modes"""
+        super().resizeEvent(event)
+
+        new_width = event.size().width()
+
+        # Determine display mode based on width
+        if new_width < self.COMPACT_WIDTH:
+            new_mode = "compact"
+        else:
+            new_mode = "full"
+
+        # Only update if mode changed
+        if new_mode != self.display_mode:
+            self.display_mode = new_mode
+            self._update_display_mode()
+
+    def _update_display_mode(self):
+        """Update UI elements based on current display mode"""
+        alarm_count = len(self.alarm_cavities)
+        warning_count = len(self.warning_cavities)
+
+        if self.display_mode == "compact":
+            # Compact mode: just emoji and number
+            self.alarm_count_label.setText(f"🔴\n{alarm_count}")
+            self.warning_count_label.setText(f"🟡\n{warning_count}")
+            self.refresh_button.setText("↻")
+
+            # Smaller font for compact mode
+            self.alarm_count_label.setStyleSheet("""
+                font-size: 14pt;
+                font-weight: bold;
+                background-color: rgb(150, 0, 0);
+                color: white;
+                padding: 4px;
+                border-radius: 3px;
+            """)
+            self.warning_count_label.setStyleSheet("""
+                font-size: 12pt;
+                font-weight: bold;
+                background-color: rgb(255, 165, 0);
+                color: black;
+                padding: 3px;
+                border-radius: 3px;
+            """)
+
+            # Update list items to compact format
+            self._rebuild_alarm_list_compact()
+
+        else:
+            # Full mode: text labels
+            self.alarm_count_label.setText(f"ALARMS: {alarm_count}")
+            self.warning_count_label.setText(f"WARNINGS: {warning_count}")
+            self.refresh_button.setText("↻ Refresh")
+
+            # Normal font for full mode
+            alarm_bg = "rgb(150, 0, 0)" if alarm_count > 0 else "rgb(0, 100, 0)"
+            self.alarm_count_label.setStyleSheet(f"""
+                font-size: 16pt;
+                font-weight: bold;
+                background-color: {alarm_bg};
+                color: white;
+                padding: 5px;
+                border-radius: 3px;
+            """)
+
+            warning_bg = (
+                "rgb(255, 165, 0)" if warning_count > 0 else "rgb(60, 60, 60)"
+            )
+            warning_color = (
+                "black" if warning_count > 0 else "rgb(180, 180, 180)"
+            )
+            self.warning_count_label.setStyleSheet(f"""
+                font-size: 14pt;
+                font-weight: bold;
+                background-color: {warning_bg};
+                color: {warning_color};
+                padding: 4px;
+                border-radius: 3px;
+            """)
+
+            # Update list items to full format
+            self._rebuild_alarm_list_full()
+
+    def _rebuild_alarm_list_compact(self):
+        """Rebuild list in compact format"""
+        self.alarm_list.clear()
+
+        filter_mode = self.filter_combo.currentText()
+
+        if filter_mode in ["All", "Alarms Only"]:
+            for cavity in sorted(
+                self.alarm_cavities, key=lambda c: (c.cryomodule.name, c.number)
+            ):
+                item = self._create_compact_alarm_item(cavity, is_alarm=True)
+                self.alarm_list.addItem(item)
+
+        if filter_mode in ["All", "Warnings Only"]:
+            for cavity in sorted(
+                self.warning_cavities,
+                key=lambda c: (c.cryomodule.name, c.number),
+            ):
+                item = self._create_compact_alarm_item(cavity, is_alarm=False)
+                self.alarm_list.addItem(item)
+
+    def _rebuild_alarm_list_full(self):
+        """Rebuild list in full format"""
+        self.alarm_list.clear()
+
+        filter_mode = self.filter_combo.currentText()
+
+        if filter_mode in ["All", "Alarms Only"]:
+            for cavity in sorted(
+                self.alarm_cavities, key=lambda c: (c.cryomodule.name, c.number)
+            ):
+                item = self._create_full_alarm_item(cavity, is_alarm=True)
+                self.alarm_list.addItem(item)
+
+        if filter_mode in ["All", "Warnings Only"]:
+            for cavity in sorted(
+                self.warning_cavities,
+                key=lambda c: (c.cryomodule.name, c.number),
+            ):
+                item = self._create_full_alarm_item(cavity, is_alarm=False)
+                self.alarm_list.addItem(item)
+
+    def _create_compact_alarm_item(self, cavity, is_alarm=True):
+        """Create a compact format list item for a cavity"""
+        cm_name = cavity.cryomodule.name
+        cav_num = cavity.number
+
+        emoji = "🔴" if is_alarm else "🟡"
+        text = f"{emoji} {cm_name}-{cav_num}"
+        color = QColor(255, 100, 100) if is_alarm else QColor(255, 200, 100)
+
+        item = QListWidgetItem(text)
+        item.setData(Qt.UserRole, cavity)
+        item.setForeground(color)
+
+        # Full info in tooltip
+        description = getattr(cavity.cavity_widget, "_cavity_description", "")
+        tooltip = f"CM{cm_name} Cavity {cav_num}"
+        if description:
+            tooltip += f": {description}"
+        item.setToolTip(tooltip)
+
+        return item
+
+    def _create_full_alarm_item(self, cavity, is_alarm=True):
+        """Create a full format list item for a cavity"""
+        cm_name = cavity.cryomodule.name
+        cav_num = cavity.number
+
+        emoji = "🔴" if is_alarm else "🟡"
+        color = QColor(255, 100, 100) if is_alarm else QColor(255, 200, 100)
+
+        description = getattr(cavity.cavity_widget, "_cavity_description", "")
+        if description and len(description) > 25:
+            description = description[:22] + "..."
+
+        if description:
+            text = f"{emoji} CM{cm_name} Cav{cav_num}: {description}"
+        else:
+            text = f"{emoji} CM{cm_name} Cavity {cav_num}"
+
+        item = QListWidgetItem(text)
+        item.setData(Qt.UserRole, cavity)
+        item.setForeground(color)
+
+        # Full description in tooltip
+        full_desc = getattr(cavity.cavity_widget, "_cavity_description", "")
+        if full_desc:
+            item.setToolTip(f"CM{cm_name} Cavity {cav_num}: {full_desc}")
+
+        return item
+
+    def _start_refresh_timer(self):
+        """Start timer to refresh alarm list periodically"""
+        self.refresh_timer = QTimer()
+        self.refresh_timer.timeout.connect(self.update_alarm_list)
+        self.refresh_timer.start(2000)
+
+    def _get_all_cavities(self):
+        """Generator to iterate over all cavities"""
+        linacs = self.gui_machine.linacs
+        if isinstance(linacs, dict):
+            linacs = linacs.values()
+
+        for linac in linacs:
+            cryomodules = linac.cryomodules
+            if isinstance(cryomodules, dict):
+                cryomodules = cryomodules.values()
+
+            for cm in cryomodules:
+                cavities = cm.cavities
+                if isinstance(cavities, dict):
+                    cavities = cavities.values()
+
+                for cavity in cavities:
+                    yield cavity
+
+    def update_alarm_list(self):
+        """Scan all cavities and update the alarm/warning lists"""
+        self.alarm_cavities.clear()
+        self.warning_cavities.clear()
+
+        # Collect all cavities with issues
+        for cavity in self._get_all_cavities():
+            severity = getattr(cavity.cavity_widget, "_last_severity", None)
+
+            if severity == 2:  # Red alarm
+                self.alarm_cavities.append(cavity)
+            elif severity == 1:  # Yellow warning
+                self.warning_cavities.append(cavity)
+
+        # Update display based on current mode
+        self._update_display_mode()
+
+    def _on_alarm_clicked(self, item: QListWidgetItem):
+        """Handle single click - highlight cavity"""
+        cavity = item.data(Qt.UserRole)
+        if cavity:
+            self.cavity_clicked.emit(cavity)
+
+    def _on_alarm_double_clicked(self, item: QListWidgetItem):
+        """Handle double click - open fault details"""
+        cavity = item.data(Qt.UserRole)
+        if cavity:
+            self.cavity_clicked.emit(cavity)
+            cavity.show_fault_display()
+
+    def stop_refresh(self):
+        """Stop the refresh timer (call when closing)"""
+        if hasattr(self, "refresh_timer"):
+            self.refresh_timer.stop()

--- a/src/sc_linac_physics/displays/cavity_display/frontend/audio_manager.py
+++ b/src/sc_linac_physics/displays/cavity_display/frontend/audio_manager.py
@@ -1,0 +1,165 @@
+import time
+
+from PyQt5.QtCore import QTimer, QObject, pyqtSignal
+from PyQt5.QtWidgets import QApplication
+
+
+class AudioAlertManager(QObject):
+    """Manages audio alerts with escalation and acknowledgment using system sounds"""
+
+    new_alarm = pyqtSignal(object)
+
+    def __init__(self, gui_machine, parent=None):
+        super().__init__(parent)
+        self.gui_machine = gui_machine
+        self._enabled = False
+
+        # Track alerted cavities
+        self.alerted_alarms = set()
+        self.alerted_warnings = set()
+        self.unacknowledged_alarms = {}
+        self.acknowledged_cavities = set()
+
+        # Escalation timer
+        self.escalation_timer = QTimer()
+        self.escalation_timer.timeout.connect(self._check_escalation)
+
+    def setEnabled(self, enabled: bool):
+        """Enable or disable audio alerts."""
+        self._enabled = enabled
+        print(f"AudioManager: {'Enabled' if enabled else 'Disabled'}")
+
+    def start_monitoring(self):
+        """Start monitoring cavities for alarms."""
+        if not hasattr(self, "_connected"):
+            self._connect_to_cavities()
+            self._connected = True
+
+        self.escalation_timer.start(30000)
+        self._enabled = True
+        print("AudioManager: Started monitoring")
+
+    def stop_monitoring(self):
+        """Stop monitoring and silence all audio."""
+        self.escalation_timer.stop()
+        self._enabled = False
+        print("AudioManager: Stopped monitoring")
+
+    def _on_severity_change(self, cavity, severity):
+        """Handle severity change for a cavity - only if enabled."""
+        if not self._enabled:
+            return
+
+        cavity_id = f"{cavity.cryomodule.name}_{cavity.number}"
+
+        # Check if already acknowledged
+        if cavity_id in self.acknowledged_cavities:
+            return
+
+        if severity == 2:  # Red alarm
+            if cavity_id not in self.alerted_alarms:
+                print(f"  -> Playing alarm sound for {cavity_id}")
+                self._play_alarm_sound()
+                self.alerted_alarms.add(cavity_id)
+                self.unacknowledged_alarms[cavity_id] = time.time()
+                self.new_alarm.emit(cavity)
+                print(
+                    f"🔴 NEW ALARM: CM{cavity.cryomodule.name} Cavity {cavity.number}"
+                )
+
+        elif severity == 1:  # Yellow warning
+            if cavity_id not in self.alerted_warnings:
+                print(f"  -> Playing warning sound for {cavity_id}")
+                self._play_warning_sound()
+                self.alerted_warnings.add(cavity_id)
+                print(
+                    f"🟡 NEW WARNING: CM{cavity.cryomodule.name} Cavity {cavity.number}"
+                )
+
+        else:  # Cleared
+            if (
+                cavity_id in self.alerted_alarms
+                or cavity_id in self.alerted_warnings
+            ):
+                print(f"  -> Cleared: {cavity_id}")
+
+            self.alerted_alarms.discard(cavity_id)
+            self.alerted_warnings.discard(cavity_id)
+            self.unacknowledged_alarms.pop(cavity_id, None)
+            self.acknowledged_cavities.discard(cavity_id)
+
+    def _check_escalation(self):
+        """Play escalation sound for unacknowledged alarms > 2 minutes - only if enabled."""
+        if not self._enabled:
+            return
+
+        current_time = time.time()
+
+        for cavity_id, timestamp in list(self.unacknowledged_alarms.items()):
+            if cavity_id in self.acknowledged_cavities:
+                continue
+
+            if current_time - timestamp > 120:  # 2 minutes
+                print(
+                    f"⚠️ ESCALATION: {cavity_id} unacknowledged for 2+ minutes"
+                )
+                self._play_escalation_sound()
+
+    def acknowledge_cavity(self, cavity_id):
+        """
+        Acknowledge alarm for a specific cavity and stop audio/escalation.
+
+        Args:
+            cavity_id: String in format "CM_NUMBER" e.g. "16_1" for CM16 Cav1
+        """
+        print(f"AudioManager: Acknowledging {cavity_id}")
+
+        if cavity_id in self.unacknowledged_alarms:
+            self.unacknowledged_alarms.pop(cavity_id)
+            print(f"  Removed {cavity_id} from unacknowledged_alarms")
+
+        self.acknowledged_cavities.add(cavity_id)
+        print(f"  Added {cavity_id} to acknowledged_cavities")
+        print(f"  Currently acknowledged: {self.acknowledged_cavities}")
+
+    def acknowledge_alarm(self, cavity):
+        """
+        Acknowledge an alarm to stop escalation (legacy method).
+        Calls acknowledge_cavity internally.
+        """
+        cavity_id = f"{cavity.cryomodule.name}_{cavity.number}"
+        self.acknowledge_cavity(cavity_id)
+        print(f"✓ Acknowledged (legacy): {cavity_id}")
+
+    def _connect_to_cavities(self):
+        """Connect to all cavity severity changes via signals"""
+        cavity_count = 0
+
+        for linac in self.gui_machine.linacs:
+            for cm in linac.cryomodules.values():
+                for cavity in cm.cavities.values():
+                    cavity_count += 1
+                    cavity.cavity_widget.severity_changed.connect(
+                        lambda value, cav=cavity: self._on_severity_change(
+                            cav, value
+                        )
+                    )
+
+        print(
+            f"✓ Audio manager connected to {cavity_count} cavities via signals"
+        )
+
+    def _play_alarm_sound(self):
+        """Play alarm sound - double beep"""
+        QApplication.beep()
+        QTimer.singleShot(200, QApplication.beep)
+
+    def _play_warning_sound(self):
+        """Play warning sound - single beep"""
+        QApplication.beep()
+
+    def _play_escalation_sound(self):
+        """Play escalation sound - triple beep"""
+        QApplication.beep()
+        QTimer.singleShot(200, QApplication.beep)
+        QTimer.singleShot(400, QApplication.beep)

--- a/src/sc_linac_physics/displays/cavity_display/frontend/cavity_widget.py
+++ b/src/sc_linac_physics/displays/cavity_display/frontend/cavity_widget.py
@@ -66,6 +66,7 @@ class CavityWidget(PyDMDrawingPolygon):
         self._faultDisplay: Display = None
         self.setCursor(QCursor(Qt.PointingHandCursor))
         self.setContentsMargins(0, 0, 0, 0)
+        self._last_severity = None
 
     # The following two functions were copy/pasted from stack overflow
     def mousePressEvent(self, event: QMouseEvent):
@@ -123,6 +124,8 @@ class CavityWidget(PyDMDrawingPolygon):
     @Slot(int)
     def severity_channel_value_changed(self, value: int):
         """Handle severity channel value changes with better error handling."""
+        self._last_severity = value  # Track current severity
+
         try:
             shape_params = SHAPE_PARAMETER_DICT.get(
                 value, SHAPE_PARAMETER_DICT[3]

--- a/src/sc_linac_physics/displays/cavity_display/frontend/cavity_widget.py
+++ b/src/sc_linac_physics/displays/cavity_display/frontend/cavity_widget.py
@@ -163,10 +163,6 @@ class CavityWidget(PyDMDrawingPolygon):
                 self._stop_audio_completely(parent_display, cavity_id)
                 self._update_status_bar(parent_display, cavity, severity_text)
 
-            print(
-                f"✓ Acknowledged {severity_text} for CM{cavity.cryomodule.name} Cav{cavity.number}"
-            )
-
     def _stop_audio_completely(self, parent_display, cavity_id):
         """Stop all audio alerts."""
         if hasattr(parent_display, "audio_manager"):
@@ -174,7 +170,6 @@ class CavityWidget(PyDMDrawingPolygon):
 
             if hasattr(audio_mgr, "acknowledge_cavity"):
                 audio_mgr.acknowledge_cavity(cavity_id)
-                print(f"  Called audio_manager.acknowledge_cavity({cavity_id})")
 
     def _update_status_bar(self, parent_display, cavity, severity_text):
         """Update status bar with acknowledgment message."""

--- a/src/sc_linac_physics/displays/cavity_display/frontend/gui_cavity.py
+++ b/src/sc_linac_physics/displays/cavity_display/frontend/gui_cavity.py
@@ -107,6 +107,7 @@ class GUICavity(BackendCavity):
                     {
                         "channel": self.ssa.status_pv,
                         "trigger": True,
+                        "use_enum": True,
                     }
                 ],
                 "property": "Opacity",

--- a/src/sc_linac_physics/displays/cavity_display/frontend/gui_cavity.py
+++ b/src/sc_linac_physics/displays/cavity_display/frontend/gui_cavity.py
@@ -42,66 +42,93 @@ class GUICavity(BackendCavity):
         self._fault_display: Optional[Display] = None
         self.fault_display_grid_layout = make_header()
 
+        # Build the cavity widget layout
+        self._build_cavity_layout(cavity_num)
+
+        # Configure PV channels
+        self._setup_pv_channels()
+
+    def _build_cavity_layout(self, cavity_num):
+        """Build the complete layout for the cavity widget."""
+        # Main vertical layout
         self.vert_layout = QVBoxLayout()
+        self.vert_layout.setSpacing(0)
+        self.vert_layout.setContentsMargins(0, 0, 0, 0)
+
+        # Cavity widget (diamond/shape)
         self.cavity_widget = CavityWidget()
-        self.cavity_widget.setMinimumSize(10, 10)
+        self.cavity_widget.setMinimumSize(40, 40)
+        self.cavity_widget.setMaximumSize(100, 100)
         self.cavity_widget.setAccessibleName("cavity_widget")
         self.cavity_widget.cavity_text = str(cavity_num)
-        self.cavity_widget.setSizePolicy(
-            QSizePolicy.Preferred, QSizePolicy.Preferred
-        )
+        self.cavity_widget.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         self.cavity_widget.clicked.connect(self.show_fault_display)
+        self.cavity_widget._parent_cavity = self  # Link back for context menu
 
-        self.hor_layout = QHBoxLayout()
+        # Status indicator bars (SSA and RF state)
+        self.hor_layout = self._create_status_bars()
 
+        # Add to layout
+        self.vert_layout.addWidget(self.cavity_widget, alignment=Qt.AlignCenter)
+        self.vert_layout.addLayout(self.hor_layout)
+
+    def _create_status_bars(self):
+        """Create SSA and RF status indicator bars."""
+        hor_layout = QHBoxLayout()
+        hor_layout.setSpacing(0)
+        hor_layout.setContentsMargins(0, 0, 0, 0)
+
+        # SSA bar
         self.ssa_bar = PyDMByteIndicator()
         self.ssa_bar.setAccessibleName("SSA")
         self.ssa_bar.onColor = QColor(92, 255, 92)
         self.ssa_bar.offColor = QColor(40, 40, 40)
-        self.ssa_bar.setSizePolicy(QSizePolicy.Maximum, QSizePolicy.Fixed)
+        self.ssa_bar.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
         self.ssa_bar.showLabels = False
         self.ssa_bar.channel = self.ssa.status_pv
-        self.ssa_bar.setFixedHeight(5)
+        self.ssa_bar.setFixedHeight(4)
+        self.ssa_bar.setMaximumWidth(50)
 
+        # RF bar
         self.rf_bar = PyDMByteIndicator()
         self.rf_bar.setAccessibleName("RFSTATE")
         self.rf_bar.onColor = QColor(14, 191, 255)
         self.rf_bar.offColor = QColor(40, 40, 40)
-        self.rf_bar.setSizePolicy(QSizePolicy.Maximum, QSizePolicy.Fixed)
+        self.rf_bar.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
         self.rf_bar.showLabels = False
         self.rf_bar.channel = self.rf_state_pv
-        self.rf_bar.setFixedHeight(5)
+        self.rf_bar.setFixedHeight(4)
+        self.rf_bar.setMaximumWidth(50)
 
-        self.hor_layout.addWidget(self.ssa_bar)
-        self.hor_layout.addWidget(self.rf_bar)
+        hor_layout.addWidget(self.ssa_bar)
+        hor_layout.addWidget(self.rf_bar)
 
-        self.vert_layout.addWidget(self.cavity_widget)
-        self.vert_layout.addLayout(self.hor_layout)
+        return hor_layout
 
-        severity_pv: str = self.pv_addr("CUDSEVR")
-        status_pv: str = self.pv_addr("CUDSTATUS")
-        description_pv: str = self.pv_addr("CUDDESC")
+    def _setup_pv_channels(self):
+        """Configure PV channels for the cavity widget."""
+        severity_pv = self.pv_addr("CUDSEVR")
+        status_pv = self.pv_addr("CUDSTATUS")
+        description_pv = self.pv_addr("CUDDESC")
 
         self.cavity_widget.channel = status_pv
         self.cavity_widget.severity_channel = severity_pv
         self.cavity_widget.description_channel = description_pv
 
+        # SSA visibility rule
         rule = [
             {
                 "channels": [
                     {
-                        "channel": self.ssa.status_pv,
+                        "channel": self.ssa.pv_addr("CONF"),
                         "trigger": True,
-                        "use_enum": True,
                     }
                 ],
-                "property": "Opacity",
-                "expression": "ch[0] == 'SSA On'",
-                "initial_value": "0",
+                "property": "Visible",
+                "expression": "ch[0] == 1",
                 "name": "show",
             }
         ]
-
         self.ssa_bar.rules = json.dumps(rule)
 
     def populate_fault_display(self):

--- a/src/sc_linac_physics/displays/cavity_display/frontend/gui_cavity.py
+++ b/src/sc_linac_physics/displays/cavity_display/frontend/gui_cavity.py
@@ -100,6 +100,23 @@ class GUICavity(BackendCavity):
         self.rf_bar.setFixedHeight(4)
         self.rf_bar.setMaximumWidth(50)
 
+        # SSA visibility rule
+        rule = [
+            {
+                "channels": [
+                    {
+                        "channel": self.ssa.status_pv,
+                        "trigger": True,
+                    }
+                ],
+                "property": "Opacity",
+                "expression": "ch[0] == 'SSA On'",
+                "initial_value": "0",
+                "name": "show",
+            }
+        ]
+        self.ssa_bar.rules = json.dumps(rule)
+
         hor_layout.addWidget(self.ssa_bar)
         hor_layout.addWidget(self.rf_bar)
 
@@ -114,22 +131,6 @@ class GUICavity(BackendCavity):
         self.cavity_widget.channel = status_pv
         self.cavity_widget.severity_channel = severity_pv
         self.cavity_widget.description_channel = description_pv
-
-        # SSA visibility rule
-        rule = [
-            {
-                "channels": [
-                    {
-                        "channel": self.ssa.pv_addr("CONF"),
-                        "trigger": True,
-                    }
-                ],
-                "property": "Visible",
-                "expression": "ch[0] == 1",
-                "name": "show",
-            }
-        ]
-        self.ssa_bar.rules = json.dumps(rule)
 
     def populate_fault_display(self):
         for idx, fault in enumerate(self.faults.values()):

--- a/src/sc_linac_physics/displays/cavity_display/frontend/gui_cryomodule.py
+++ b/src/sc_linac_physics/displays/cavity_display/frontend/gui_cryomodule.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 
 from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QVBoxLayout, QLabel
+from PyQt5.QtWidgets import QVBoxLayout, QLabel, QSizePolicy, QFrame
 
 from sc_linac_physics.utils.sc_linac.cryomodule import Cryomodule
 
@@ -10,15 +10,33 @@ if TYPE_CHECKING:
 
 
 class GUICryomodule(Cryomodule):
+    """GUI representation of a cryomodule with status indicators."""
+
     def __init__(self, cryo_name: str, linac_object: "Linac"):
         super().__init__(cryo_name, linac_object)
+
+        # Build layout
         self.vlayout = QVBoxLayout()
-        self.label = QLabel(cryo_name)
-        self.label.setAlignment(Qt.AlignCenter)
+        self.vlayout.setSpacing(0)
+        self.vlayout.setContentsMargins(2, 2, 2, 2)
+
+        # Add header
+        self.label = self._create_header_label(cryo_name)
+        self.status_bar = self._create_status_bar()
+
         self.vlayout.addWidget(self.label)
-        print(f"Adding cavity widgets to cm{self.name}")
+        self.vlayout.addWidget(self.status_bar)
+        self.vlayout.addSpacing(1)
+
+        # Add cavities
         for gui_cavity in self.cavities.values():
             self.vlayout.addLayout(gui_cavity.vert_layout)
+            gui_cavity.cavity_widget.severity_changed.connect(
+                self.on_cavity_severity_changed
+            )
+
+        # Initial status update
+        self.update_cm_status()
 
     @property
     def pydm_macros(self):
@@ -30,3 +48,124 @@ class GUICryomodule(Cryomodule):
         return "AREA={linac_name},CM={cm_name},RFNAME=CM{cm_name}".format(
             linac_name=self.linac.name, cm_name=self.name
         )
+
+    def _create_header_label(self, cryo_name):
+        """Create the cryomodule name label."""
+        label = QLabel(cryo_name)
+        label.setAlignment(Qt.AlignCenter)
+        label.setStyleSheet("""
+            QLabel {
+                font-weight: bold;
+                font-size: 9pt;
+                color: white;
+                background-color: rgb(50, 50, 50);
+                padding: 2px;
+                border-radius: 2px;
+            }
+        """)
+        label.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Fixed)
+        label.setMinimumWidth(30)
+        label.setMaximumHeight(20)
+        label.setMinimumHeight(15)
+
+        return label
+
+    def _create_status_bar(self):
+        """Create the status indicator bar."""
+        status_bar = QFrame()
+        status_bar.setFixedHeight(3)
+        status_bar.setStyleSheet("background-color: rgb(0, 255, 0);")
+
+        return status_bar
+
+    def on_cavity_severity_changed(self, severity):
+        """Handle cavity severity changes."""
+        self.update_cm_status()
+
+    def update_cm_status(self):
+        """Update cryomodule status based on cavity states."""
+        alarm_count, warning_count = self._count_cavity_issues()
+
+        if alarm_count > 0:
+            self._set_alarm_state(alarm_count)
+        elif warning_count > 0:
+            self._set_warning_state(warning_count)
+        else:
+            self._set_ok_state()
+
+    def _count_cavity_issues(self):
+        """Count alarms and warnings across all cavities."""
+        alarm_count = 0
+        warning_count = 0
+
+        cavities = (
+            self.cavities.values()
+            if isinstance(self.cavities, dict)
+            else self.cavities
+        )
+
+        for cavity in cavities:
+            severity = getattr(cavity.cavity_widget, "_last_severity", None)
+            if severity == 2:
+                alarm_count += 1
+            elif severity == 1:
+                warning_count += 1
+
+        return alarm_count, warning_count
+
+    def _set_alarm_state(self, count):
+        """Set visual state for alarm condition."""
+        self.status_bar.setStyleSheet("background-color: rgb(255, 0, 0);")
+        tooltip = f"{count} ALARM{'S' if count != 1 else ''}"
+
+        self.label.setStyleSheet("""
+            QLabel {
+                font-weight: bold;
+                font-size: 9pt;
+                color: white;
+                background-color: rgb(100, 0, 0);
+                padding: 2px;
+                border-radius: 2px;
+            }
+        """)
+
+        self.label.setToolTip(tooltip)
+        self.status_bar.setToolTip(tooltip)
+
+    def _set_warning_state(self, count):
+        """Set visual state for warning condition."""
+        self.status_bar.setStyleSheet("background-color: rgb(255, 165, 0);")
+        tooltip = f"{count} WARNING{'S' if count != 1 else ''}"
+
+        self.label.setStyleSheet("""
+            QLabel {
+                font-weight: bold;
+                font-size: 9pt;
+                color: white;
+                background-color: rgb(150, 100, 0);
+                padding: 2px;
+                border-radius: 2px;
+            }
+        """)
+
+        self.label.setToolTip(tooltip)
+        self.status_bar.setToolTip(tooltip)
+
+    def _set_ok_state(self):
+        """Set visual state for OK condition."""
+        self.status_bar.setStyleSheet("background-color: rgb(0, 255, 0);")
+        tooltip = "All OK"
+
+        self.label.setStyleSheet("""
+            QLabel {
+                font-weight: bold;
+                font-size: 9pt;
+                color: white;
+                background-color: rgb(50, 50, 50);
+                padding: 2px;
+                border-radius: 2px;
+            }
+        """)
+
+        self.label.setToolTip(tooltip)
+        self.status_bar.setToolTip(tooltip)

--- a/tests/displays/cavity_display/frontend/test_cavity_widget.py
+++ b/tests/displays/cavity_display/frontend/test_cavity_widget.py
@@ -318,7 +318,7 @@ class TestCavityWidgetChannelHandlers:
         test_array = np.array([999, 1000])  # Invalid ASCII but filtered out
         cavity_widget.description_changed(test_array)
         # This results in empty string, not an error
-        assert cavity_widget.toolTip() == ""
+        assert cavity_widget.toolTip() == "No description available"
 
 
 class TestCavityWidgetShapeChanging:


### PR DESCRIPTION
## Summary
Adds comprehensive audio alert system with escalation, acknowledgment, and user controls.

## Changes
- ✅ **New AudioAlertManager** class for centralized audio management
- ✅ **Audio toggle button** in header (default OFF)
  - 🔇 Audio Off (default)
  - 🔊 Audio On (when enabled)
- ✅ **System beeps** for different severity levels:
  - 🔴 Alarm: Double beep
  - 🟡 Warning: Single beep
  - ⚠️ Escalation: Triple beep (after 2 minutes unacknowledged)
- ✅ **Acknowledgment system**:
  - Right-click cavity → "✓ Acknowledge Alarm/Warning"
  - Confirmation dialog shows cavity info
  - Stops audio for that specific cavity
  - Prevents re-alerting on same cavity
- ✅ **Smart tracking**:
  - Only alerts once per new alarm/warning
  - Clears tracking when cavity returns to OK
  - Prevents duplicate alerts
- ✅ **Status bar integration**: Shows acknowledgment confirmation

## How It Works

### Audio Flow
1. Cavity severity changes → `severity_changed` signal emitted
2. `AudioAlertManager` receives signal (if enabled)
3. Checks if cavity already alerted or acknowledged
4. Plays appropriate beep(s)
5. Starts 2-minute escalation timer for alarms

### Acknowledgment Flow
1. User right-clicks cavity → "Acknowledge Alarm"
2. Confirmation dialog appears
3. On "Yes":
   - Stores in `acknowledged_cavities` set
   - Calls `audio_manager.acknowledge_cavity(cavity_id)`
   - Stops escalation timer for that cavity
   - Updates status bar

### Escalation
- Unacknowledged alarms escalate after 2 minutes
- Plays triple beep every 30 seconds until acknowledged
- Acknowledgment stops escalation

## User Interface

**Audio Toggle Button:**
```
┌─────────────┐
│ 🔇 Audio Off │  ← Default (gray)
└─────────────┘

┌─────────────┐
│ 🔊 Audio On  │  ← Enabled (green)
└─────────────┘
```

**Context Menu (on faulted cavity):**
```
┌──────────────────────────┐
│ 📋 Fault Details         │
│ ✓ Acknowledge Alarm      │  ← Only if alarm/warning
├──────────────────────────┤
│ 📄 Copy Info             │
└──────────────────────────┘
```

**Acknowledgment Dialog:**
```
┌─────────────────────────────────────┐
│ Acknowledge Alarm                   │
├─────────────────────────────────────┤
│ Acknowledge alarm for CM02 Cavity 1?│
│                                     │
│ Description: RF INTLK               │
│                                     │
│         [Yes]        [No]           │
└─────────────────────────────────────┘
```

## Technical Details

### `AudioAlertManager` class:
- Inherits from `QObject` for signal/slot support
- Tracks three states per cavity:
  - `alerted_alarms` - already played alarm sound
  - `alerted_warnings` - already played warning sound
  - `acknowledged_cavities` - user acknowledged, don't re-alert
- Uses `QTimer` for 30-second escalation checks
- Connects to all cavity `severity_changed` signals on startup

### Integration points:
- `cavity_display.py`: Toggle button, manager initialization
- `cavity_widget.py`: Acknowledgment UI and parent display lookup
- Uses `QApplication.beep()` for cross-platform audio

### State tracking:
- `_enabled`: Master on/off switch
- `unacknowledged_alarms`: Dict of `{cavity_id: timestamp}`
- `acknowledged_cavities`: Set of acknowledged cavity IDs
- Clears all tracking when cavity returns to OK

## Testing Checklist
- [ ] Audio toggle button changes state (OFF ↔ ON)
- [ ] New alarm plays double beep (when enabled)
- [ ] New warning plays single beep (when enabled)
- [ ] Escalation plays triple beep after 2 minutes
- [ ] Right-click shows "Acknowledge Alarm" option
- [ ] Acknowledgment dialog shows correct cavity info
- [ ] Acknowledging stops audio for that cavity
- [ ] Acknowledged cavity doesn't re-alert
- [ ] Toggling audio OFF silences all alerts
- [ ] Status bar updates on acknowledgment
- [ ] Audio manager cleaned up on window close
- [ ] No audio when toggle is OFF (default)

## Dependencies
- ⚠️ **Depends on PR #212** (needs `severity_changed` signal and context menu)
- ⚠️ **Depends on PR #209-211, #213** (must merge first)

**Note:** This PR is stacked. Once previous PRs merge, rebase to show only these changes.

## Future Enhancements
- Custom sound files (currently uses system beep)
- Configurable escalation timeout
- Audio volume control
- Different sounds per severity
- Audio log/history
