### PR TITLE
Add fault heatmap display for cavity fault visualization

### DIFF
--- a/src/sc_linac_physics/displays/cavity_display/frontend/heatmap/color_bar_widget.py
+++ b/src/sc_linac_physics/displays/cavity_display/frontend/heatmap/color_bar_widget.py
@@ -1,0 +1,200 @@
+import math
+from typing import Optional, List, TYPE_CHECKING
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import (
+    QColor,
+    QPainter,
+    QFont,
+    QPen,
+    QLinearGradient,
+)
+from PyQt5.QtWidgets import QWidget, QSizePolicy
+
+if TYPE_CHECKING:
+    from sc_linac_physics.displays.cavity_display.frontend.heatmap.color_mapper import (  # noqa: E501
+        ColorMapper,
+    )
+
+
+class ColorBarWidget(QWidget):
+    """Vertical color scale legend showing fault count to color mapping."""
+
+    DEFAULT_WIDTH = 60
+    DEFAULT_HEIGHT = 180
+    BAR_WIDTH = 14
+    TICK_LENGTH = 4
+    LABEL_MARGIN = 4
+    PADDING_TOP = 6
+    PADDING_BOTTOM = 6
+    NUM_TICKS = 5
+
+    BORDER_COLOR = QColor(180, 180, 180)
+    TICK_COLOR = QColor(200, 200, 200)
+    LABEL_COLOR = QColor(200, 200, 200)
+    LABEL_FONT_SIZE = 7
+    BAR_X_OFFSET = 10
+    GRADIENT_STOPS = 64
+
+    def __init__(
+        self,
+        color_mapper: Optional["ColorMapper"] = None,
+        title: str = "Faults",
+        num_ticks: int = NUM_TICKS,
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        super().__init__(parent)
+
+        self._color_mapper = color_mapper
+        self._title = title
+        self._num_ticks = max(2, num_ticks)
+
+        self._vmin: float = 0.0
+        self._vmax: float = 1.0
+
+        if self._color_mapper:
+            self._vmin = self._color_mapper.vmin
+            self._vmax = self._color_mapper.vmax
+
+        self.setMinimumWidth(self.DEFAULT_WIDTH)
+        self.setMinimumHeight(self.DEFAULT_HEIGHT)
+        self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Expanding)
+
+    @property
+    def _log_scale(self) -> bool:
+        if self._color_mapper:
+            return self._color_mapper.log_scale
+        return False
+
+    def update_range(self) -> None:
+        if self._color_mapper:
+            self._vmin = self._color_mapper.vmin
+            self._vmax = self._color_mapper.vmax
+        self.update()
+
+    def _get_tick_values(self) -> List[float]:
+        if self._num_ticks < 2 or self._vmax == self._vmin:
+            return [self._vmax, self._vmin]
+
+        if self._log_scale and self._vmax > 0:
+            log_max = math.log1p(self._vmax - self._vmin)
+            step = log_max / (self._num_ticks - 1)
+            return [
+                self._vmin + math.expm1(log_max - i * step)
+                for i in range(self._num_ticks)
+            ]
+
+        step = (self._vmax - self._vmin) / (self._num_ticks - 1)
+        return [self._vmax - i * step for i in range(self._num_ticks)]
+
+    def _value_to_bar_t(self, value: float) -> float:
+        """Map a data value to a bar position (0=top/max, 1=bottom/min)."""
+        if self._vmax == self._vmin:
+            return 0.5
+
+        if self._log_scale and self._vmax > self._vmin:
+            log_range = math.log1p(self._vmax - self._vmin)
+            if log_range == 0.0:
+                return 0.5
+            return 1.0 - math.log1p(value - self._vmin) / log_range
+
+        return (self._vmax - value) / (self._vmax - self._vmin)
+
+    def _format_tick_label(self, value: float) -> str:
+        if self._vmax - self._vmin >= 1.0:
+            return str(int(round(value)))
+        return f"{value:.1f}"
+
+    def paintEvent(self, event) -> None:
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.Antialiasing)
+
+        widget_width = self.width()
+        widget_height = self.height()
+
+        # Title
+        title_font = QFont()
+        title_font.setPointSize(self.LABEL_FONT_SIZE + 1)
+        title_font.setBold(True)
+        painter.setFont(title_font)
+        title_metrics = painter.fontMetrics()
+        title_height = title_metrics.height()
+
+        painter.setPen(self.LABEL_COLOR)
+        painter.drawText(
+            0,
+            0,
+            widget_width,
+            title_height + self.PADDING_TOP,
+            Qt.AlignHCenter | Qt.AlignBottom,
+            self._title,
+        )
+
+        # Gradient bar
+        bar_top = self.PADDING_TOP + title_height + 4
+        bar_bottom = widget_height - self.PADDING_BOTTOM
+        bar_height = bar_bottom - bar_top
+
+        if bar_height < 10:
+            painter.end()
+            return
+
+        bar_x = self.BAR_X_OFFSET
+
+        # Top = yellow/high, bottom = navy/low
+        gradient = QLinearGradient(bar_x, bar_top, bar_x, bar_bottom)
+
+        if self._color_mapper:
+            for i in range(self.GRADIENT_STOPS + 1):
+                t = i / self.GRADIENT_STOPS
+                # Sample in the same space as the scale (log or linear)
+                # so the gradient shows an even color distribution.
+                if self._log_scale and self._vmax > self._vmin:
+                    log_range = math.log1p(self._vmax - self._vmin)
+                    value = self._vmin + math.expm1(log_range * (1 - t))
+                else:
+                    value = self._vmax - t * (self._vmax - self._vmin)
+                color = self._color_mapper.get_color(value)
+                gradient.setColorAt(t, color)
+        else:
+            gradient.setColorAt(0.0, QColor(253, 231, 37))
+            gradient.setColorAt(1.0, QColor(68, 1, 84))
+
+        painter.setBrush(gradient)
+        painter.setPen(QPen(self.BORDER_COLOR, 1))
+        painter.drawRect(bar_x, bar_top, self.BAR_WIDTH, bar_height)
+
+        # Tick marks and labels
+        label_font = QFont()
+        label_font.setPointSize(self.LABEL_FONT_SIZE)
+        painter.setFont(label_font)
+        painter.setPen(QPen(self.TICK_COLOR, 1))
+
+        tick_values = self._get_tick_values()
+        tick_x_start = bar_x + self.BAR_WIDTH
+        tick_x_end = tick_x_start + self.TICK_LENGTH
+        label_x = tick_x_end + self.LABEL_MARGIN
+
+        for value in tick_values:
+            t = self._value_to_bar_t(value)
+            y = bar_top + t * bar_height
+
+            painter.drawLine(
+                int(tick_x_start),
+                int(y),
+                int(tick_x_end),
+                int(y),
+            )
+
+            label = self._format_tick_label(value)
+            label_rect_height = painter.fontMetrics().height()
+            painter.drawText(
+                int(label_x),
+                int(y - label_rect_height / 2),
+                widget_width - int(label_x),
+                label_rect_height,
+                Qt.AlignLeft | Qt.AlignVCenter,
+                label,
+            )
+
+        painter.end()

--- a/src/sc_linac_physics/displays/cavity_display/frontend/heatmap/color_mapper.py
+++ b/src/sc_linac_physics/displays/cavity_display/frontend/heatmap/color_mapper.py
@@ -1,18 +1,35 @@
 import math
+from typing import List, Optional, Tuple
 
 from PyQt5.QtGui import QColor
 
 
 class ColorMapper:
-    """Maps fault count values to a Blue -> White -> Red color gradient."""
+    """Maps a numeric value to a color on a navy-to-yellow gradient.
 
-    COLOR_LOW = QColor(0, 0, 255)
-    COLOR_MID = QColor(255, 255, 255)
-    COLOR_HIGH = QColor(255, 0, 0)
+    Supports log scale for ranges that span several orders of magnitude.
+    """
 
-    def __init__(self, vmin: float = 0.0, vmax: float = 1.0) -> None:
+    DEFAULT_STOPS: List[Tuple[float, QColor]] = [
+        (0.0, QColor(68, 1, 84)),  # dark purple
+        (0.2, QColor(65, 68, 135)),  # blue purple
+        (0.4, QColor(42, 120, 142)),  # teal
+        (0.6, QColor(34, 168, 132)),  # green teal
+        (0.8, QColor(122, 209, 81)),  # green yellow
+        (1.0, QColor(253, 231, 37)),  # bright yellow
+    ]
+
+    def __init__(
+        self,
+        vmin: float = 0.0,
+        vmax: float = 1.0,
+        stops: Optional[List[Tuple[float, QColor]]] = None,
+        log_scale: bool = False,
+    ) -> None:
         self._vmin = vmin
         self._vmax = vmax
+        self._stops = stops if stops is not None else list(self.DEFAULT_STOPS)
+        self._log_scale = log_scale
 
     def set_range(self, vmin: float, vmax: float) -> None:
         if vmin > vmax:
@@ -28,11 +45,24 @@ class ColorMapper:
     def vmax(self) -> float:
         return self._vmax
 
+    @property
+    def log_scale(self) -> bool:
+        return self._log_scale
+
     def _normalize(self, value: float) -> float:
         if math.isnan(value) or math.isinf(value):
             return 0.0
         if self._vmax == self._vmin:
             return 0.0
+
+        if self._log_scale:
+            # log1p(x) = ln(1+x), maps 0 -> 0 and spreads large ranges
+            log_range = math.log1p(self._vmax - self._vmin)
+            if log_range == 0.0:
+                return 0.0
+            clamped = max(self._vmin, min(self._vmax, value))
+            return math.log1p(clamped - self._vmin) / log_range
+
         normalized = (value - self._vmin) / (self._vmax - self._vmin)
         return max(0.0, min(1.0, normalized))
 
@@ -45,11 +75,13 @@ class ColorMapper:
         return QColor(r, g, b)
 
     def get_color(self, value: float) -> QColor:
-        normalized = self._normalize(value)
+        t = self._normalize(value)
 
-        if normalized <= 0.5:
-            t = normalized * 2.0
-            return self._interpolate_color(self.COLOR_LOW, self.COLOR_MID, t)
-        else:
-            t = (normalized - 0.5) * 2.0
-            return self._interpolate_color(self.COLOR_MID, self.COLOR_HIGH, t)
+        for i in range(len(self._stops) - 1):
+            t0, c0 = self._stops[i]
+            t1, c1 = self._stops[i + 1]
+            if t <= t1:
+                seg_t = (t - t0) / (t1 - t0) if t1 != t0 else 0.0
+                return self._interpolate_color(c0, c1, seg_t)
+
+        return self._stops[-1][1]

--- a/src/sc_linac_physics/displays/cavity_display/frontend/heatmap/fault_data_fetcher.py
+++ b/src/sc_linac_physics/displays/cavity_display/frontend/heatmap/fault_data_fetcher.py
@@ -1,0 +1,173 @@
+import dataclasses
+import threading
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from PyQt5.QtCore import QThread, pyqtSignal
+
+from sc_linac_physics.displays.cavity_display.backend.fault import (
+    FaultCounter,
+)
+
+
+@dataclasses.dataclass
+class CavityFaultResult:
+    """Fault counts for a single cavity, broken down by TLC."""
+
+    cm_name: str
+    cavity_num: int
+    fault_counts_by_tlc: Optional[Dict[str, FaultCounter]] = None
+    error: Optional[str] = None
+
+    def _sum_tlc_field(self, field: str) -> int:
+        if not self.fault_counts_by_tlc:
+            return 0
+        return sum(getattr(c, field) for c in self.fault_counts_by_tlc.values())
+
+    @property
+    def alarm_count(self) -> int:
+        return self._sum_tlc_field("alarm_count")
+
+    @property
+    def warning_count(self) -> int:
+        return self._sum_tlc_field("warning_count")
+
+    @property
+    def invalid_count(self) -> int:
+        return self._sum_tlc_field("invalid_count")
+
+    @property
+    def ok_count(self) -> int:
+        return self._sum_tlc_field("ok_count")
+
+    @property
+    def is_error(self) -> bool:
+        return self.error is not None
+
+    def to_fault_counter(self) -> FaultCounter:
+        return FaultCounter(
+            alarm_count=self.alarm_count,
+            warning_count=self.warning_count,
+            invalid_count=self.invalid_count,
+            ok_count=self.ok_count,
+        )
+
+
+class FaultDataFetcher(QThread):
+    """Fetches fault counts for all cavities in a background thread."""
+
+    progress = pyqtSignal(int, int)
+    cavity_result = pyqtSignal(object)
+    finished_all = pyqtSignal(object)
+    fetch_error = pyqtSignal(str)
+
+    def __init__(
+        self,
+        machine,
+        start_time: datetime,
+        end_time: datetime,
+        cavity_filter: Optional[Set[Tuple[str, int]]] = None,
+        cm_whitelist: Optional[Set[str]] = None,
+        parent=None,
+    ) -> None:
+        super().__init__(parent)
+        self._machine = machine
+        self._start_time = start_time
+        self._end_time = end_time
+        self._cavity_filter = cavity_filter
+        self._cm_whitelist = cm_whitelist
+        self._abort_event = threading.Event()
+
+    def abort(self) -> None:
+        self._abort_event.set()
+
+    @property
+    def is_abort_requested(self) -> bool:
+        return self._abort_event.is_set()
+
+    def _collect_cavities(self) -> List[Tuple[str, int, Any]]:
+        cavities = []
+        for linac in self._machine.linacs:
+            for cm_name, cm in linac.cryomodules.items():
+                if (
+                    self._cm_whitelist is not None
+                    and cm_name not in self._cm_whitelist
+                ):
+                    continue
+                for cav_num, cavity in cm.cavities.items():
+                    if (
+                        self._cavity_filter is None
+                        or (cm_name, cav_num) in self._cavity_filter
+                    ):
+                        cavities.append((cm_name, cav_num, cavity))
+        return cavities
+
+    MAX_WORKERS = 8
+
+    def run(self) -> None:
+        try:
+            cavities = self._collect_cavities()
+        except Exception as e:
+            self.fetch_error.emit(f"Failed to enumerate cavities: {e}")
+            return
+
+        total = len(cavities)
+        if total == 0:
+            self.fetch_error.emit("No cavities found in machine")
+            return
+
+        all_results: List[CavityFaultResult] = []
+
+        with ThreadPoolExecutor(max_workers=self.MAX_WORKERS) as executor:
+            futures: Dict[Future, Tuple[str, int]] = {}
+            for cm_name, cav_num, cavity in cavities:
+                if self._abort_event.is_set():
+                    break
+                future = executor.submit(
+                    self._fetch_single_cavity,
+                    cm_name,
+                    cav_num,
+                    cavity,
+                )
+                futures[future] = (cm_name, cav_num)
+
+            for future in as_completed(futures):
+                result = future.result()
+                all_results.append(result)
+                self.cavity_result.emit(result)
+                self.progress.emit(len(all_results), total)
+
+                if self._abort_event.is_set():
+                    for f in futures:
+                        f.cancel()
+                    break
+
+        self.finished_all.emit(all_results)
+
+    def _fetch_single_cavity(
+        self, cm_name: str, cavity_num: int, cavity
+    ) -> CavityFaultResult:
+        if self._abort_event.is_set():
+            return CavityFaultResult(
+                cm_name=cm_name,
+                cavity_num=cavity_num,
+                error="Aborted",
+            )
+
+        try:
+            fault_counts = cavity.get_fault_counts(
+                self._start_time, self._end_time
+            )
+        except Exception as e:
+            return CavityFaultResult(
+                cm_name=cm_name,
+                cavity_num=cavity_num,
+                error=str(e),
+            )
+
+        return CavityFaultResult(
+            cm_name=cm_name,
+            cavity_num=cavity_num,
+            fault_counts_by_tlc=dict(fault_counts),
+        )

--- a/src/sc_linac_physics/displays/cavity_display/frontend/heatmap/fault_data_fetcher.py
+++ b/src/sc_linac_physics/displays/cavity_display/frontend/heatmap/fault_data_fetcher.py
@@ -132,6 +132,8 @@ class FaultDataFetcher(QThread):
                 )
                 futures[future] = (cm_name, cav_num)
 
+            total = len(futures)
+
             for future in as_completed(futures):
                 result = future.result()
                 all_results.append(result)

--- a/src/sc_linac_physics/displays/cavity_display/frontend/heatmap/fault_data_fetcher.py
+++ b/src/sc_linac_physics/displays/cavity_display/frontend/heatmap/fault_data_fetcher.py
@@ -162,6 +162,12 @@ class FaultDataFetcher(QThread):
                 self._start_time, self._end_time
             )
         except Exception as e:
+            if self._abort_event.is_set():
+                return CavityFaultResult(
+                    cm_name=cm_name,
+                    cavity_num=cavity_num,
+                    error="Aborted",
+                )
             return CavityFaultResult(
                 cm_name=cm_name,
                 cavity_num=cavity_num,

--- a/src/sc_linac_physics/displays/cavity_display/frontend/heatmap/fault_heatmap_display.py
+++ b/src/sc_linac_physics/displays/cavity_display/frontend/heatmap/fault_heatmap_display.py
@@ -900,9 +900,9 @@ class FaultHeatmapDisplay(Display):
     def closeEvent(self, event) -> None:
         if self._fetcher and self._fetcher.isRunning():
             self._fetcher.abort()
-            if not self._fetcher.wait(timeout=5000):
+            if not self._fetcher.wait(5000):
                 self._fetcher.terminate()
-                self._fetcher.wait(timeout=2000)
+                self._fetcher.wait(2000)
         super().closeEvent(event)
 
 

--- a/src/sc_linac_physics/displays/cavity_display/frontend/heatmap/fault_heatmap_display.py
+++ b/src/sc_linac_physics/displays/cavity_display/frontend/heatmap/fault_heatmap_display.py
@@ -1,0 +1,933 @@
+import math
+from datetime import datetime, timedelta
+from typing import Dict, List, Optional, Set, Tuple
+
+from PyQt5.QtCore import Qt, QTimer
+from PyQt5.QtGui import QFont, QKeySequence
+from PyQt5.QtWidgets import (
+    QVBoxLayout,
+    QHBoxLayout,
+    QWidget,
+    QLabel,
+    QPushButton,
+    QProgressBar,
+    QDateTimeEdit,
+    QCheckBox,
+    QGroupBox,
+    QScrollArea,
+    QMessageBox,
+    QShortcut,
+    QSizePolicy,
+    QComboBox,
+)
+from pydm import Display
+
+from sc_linac_physics.displays.cavity_display.frontend.heatmap.color_bar_widget import (
+    ColorBarWidget,
+)
+from sc_linac_physics.displays.cavity_display.frontend.heatmap.color_mapper import (
+    ColorMapper,
+)
+from sc_linac_physics.displays.cavity_display.frontend.heatmap.fault_data_fetcher import (
+    CavityFaultResult,
+    FaultDataFetcher,
+)
+from sc_linac_physics.displays.cavity_display.frontend.heatmap.heatmap_cm_widget import (
+    HeatmapCMWidget,
+    format_cm_display_name,
+)
+from sc_linac_physics.displays.cavity_display.frontend.heatmap.severity_filter import (
+    SeverityFilter,
+)
+from sc_linac_physics.utils.sc_linac.linac_utils import (
+    L0B,
+    L1B,
+    L1BHL,
+    L2B,
+    L3B,
+    L4B,
+)
+
+HEATMAP_ROWS = [
+    [("L0B", L0B), ("L1B", L1B + L1BHL), ("L2B", L2B)],
+    [("L3B", L3B)],
+    [("L4B", L4B)],
+]
+
+HIGHLIGHT_THRESHOLD_FRACTION = 0.75
+
+
+LINAC_COLORS = {
+    "L0B": {
+        "border": "rgb(100, 180, 255)",
+        "text": "rgb(100, 180, 255)",
+        "bg": "rgb(20, 40, 80)",
+    },
+    "L1B": {
+        "border": "rgb(0, 200, 200)",
+        "text": "rgb(0, 220, 220)",
+        "bg": "rgb(0, 60, 60)",
+    },
+    "L2B": {
+        "border": "rgb(255, 140, 0)",
+        "text": "rgb(255, 160, 40)",
+        "bg": "rgb(80, 50, 10)",
+    },
+    "L3B": {
+        "border": "rgb(255, 100, 180)",
+        "text": "rgb(255, 120, 200)",
+        "bg": "rgb(80, 30, 60)",
+    },
+    "L4B": {
+        "border": "rgb(100, 200, 255)",
+        "text": "rgb(120, 200, 255)",
+        "bg": "rgb(30, 50, 80)",
+    },
+}
+DEFAULT_LINAC_COLORS = {
+    "border": "rgb(100, 100, 100)",
+    "text": "rgb(200, 200, 200)",
+    "bg": "rgb(50, 50, 50)",
+}
+
+
+class FaultHeatmapDisplay(Display):
+    """Main PyDM display for visualizing fault activity across all cavities."""
+
+    def __init__(
+        self,
+        machine=None,
+        parent=None,
+        args=None,
+        macros=None,
+    ) -> None:
+        super().__init__(parent=parent, args=args, macros=macros)
+
+        self._machine = machine
+        self._fetcher: Optional[FaultDataFetcher] = None
+        self._results: List[CavityFaultResult] = []
+        self._cavity_filter_active = False
+
+        self._color_mapper = ColorMapper(vmin=0, vmax=1, log_scale=True)
+        self._severity_filter = SeverityFilter()
+
+        self._cm_widgets: Dict[str, HeatmapCMWidget] = {}
+        self._section_labels: Dict[str, QLabel] = {}
+        self._section_cm_names: Dict[str, list] = {}
+        self._selection: Set[Tuple[str, int]] = set()
+        self._last_edited: str = "end"
+
+        self._resize_timer = QTimer(self)
+        self._resize_timer.setSingleShot(True)
+        self._resize_timer.timeout.connect(self._auto_fit)
+        self._auto_fit_in_progress = False
+
+        self._setup_ui()
+        self._set_quick_range(hours=1)
+
+        self._cm_to_section: Dict[str, str] = {}
+        for row_sections in HEATMAP_ROWS:
+            for section_name, cm_names in row_sections:
+                self._section_cm_names[section_name] = cm_names
+                for cm in cm_names:
+                    self._cm_to_section[cm] = section_name
+
+    def _setup_ui(self) -> None:
+        main_layout = QVBoxLayout()
+        main_layout.setContentsMargins(2, 2, 2, 2)
+        main_layout.setSpacing(4)
+        self.setLayout(main_layout)
+
+        main_layout.addLayout(self._build_controls_row())
+        main_layout.addLayout(self._build_summary_row())
+
+        heatmap_row = QHBoxLayout()
+
+        self._scroll = QScrollArea()
+        self._scroll.setWidgetResizable(True)
+        self._scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+        self._scroll.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+
+        heatmap_container = QWidget()
+        heatmap_layout = QVBoxLayout()
+        heatmap_layout.setContentsMargins(0, 0, 0, 0)
+        heatmap_layout.setSpacing(4)
+        heatmap_container.setLayout(heatmap_layout)
+
+        for row_sections in HEATMAP_ROWS:
+            heatmap_layout.addLayout(self._build_heatmap_row(row_sections))
+
+        self._scroll.setWidget(heatmap_container)
+        heatmap_row.addWidget(self._scroll, stretch=1)
+
+        self._color_bar = ColorBarWidget(
+            color_mapper=self._color_mapper, title="Faults"
+        )
+        heatmap_row.addWidget(self._color_bar)
+
+        main_layout.addLayout(heatmap_row, stretch=1)
+
+        self._progress_bar = QProgressBar()
+        self._progress_bar.setValue(0)
+        self._progress_bar.setTextVisible(True)
+        self._progress_bar.setFormat("Ready")
+        self._progress_bar.setMaximumHeight(14)
+        main_layout.addWidget(self._progress_bar)
+
+        self._status_label = QLabel(
+            "Select a time range and click Load All Faults."
+        )
+        self._status_label.setAlignment(Qt.AlignLeft)
+        main_layout.addWidget(self._status_label)
+
+        self._selection_label = QLabel("")
+        self._selection_label.setAlignment(Qt.AlignLeft)
+        self._selection_label.setVisible(False)
+        main_layout.addWidget(self._selection_label)
+
+        self.setWindowTitle("LCLS-II Fault Heatmap")
+
+        refresh_shortcut = QShortcut(QKeySequence(Qt.Key_F5), self)
+        refresh_shortcut.activated.connect(self._on_refresh_clicked)
+
+        clear_sel_shortcut = QShortcut(QKeySequence(Qt.Key_Escape), self)
+        clear_sel_shortcut.activated.connect(self._clear_selection)
+
+    def _build_controls_row(self) -> QHBoxLayout:
+        row = QHBoxLayout()
+        row.setSpacing(6)
+
+        # Time range
+        time_group = QGroupBox("Time Range")
+        time_layout = QHBoxLayout()
+        time_layout.setContentsMargins(4, 2, 4, 2)
+        time_layout.setSpacing(3)
+        time_group.setLayout(time_layout)
+
+        time_layout.addWidget(QLabel("Start:"))
+        self._start_dt = QDateTimeEdit()
+        self._start_dt.setCalendarPopup(True)
+        self._start_dt.setDisplayFormat("yyyy-MM-dd HH:mm")
+        self._start_dt.setMinimumWidth(170)
+        self._start_dt.dateTimeChanged.connect(
+            lambda: setattr(self, "_last_edited", "start")
+        )
+        time_layout.addWidget(self._start_dt)
+
+        time_layout.addWidget(QLabel("End:"))
+        self._end_dt = QDateTimeEdit()
+        self._end_dt.setCalendarPopup(True)
+        self._end_dt.setDisplayFormat("yyyy-MM-dd HH:mm")
+        self._end_dt.setMinimumWidth(170)
+        self._end_dt.setDateTime(datetime.now())
+        self._end_dt.dateTimeChanged.connect(
+            lambda: setattr(self, "_last_edited", "end")
+        )
+        time_layout.addWidget(self._end_dt)
+
+        for label, kwargs in [
+            ("30m", {"minutes": 30}),
+            ("1h", {"hours": 1}),
+            ("4h", {"hours": 4}),
+            ("24h", {"hours": 24}),
+            ("1w", {"days": 7}),
+        ]:
+            btn = QPushButton(label)
+            btn.setMinimumWidth(40)
+            btn.setFixedHeight(28)
+            btn.clicked.connect(
+                lambda _, kw=kwargs: self._set_quick_range(**kw)
+            )
+            time_layout.addWidget(btn)
+
+        row.addWidget(time_group)
+
+        # Severity filters
+        filter_group = QGroupBox("Severity Filter")
+        filter_layout = QHBoxLayout()
+        filter_layout.setContentsMargins(4, 2, 4, 2)
+        filter_layout.setSpacing(3)
+        filter_group.setLayout(filter_layout)
+
+        self._cb_alarms = QCheckBox("Alarms")
+        self._cb_alarms.setChecked(True)
+        self._cb_alarms.toggled.connect(self._on_filter_changed)
+        filter_layout.addWidget(self._cb_alarms)
+
+        self._cb_warnings = QCheckBox("Warnings")
+        self._cb_warnings.setChecked(True)
+        self._cb_warnings.toggled.connect(self._on_filter_changed)
+        filter_layout.addWidget(self._cb_warnings)
+
+        self._cb_invalid = QCheckBox("Invalid")
+        self._cb_invalid.setChecked(True)
+        self._cb_invalid.toggled.connect(self._on_filter_changed)
+        filter_layout.addWidget(self._cb_invalid)
+
+        row.addWidget(filter_group)
+
+        # TLC fault type selector
+        self._tlc_combo = QComboBox()
+        self._tlc_combo.addItem("All Fault Types")
+        self._tlc_combo.setMinimumWidth(130)
+        self._tlc_combo.setFixedHeight(28)
+        self._tlc_combo.currentTextChanged.connect(self._on_tlc_filter_changed)
+        row.addWidget(self._tlc_combo)
+
+        self._refresh_btn = QPushButton("Load All Faults")
+        self._refresh_btn.setFixedHeight(28)
+        self._refresh_btn.setMinimumWidth(140)
+        refresh_font = QFont()
+        refresh_font.setBold(True)
+        self._refresh_btn.setFont(refresh_font)
+        self._refresh_btn.clicked.connect(self._on_refresh_clicked)
+        row.addWidget(self._refresh_btn)
+
+        self._fetch_selected_btn = QPushButton("Fetch Selected")
+        self._fetch_selected_btn.setFixedHeight(28)
+        self._fetch_selected_btn.setMinimumWidth(120)
+        self._fetch_selected_btn.setEnabled(False)
+        self._fetch_selected_btn.clicked.connect(
+            self._on_fetch_selected_clicked
+        )
+        row.addWidget(self._fetch_selected_btn)
+
+        self._abort_btn = QPushButton("Abort")
+        self._abort_btn.setFixedHeight(28)
+        self._abort_btn.setEnabled(False)
+        self._abort_btn.clicked.connect(self._on_abort_clicked)
+        row.addWidget(self._abort_btn)
+
+        self._clear_selection_btn = QPushButton("Clear Selection")
+        self._clear_selection_btn.setFixedHeight(28)
+        self._clear_selection_btn.setEnabled(False)
+        self._clear_selection_btn.clicked.connect(self._clear_selection)
+        row.addWidget(self._clear_selection_btn)
+
+        return row
+
+    def _build_summary_row(self) -> QHBoxLayout:
+        """Build a row of color-coded labels showing per-section totals."""
+        row = QHBoxLayout()
+        row.setSpacing(4)
+        for row_sections in HEATMAP_ROWS:
+            for section_name, _ in row_sections:
+                colors = LINAC_COLORS.get(section_name, DEFAULT_LINAC_COLORS)
+                label = QLabel(f"{section_name}: \u2014")  # em-dash
+                label.setAlignment(Qt.AlignCenter)
+                label.setStyleSheet(
+                    f"QLabel {{"
+                    f"  color: {colors['text']};"
+                    f"  background-color: {colors['bg']};"
+                    f"  border: 1px solid {colors['border']};"
+                    f"  border-radius: 3px;"
+                    f"  padding: 2px 8px;"
+                    f"  font-weight: bold;"
+                    f"}}"
+                )
+                row.addWidget(label, stretch=1)
+                self._section_labels[section_name] = label
+        return row
+
+    def _build_heatmap_row(self, sections: list) -> QHBoxLayout:
+        row = QHBoxLayout()
+        row.setSpacing(4)
+
+        for section_name, cm_names in sections:
+            section_widget = self._create_linac_section(section_name, cm_names)
+            row.addWidget(section_widget, len(cm_names))
+
+        return row
+
+    def _create_linac_section(
+        self, section_name: str, cm_names: list
+    ) -> QWidget:
+        """Create a bordered section for a linac with header and CMs."""
+        section = QWidget()
+        section_layout = QVBoxLayout()
+        section_layout.setSpacing(2)
+        section_layout.setContentsMargins(3, 3, 3, 3)
+
+        # Colored header label
+        colors = LINAC_COLORS.get(section_name, DEFAULT_LINAC_COLORS)
+        header_row = QHBoxLayout()
+        header_row.setContentsMargins(0, 0, 0, 0)
+        header_row.setSpacing(2)
+
+        header = QLabel(section_name)
+        header.setAlignment(Qt.AlignCenter)
+        header.setStyleSheet(
+            f"QLabel {{"
+            f"  font-weight: bold; font-size: 10pt;"
+            f"  color: {colors['text']};"
+            f"  background-color: {colors['bg']};"
+            f"  padding: 3px; border-radius: 2px;"
+            f"}}"
+        )
+        header.setFixedHeight(20)
+        header_row.addWidget(header, stretch=1)
+
+        section_select_btn = QPushButton("\u25a3")  # ▣
+        section_select_btn.setFixedSize(20, 20)
+        section_select_btn.setToolTip(f"Select all cavities in {section_name}")
+        section_select_btn.setStyleSheet(
+            f"QPushButton {{"
+            f"  color: {colors['text']};"
+            f"  background-color: {colors['bg']};"
+            f"  border: 1px solid {colors['border']};"
+            f"  border-radius: 2px;"
+            f"  padding: 0px;"
+            f"  font-size: 10pt;"
+            f"  font-weight: bold;"
+            f"}}"
+            f"QPushButton:hover {{"
+            f"  background-color: {colors['border']};"
+            f"}}"
+        )
+        section_select_btn.clicked.connect(
+            lambda _, s=section_name, cms=list(
+                cm_names
+            ): self._on_section_select_clicked(s, cms)
+        )
+        header_row.addWidget(section_select_btn)
+
+        section_layout.addLayout(header_row)
+
+        # CM columns side by side
+        body = QHBoxLayout()
+        body.setSpacing(2)
+
+        for cm_name in cm_names:
+            cm_widget = HeatmapCMWidget(cm_name=cm_name)
+            cm_widget.cavity_clicked.connect(self._on_cavity_clicked)
+            cm_widget.cavity_double_clicked.connect(
+                self._on_cavity_double_clicked
+            )
+            cm_widget.cm_label_clicked.connect(self._on_cm_label_clicked)
+            body.addWidget(cm_widget, stretch=1)
+            self._cm_widgets[cm_name] = cm_widget
+
+        section_layout.addLayout(body, stretch=1)
+        section.setLayout(section_layout)
+
+        section.setObjectName("linac_section")
+        section.setStyleSheet(
+            f"#linac_section {{"
+            f"  background-color: rgb(35, 35, 35);"
+            f"  border: 2px solid {colors['border']};"
+            f"  border-radius: 3px;"
+            f"}}"
+        )
+        section.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+
+        return section
+
+    def _set_quick_range(self, minutes=0, hours=0, days=0):
+        delta = timedelta(minutes=minutes, hours=hours, days=days)
+        if getattr(self, "_last_edited", "end") == "start":
+            start = self._start_dt.dateTime().toPyDateTime()
+            self._end_dt.setDateTime(start + delta)
+        else:
+            end = self._end_dt.dateTime().toPyDateTime()
+            self._start_dt.setDateTime(end - delta)
+
+    def _get_time_range(self) -> tuple:
+        start = self._start_dt.dateTime().toPyDateTime()
+        end = self._end_dt.dateTime().toPyDateTime()
+        if start >= end:
+            raise ValueError("Start time must be before end time.")
+        return start, end
+
+    def resizeEvent(self, event) -> None:
+        """Auto-fit heatmap when window is resized (300ms debounce)."""
+        super().resizeEvent(event)
+        self._resize_timer.start(300)
+
+    def showEvent(self, event) -> None:
+        """Auto-fit on first show."""
+        super().showEvent(event)
+        self._resize_timer.start(200)
+
+    def _auto_fit(self) -> None:
+        """Reset to scale 1.0, then measure on next tick to get correct sizes."""
+        if self._auto_fit_in_progress:
+            return
+        self._auto_fit_in_progress = True
+
+        viewport = self._scroll.viewport()
+        if viewport.width() <= 0 or viewport.height() <= 0:
+            self._auto_fit_in_progress = False
+            return
+
+        self._apply_scale(1.0)
+        QTimer.singleShot(0, self._measure_and_fit)
+
+    def _measure_and_fit(self) -> None:
+        """Phase 2 of auto-fit: measure content at scale=1.0 and apply."""
+        try:
+            viewport = self._scroll.viewport()
+            available_w = viewport.width()
+            available_h = viewport.height()
+
+            if available_w <= 0 or available_h <= 0:
+                return
+
+            container = self._scroll.widget()
+            if container is None:
+                return
+            hint = container.sizeHint()
+            content_w = hint.width()
+            content_h = hint.height()
+
+            if content_w <= 0 or content_h <= 0:
+                return
+
+            w_scale = available_w / content_w
+            h_scale = available_h / content_h
+            scale = min(w_scale, h_scale)
+            scale = max(0.5, min(2.0, scale))
+
+            self._apply_scale(scale)
+        finally:
+            self._auto_fit_in_progress = False
+
+    def _apply_scale(self, scale: float) -> None:
+        """Apply zoom scale to CM label fonts."""
+        for cm_widget in self._cm_widgets.values():
+            cm_widget.set_scale(scale)
+
+    def _on_filter_changed(self) -> None:
+        self._severity_filter.set_filter(
+            include_alarms=self._cb_alarms.isChecked(),
+            include_warnings=self._cb_warnings.isChecked(),
+            include_invalid=self._cb_invalid.isChecked(),
+        )
+        if self._results:
+            self._apply_results_to_heatmap(self._results)
+
+    # TLC fault type filter
+
+    def _get_selected_tlc(self) -> Optional[str]:
+        """Return selected TLC code, or None for 'All Fault Types'."""
+        text = self._tlc_combo.currentText()
+        if text == "All Fault Types":
+            return None
+        return text
+
+    def _on_tlc_filter_changed(self) -> None:
+        """Re-apply heatmap coloring when TLC selection changes."""
+        if self._results:
+            self._apply_results_to_heatmap(self._results)
+
+    def _populate_tlc_combo(self) -> None:
+        """Rebuild TLC dropdown from current results, preserving selection."""
+        tlc_codes: Set[str] = set()
+        for result in self._results:
+            if result.fault_counts_by_tlc:
+                tlc_codes.update(result.fault_counts_by_tlc.keys())
+
+        current = self._tlc_combo.currentText()
+        self._tlc_combo.blockSignals(True)
+        self._tlc_combo.clear()
+        self._tlc_combo.addItem("All Fault Types")
+        for code in sorted(tlc_codes):
+            self._tlc_combo.addItem(code)
+        # Restore previous selection if still valid
+        idx = self._tlc_combo.findText(current)
+        self._tlc_combo.setCurrentIndex(idx if idx >= 0 else 0)
+        self._tlc_combo.blockSignals(False)
+
+    # Fetch lifecycle
+
+    def _on_refresh_clicked(self) -> None:
+        """Load faults for ALL cavities."""
+        if self._fetcher and self._fetcher.isRunning():
+            return
+        self._clear_selection()
+        self._start_fetch(cavity_filter=None)
+
+    def _on_fetch_selected_clicked(self) -> None:
+        """Load faults for only the selected cavities."""
+        if not self._selection:
+            return
+        if self._fetcher and self._fetcher.isRunning():
+            return
+        self._start_fetch(cavity_filter=set(self._selection))
+
+    def _start_fetch(
+        self,
+        cavity_filter: Optional[Set[Tuple[str, int]]] = None,
+    ) -> None:
+        try:
+            start, end = self._get_time_range()
+        except ValueError as e:
+            QMessageBox.warning(self, "Invalid Time Range", str(e))
+            return
+
+        if self._machine is None:
+            QMessageBox.information(
+                self,
+                "No Machine",
+                "No BackendMachine connected.\n"
+                "Pass a machine instance to "
+                "FaultHeatmapDisplay to fetch real data.",
+            )
+            return
+
+        self._cavity_filter_active = cavity_filter is not None
+
+        if cavity_filter is None:
+            self._results.clear()
+            for cm_widget in self._cm_widgets.values():
+                cm_widget.clear_all()
+        else:
+            self._results = [
+                r
+                for r in self._results
+                if (r.cm_name, r.cavity_num) not in cavity_filter
+            ]
+            for cm_name, cav_num in cavity_filter:
+                cm_widget = self._cm_widgets.get(cm_name)
+                if cm_widget:
+                    cav_widget = cm_widget.cavity_widgets.get(cav_num)
+                    if cav_widget:
+                        cav_widget.clear()
+
+        self._refresh_btn.setEnabled(False)
+        self._fetch_selected_btn.setEnabled(False)
+        self._abort_btn.setEnabled(True)
+        self._start_dt.setEnabled(False)
+        self._end_dt.setEnabled(False)
+        self._progress_bar.setValue(0)
+        self._progress_bar.setFormat("Fetching...")
+        self._status_label.setText("Fetching fault data from archiver...")
+
+        self._fetcher = FaultDataFetcher(
+            self._machine,
+            start,
+            end,
+            cavity_filter=cavity_filter,
+            cm_whitelist=set(self._cm_widgets.keys()),
+        )
+        self._fetcher.progress.connect(self._on_fetch_progress)
+        self._fetcher.cavity_result.connect(self._on_cavity_result)
+        self._fetcher.finished_all.connect(self._on_fetch_finished)
+        self._fetcher.fetch_error.connect(self._on_fetch_error)
+        self._fetcher.start()
+
+    def _on_abort_clicked(self) -> None:
+        if self._fetcher:
+            self._fetcher.abort()
+            self._status_label.setText("Aborting...")
+            self._abort_btn.setEnabled(False)
+
+    def _on_fetch_progress(self, current: int, total: int) -> None:
+        self._progress_bar.setMaximum(total)
+        self._progress_bar.setValue(current)
+        self._progress_bar.setFormat(f"{current}/{total} cavities")
+
+    def _on_cavity_result(self, result: CavityFaultResult) -> None:
+        cm_widget = self._cm_widgets.get(result.cm_name)
+        if not cm_widget:
+            return
+        if result.is_error:
+            cm_widget.set_cavity_error(
+                result.cavity_num, result.error or "Unknown error"
+            )
+        else:
+            cm_widget.set_cavity_data_pending(result.cavity_num)
+
+    def _on_fetch_finished(self, results: List[CavityFaultResult]) -> None:
+        self._merge_results(results)
+        self._populate_tlc_combo()
+        self._apply_results_to_heatmap(self._results)
+
+        valid = [r for r in self._results if not r.is_error]
+        errors = sum(1 for r in self._results if r.is_error)
+        aborted = self._fetcher.is_abort_requested if self._fetcher else False
+
+        self._status_label.setText(
+            self._build_status_text(valid, errors, aborted)
+        )
+        self._progress_bar.setFormat("Done")
+        self._cavity_filter_active = False
+        self._set_idle_state()
+
+    def _merge_results(self, new_results: List[CavityFaultResult]) -> None:
+        """Replace existing results for re-fetched cavities, keep the rest."""
+        new_keys = {(r.cm_name, r.cavity_num) for r in new_results}
+        self._results = [
+            r
+            for r in self._results
+            if (r.cm_name, r.cavity_num) not in new_keys
+        ]
+        self._results.extend(new_results)
+
+    def _build_status_text(
+        self,
+        valid_results: List[CavityFaultResult],
+        error_count: int,
+        aborted: bool,
+    ) -> str:
+        """Build the status bar summary string."""
+        if valid_results:
+            faulted = sum(
+                1 for r in valid_results if self._get_filtered_count(r) > 0
+            )
+            ok_cavities = len(valid_results) - faulted
+            max_result = max(
+                valid_results,
+                key=lambda r: self._get_filtered_count(r),
+            )
+            max_count = self._get_filtered_count(max_result)
+            max_cm = format_cm_display_name(max_result.cm_name)
+
+            parts = [f"{faulted} faulted", f"{ok_cavities} OK"]
+            if error_count:
+                parts.append(f"{error_count} errors")
+            parts.append(
+                f"Max: {max_cm} Cav {max_result.cavity_num}" f" ({max_count})"
+            )
+        else:
+            parts = ["0 cavities loaded"]
+            if error_count:
+                parts.append(f"{error_count} errors")
+
+        if aborted:
+            parts.append("(aborted)")
+
+        timestamp = datetime.now().strftime("%H:%M:%S")
+        parts.append(f"Updated {timestamp}")
+        return " | ".join(parts)
+
+    def _on_fetch_error(self, msg: str) -> None:
+        self._status_label.setText(f"Error: {msg}")
+        self._progress_bar.setValue(0)
+        self._progress_bar.setFormat("Error")
+        self._cavity_filter_active = False
+        self._set_idle_state()
+
+    def _set_idle_state(self) -> None:
+        self._refresh_btn.setEnabled(True)
+        self._abort_btn.setEnabled(False)
+        self._start_dt.setEnabled(True)
+        self._end_dt.setEnabled(True)
+        self._fetcher = None
+        self._update_selection_ui()
+
+    # Heatmap coloring
+
+    def _get_filtered_count(self, result: CavityFaultResult) -> int:
+        tlc = self._get_selected_tlc()
+        if tlc is not None and result.fault_counts_by_tlc:
+            counter = result.fault_counts_by_tlc.get(tlc)
+            if counter is None:
+                return 0
+            return self._severity_filter.get_filtered_count(counter)
+        return self._severity_filter.get_filtered_count(
+            result.to_fault_counter()
+        )
+
+    def _apply_results_to_heatmap(
+        self, results: List[CavityFaultResult]
+    ) -> None:
+        valid_results = [r for r in results if not r.is_error]
+        if not valid_results:
+            for section_name, label in self._section_labels.items():
+                label.setText(f"{section_name}: \u2014")
+            return
+
+        filtered_counts = {
+            (r.cm_name, r.cavity_num): self._get_filtered_count(r)
+            for r in valid_results
+        }
+
+        counts = list(filtered_counts.values())
+        vmax = max(counts) if counts else 1
+        if vmax == 0:
+            vmax = 1
+
+        self._color_mapper.set_range(0, vmax)
+        self._color_bar.update_range()
+
+        highlight_threshold = math.ceil(HIGHLIGHT_THRESHOLD_FRACTION * vmax)
+
+        for cm_widget in self._cm_widgets.values():
+            cm_widget.reset_highlight()
+
+        for result in results:
+            cm_widget = self._cm_widgets.get(result.cm_name)
+            if not cm_widget:
+                continue
+
+            if result.is_error:
+                cm_widget.set_cavity_error(
+                    result.cavity_num,
+                    result.error or "Unknown error",
+                )
+                continue
+
+            count = filtered_counts[(result.cm_name, result.cavity_num)]
+            color = self._color_mapper.get_color(count)
+            tooltip = self._build_tooltip(result, count)
+            highlight = count >= highlight_threshold and count > 0
+            cm_widget.update_cavity(
+                result.cavity_num,
+                count,
+                color,
+                tooltip,
+                highlight=highlight,
+            )
+
+        self._update_section_summaries()
+
+    def _update_section_summaries(self) -> None:
+        """Aggregate filtered fault counts per linac section."""
+        section_totals: Dict[str, int] = {s: 0 for s in self._section_labels}
+        for result in self._results:
+            if result.is_error:
+                continue
+            section = self._cm_to_section.get(result.cm_name)
+            if section:
+                section_totals[section] += self._get_filtered_count(result)
+        for section_name, label in self._section_labels.items():
+            total = section_totals[section_name]
+            label.setText(f"{section_name}: {total}")
+
+    def _build_tooltip(
+        self, result: CavityFaultResult, filtered_count: int
+    ) -> str:
+        total = result.alarm_count + result.warning_count + result.invalid_count
+        return (
+            f"{format_cm_display_name(result.cm_name)} "
+            f"Cavity {result.cavity_num}\n"
+            f"Alarms:   {result.alarm_count}\n"
+            f"Warnings: {result.warning_count}\n"
+            f"Invalid:  {result.invalid_count}\n"
+            f"Total:    {total}\n"
+            f"Filtered: {filtered_count}"
+        )
+
+    def _on_cavity_clicked(self, cm_name: str, cavity_num: int) -> None:
+        key = (cm_name, cavity_num)
+        if key in self._selection:
+            self._selection.discard(key)
+        else:
+            self._selection.add(key)
+
+        cm_widget = self._cm_widgets.get(cm_name)
+        if cm_widget:
+            cm_widget.set_cavity_selected(cavity_num, key in self._selection)
+        self._update_selection_ui()
+
+    def _on_cavity_double_clicked(self, cm_name: str, cavity_num: int) -> None:
+        """Open fault detail display for the double-clicked cavity."""
+        if self._machine is None:
+            return
+        for linac in self._machine.linacs:
+            cm = linac.cryomodules.get(cm_name)
+            if cm is None:
+                continue
+            cavity = cm.cavities.get(cavity_num)
+            if cavity is None:
+                continue
+            if hasattr(cavity, "show_fault_display"):
+                cavity.show_fault_display()
+            return
+
+    def _on_cm_label_clicked(self, cm_name: str) -> None:
+        cm_widget = self._cm_widgets.get(cm_name)
+        if not cm_widget:
+            return
+
+        if cm_widget.all_selected():
+            for cav_num in range(1, HeatmapCMWidget.NUM_CAVITIES + 1):
+                self._selection.discard((cm_name, cav_num))
+            cm_widget.deselect_all()
+        else:
+            for cav_num in range(1, HeatmapCMWidget.NUM_CAVITIES + 1):
+                self._selection.add((cm_name, cav_num))
+            cm_widget.select_all()
+
+        self._update_selection_ui()
+
+    def _on_section_select_clicked(
+        self, section_name: str, cm_names: List[str]
+    ) -> None:
+        """Toggle selection of all cavities in a linac section."""
+        cavs = range(1, HeatmapCMWidget.NUM_CAVITIES + 1)
+        all_selected = all(
+            (cm, cav) in self._selection for cm in cm_names for cav in cavs
+        )
+        if all_selected:
+            for cm in cm_names:
+                for cav in cavs:
+                    self._selection.discard((cm, cav))
+                cm_widget = self._cm_widgets.get(cm)
+                if cm_widget:
+                    cm_widget.deselect_all()
+        else:
+            for cm in cm_names:
+                for cav in cavs:
+                    self._selection.add((cm, cav))
+                cm_widget = self._cm_widgets.get(cm)
+                if cm_widget:
+                    cm_widget.select_all()
+        self._update_selection_ui()
+
+    def _update_selection_ui(self) -> None:
+        has_selection = len(self._selection) > 0
+        self._fetch_selected_btn.setEnabled(has_selection)
+        self._clear_selection_btn.setEnabled(has_selection)
+
+        if has_selection:
+            count = len(self._selection)
+            cm_count = len({cm for cm, _ in self._selection})
+            self._selection_label.setText(
+                f"{count} cavit{'y' if count == 1 else 'ies'} selected "
+                f"across {cm_count} CM{'s' if cm_count != 1 else ''}"
+            )
+            self._selection_label.setVisible(True)
+        else:
+            self._selection_label.setVisible(False)
+
+    def _clear_selection(self) -> None:
+        self._selection.clear()
+        for cm_widget in self._cm_widgets.values():
+            cm_widget.deselect_all()
+        self._update_selection_ui()
+
+    def closeEvent(self, event) -> None:
+        if self._fetcher and self._fetcher.isRunning():
+            self._fetcher.abort()
+            if not self._fetcher.wait(timeout=5000):
+                self._fetcher.terminate()
+                self._fetcher.wait(timeout=2000)
+        super().closeEvent(event)
+
+
+if __name__ == "__main__":
+    import logging
+    import sys
+
+    import lcls_tools.common.data.archiver as _archiver
+    from PyQt5.QtWidgets import QApplication as _QApp
+
+    from sc_linac_physics.displays.cavity_display.backend.backend_machine import (
+        BackendMachine,
+    )
+
+    from sc_linac_physics.displays.cavity_display.utils.utils import (
+        cavity_fault_logger,
+    )
+
+    cavity_fault_logger.setLevel(logging.WARNING)
+
+    _archiver.TIMEOUT = 30
+
+    app = _QApp(sys.argv)
+    machine = BackendMachine(lazy_fault_pvs=True)
+    window = FaultHeatmapDisplay(machine=machine)
+    window.resize(1400, 700)
+    window.show()
+    sys.exit(app.exec_())

--- a/src/sc_linac_physics/displays/cavity_display/frontend/heatmap/heatmap_cavity_widget.py
+++ b/src/sc_linac_physics/displays/cavity_display/frontend/heatmap/heatmap_cavity_widget.py
@@ -36,7 +36,6 @@ class HeatmapCavityWidget(QWidget):
         self.setMinimumSize(self.DEFAULT_WIDTH, self.DEFAULT_HEIGHT)
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.setCursor(Qt.PointingHandCursor)
-        self.setMouseTracking(True)
         self.setToolTip(f"Cavity {cavity_num}\nNo data loaded")
 
     @property

--- a/src/sc_linac_physics/displays/cavity_display/frontend/heatmap/heatmap_cm_widget.py
+++ b/src/sc_linac_physics/displays/cavity_display/frontend/heatmap/heatmap_cm_widget.py
@@ -98,7 +98,7 @@ class HeatmapCMWidget(QWidget):
         self._select_all_btn = QPushButton("\u25a3")  # ▣
         self._select_all_btn.setFixedSize(16, 16)
         self._select_all_btn.setToolTip(
-            f"Select all cavities in "
+            f"Select/deselect all cavities in "
             f"{format_cm_display_name(self._cm_name)}"
         )
         self._select_all_btn.setStyleSheet(

--- a/src/sc_linac_physics/displays/cavity_display/frontend/heatmap/heatmap_cm_widget.py
+++ b/src/sc_linac_physics/displays/cavity_display/frontend/heatmap/heatmap_cm_widget.py
@@ -8,6 +8,8 @@ from PyQt5.QtWidgets import (
     QFrame,
     QLabel,
     QSizePolicy,
+    QHBoxLayout,
+    QPushButton,
 )
 
 from sc_linac_physics.displays.cavity_display.frontend.heatmap.heatmap_cavity_widget import (  # noqa: E501
@@ -76,14 +78,36 @@ class HeatmapCMWidget(QWidget):
         self.setLayout(main_layout)
 
         # Top: label + status bar
+        label_row = QHBoxLayout()
+        label_row.setContentsMargins(0, 0, 0, 0)
+        label_row.setSpacing(2)
+
         self._label = ClickableLabel(format_cm_display_name(self._cm_name))
         self._label.setAlignment(Qt.AlignCenter)
         label_font = QFont()
         label_font.setPointSize(self.LABEL_FONT_SIZE)
         label_font.setBold(True)
         self._label.setFont(label_font)
+        self._label.setToolTip("Click to select/deselect all 8 cavities")
+        self._label.setStyleSheet(
+            "QLabel:hover { text-decoration: underline; }"
+        )
         self._label.clicked.connect(self._on_cm_label_clicked)
-        main_layout.addWidget(self._label)
+        label_row.addWidget(self._label, stretch=1)
+
+        self._select_all_btn = QPushButton("\u25a3")  # ▣
+        self._select_all_btn.setFixedSize(16, 16)
+        self._select_all_btn.setToolTip(
+            f"Select all cavities in "
+            f"{format_cm_display_name(self._cm_name)}"
+        )
+        self._select_all_btn.setStyleSheet(
+            "QPushButton { padding: 0px; font-size: 9pt; }"
+        )
+        self._select_all_btn.clicked.connect(self._on_cm_label_clicked)
+        label_row.addWidget(self._select_all_btn)
+
+        main_layout.addLayout(label_row)
 
         self._status_bar = QFrame()
         self._status_bar.setFixedHeight(self.BAR_HEIGHT)

--- a/src/sc_linac_physics/displays/cavity_display/frontend/heatmap/heatmap_cm_widget.py
+++ b/src/sc_linac_physics/displays/cavity_display/frontend/heatmap/heatmap_cm_widget.py
@@ -9,7 +9,6 @@ from PyQt5.QtWidgets import (
     QLabel,
     QSizePolicy,
     QHBoxLayout,
-    QPushButton,
 )
 
 from sc_linac_physics.displays.cavity_display.frontend.heatmap.heatmap_cavity_widget import (  # noqa: E501
@@ -94,18 +93,6 @@ class HeatmapCMWidget(QWidget):
         )
         self._label.clicked.connect(self._on_cm_label_clicked)
         label_row.addWidget(self._label, stretch=1)
-
-        self._select_all_btn = QPushButton("\u25a3")  # ▣
-        self._select_all_btn.setFixedSize(16, 16)
-        self._select_all_btn.setToolTip(
-            f"Select/deselect all cavities in "
-            f"{format_cm_display_name(self._cm_name)}"
-        )
-        self._select_all_btn.setStyleSheet(
-            "QPushButton { padding: 0px; font-size: 9pt; }"
-        )
-        self._select_all_btn.clicked.connect(self._on_cm_label_clicked)
-        label_row.addWidget(self._select_all_btn)
 
         main_layout.addLayout(label_row)
 

--- a/tests/displays/cavity_display/frontend/heatmap/conftest.py
+++ b/tests/displays/cavity_display/frontend/heatmap/conftest.py
@@ -1,8 +1,13 @@
+from unittest.mock import Mock
+
 import pytest
 
 from sc_linac_physics.displays.cavity_display.backend.fault import FaultCounter
 from sc_linac_physics.displays.cavity_display.frontend.heatmap.color_mapper import (
     ColorMapper,
+)
+from sc_linac_physics.displays.cavity_display.frontend.heatmap.fault_data_fetcher import (
+    CavityFaultResult,
 )
 from sc_linac_physics.displays.cavity_display.frontend.heatmap.severity_filter import (
     SeverityFilter,
@@ -31,3 +36,48 @@ def zero_fault_counter():
     return FaultCounter(
         alarm_count=0, ok_count=0, invalid_count=0, warning_count=0
     )
+
+
+def make_result(
+    cm_name: str = "01",
+    cavity_num: int = 1,
+    alarm: int = 0,
+    warning: int = 0,
+    invalid: int = 0,
+    ok: int = 0,
+) -> CavityFaultResult:
+    """Create a successful CavityFaultResult with the given fault counts."""
+    return CavityFaultResult(
+        cm_name=cm_name,
+        cavity_num=cavity_num,
+        fault_counts_by_tlc={"ALL": FaultCounter(alarm, ok, invalid, warning)},
+    )
+
+
+def make_error_result(
+    cm_name: str = "01",
+    cavity_num: int = 1,
+    error: str = "PV timeout",
+) -> CavityFaultResult:
+    """Create an error CavityFaultResult."""
+    return CavityFaultResult(
+        cm_name=cm_name,
+        cavity_num=cavity_num,
+        error=error,
+    )
+
+
+def make_machine(num_cavities: int = 1) -> Mock:
+    """Create a mock BackendMachine with one linac, one CM, and N cavities."""
+    machine = Mock()
+    linac = Mock()
+    cm = Mock()
+    cavities = {}
+    for i in range(1, num_cavities + 1):
+        cav = Mock()
+        cav.get_fault_counts = Mock(return_value={})
+        cavities[i] = cav
+    cm.cavities = cavities
+    linac.cryomodules = {"01": cm}
+    machine.linacs = [linac]
+    return machine

--- a/tests/displays/cavity_display/frontend/heatmap/test_color_bar_widget.py
+++ b/tests/displays/cavity_display/frontend/heatmap/test_color_bar_widget.py
@@ -1,0 +1,120 @@
+import pytest
+
+from sc_linac_physics.displays.cavity_display.frontend.heatmap.color_bar_widget import (
+    ColorBarWidget,
+)
+from sc_linac_physics.displays.cavity_display.frontend.heatmap.color_mapper import (
+    ColorMapper,
+)
+
+
+@pytest.fixture
+def color_bar(color_mapper):
+    w = ColorBarWidget(color_mapper=color_mapper, title="Faults", num_ticks=5)
+    yield w
+    w.deleteLater()
+
+
+class TestColorBarInit:
+    def test_creates_with_color_mapper(self, color_bar):
+        assert color_bar._vmin == 0.0
+        assert color_bar._vmax == 100.0
+
+    def test_creates_with_none_mapper(self):
+        w = ColorBarWidget(color_mapper=None, title="Test")
+        assert w._vmin == 0.0
+        assert w._vmax == 1.0
+        w.deleteLater()
+
+    def test_num_ticks_clamped_to_min_2(self):
+        w = ColorBarWidget(num_ticks=0)
+        assert w._num_ticks == 2
+        w.deleteLater()
+
+    def test_num_ticks_1_clamped_to_2(self):
+        w = ColorBarWidget(num_ticks=1)
+        assert w._num_ticks == 2
+        w.deleteLater()
+
+    def test_title_stored(self, color_bar):
+        assert color_bar._title == "Faults"
+
+
+class TestTickValues:
+    def test_five_ticks_on_0_to_100(self, color_bar):
+        ticks = color_bar._get_tick_values()
+        assert len(ticks) == 5
+        assert ticks[0] == 100.0
+        assert ticks[-1] == 0.0
+        assert ticks[2] == 50.0
+
+    def test_vmin_equals_vmax(self):
+        mapper = ColorMapper(vmin=50.0, vmax=50.0)
+        w = ColorBarWidget(color_mapper=mapper, num_ticks=5)
+        ticks = w._get_tick_values()
+        assert ticks == [50.0, 50.0]
+        w.deleteLater()
+
+    def test_two_ticks_endpoints_only(self):
+        mapper = ColorMapper(vmin=0.0, vmax=100.0)
+        w = ColorBarWidget(color_mapper=mapper, num_ticks=2)
+        ticks = w._get_tick_values()
+        assert len(ticks) == 2
+        assert ticks[0] == 100.0
+        assert ticks[1] == 0.0
+        w.deleteLater()
+
+    def test_three_ticks_correct_spacing(self):
+        mapper = ColorMapper(vmin=0.0, vmax=100.0)
+        w = ColorBarWidget(color_mapper=mapper, num_ticks=3)
+        ticks = w._get_tick_values()
+        assert len(ticks) == 3
+        assert ticks[0] == 100.0
+        assert ticks[1] == 50.0
+        assert ticks[2] == 0.0
+        w.deleteLater()
+
+
+class TestTickLabels:
+    def test_integer_range(self, color_bar):
+        assert color_bar._format_tick_label(75.0) == "75"
+        assert color_bar._format_tick_label(0.0) == "0"
+        assert color_bar._format_tick_label(100.0) == "100"
+
+    def test_fractional_range(self):
+        mapper = ColorMapper(vmin=0.0, vmax=0.5)
+        w = ColorBarWidget(color_mapper=mapper)
+        assert w._format_tick_label(0.25) == "0.2"
+        w.deleteLater()
+
+    def test_boundary_range_exactly_one(self):
+        mapper = ColorMapper(vmin=0.0, vmax=1.0)
+        w = ColorBarWidget(color_mapper=mapper)
+        # range == 1.0, so >= 1.0 condition is met -> integer format
+        assert w._format_tick_label(0.5) == "0"
+        w.deleteLater()
+
+
+class TestUpdateRange:
+    def test_reads_new_values_from_mapper(self, color_bar):
+        color_bar._color_mapper.set_range(0, 200)
+        color_bar.update_range()
+        assert color_bar._vmin == 0
+        assert color_bar._vmax == 200
+
+    def test_update_range_without_mapper_no_crash(self):
+        w = ColorBarWidget(color_mapper=None)
+        w.update_range()
+        w.deleteLater()
+
+
+class TestPaintEdgeCases:
+    def test_no_crash_with_none_mapper(self):
+        w = ColorBarWidget(color_mapper=None)
+        w.resize(60, 200)
+        w.repaint()
+        w.deleteLater()
+
+    def test_no_crash_at_tiny_size(self, color_bar):
+        color_bar.resize(5, 5)
+        color_bar.repaint()

--- a/tests/displays/cavity_display/frontend/heatmap/test_color_mapper.py
+++ b/tests/displays/cavity_display/frontend/heatmap/test_color_mapper.py
@@ -15,10 +15,24 @@ class TestColorMapperInit:
         assert color_mapper.vmin == 0.0
         assert color_mapper.vmax == 100.0
 
-    def test_class_color_constants(self):
-        assert ColorMapper.COLOR_LOW == QColor(0, 0, 255)
-        assert ColorMapper.COLOR_MID == QColor(255, 255, 255)
-        assert ColorMapper.COLOR_HIGH == QColor(255, 0, 0)
+    def test_default_stops_exist(self):
+        stops = ColorMapper.DEFAULT_STOPS
+        assert isinstance(stops, list)
+        assert len(stops) == 6
+        for pos, color in stops:
+            assert isinstance(pos, float)
+            assert isinstance(color, QColor)
+
+    def test_custom_stops(self):
+        stops = [
+            (0.0, QColor(0, 0, 0)),
+            (1.0, QColor(255, 255, 255)),
+        ]
+        mapper = ColorMapper(vmin=0, vmax=100, stops=stops)
+        color = mapper.get_color(50)
+        assert color.red() == 127
+        assert color.green() == 127
+        assert color.blue() == 127
 
 
 class TestSetRange:
@@ -41,89 +55,78 @@ class TestSetRange:
 
 
 class TestColorMapperGradient:
-    def test_color_at_vmin_is_blue(self, color_mapper):
+    def test_color_at_vmin_is_dark_purple(self, color_mapper):
         color = color_mapper.get_color(0)
-        assert color.red() == 0
-        assert color.green() == 0
-        assert color.blue() == 255
+        assert color.red() == 68
+        assert color.green() == 1
+        assert color.blue() == 84
 
-    def test_color_at_vmax_is_red(self, color_mapper):
+    def test_color_at_vmax_is_bright_yellow(self, color_mapper):
         color = color_mapper.get_color(100)
-        assert color.red() == 255
-        assert color.green() == 0
-        assert color.blue() == 0
-
-    def test_color_at_midpoint_is_white(self, color_mapper):
-        # normalized=0.5, takes the <= 0.5 branch with t=1.0 -> white
-        color = color_mapper.get_color(50)
-        assert color.red() == 255
-        assert color.green() == 255
-        assert color.blue() == 255
-
-    def test_color_below_midpoint_exact_values(self, color_mapper):
-        # value=25 on [0,100]: normalized=0.25, t=0.50
-        color = color_mapper.get_color(25)
-        assert color.red() == 127
-        assert color.green() == 127
-        assert color.blue() == 255
-
-    def test_color_above_midpoint_exact_values(self, color_mapper):
-        # value=75 on [0,100]: normalized=0.75, t=0.50
-        color = color_mapper.get_color(75)
-        assert color.red() == 255
-        assert color.green() == 127
-        assert color.blue() == 127
+        assert color.red() == 253
+        assert color.green() == 231
+        assert color.blue() == 37
 
     def test_color_returns_qcolor_instance(self, color_mapper):
         assert isinstance(color_mapper.get_color(50), QColor)
 
-    def test_color_with_negative_range(self):
-        mapper = ColorMapper(vmin=-10.0, vmax=10.0)
-        # midpoint=0.0 should be white
-        color = mapper.get_color(0.0)
-        assert color.red() == 255
-        assert color.green() == 255
-        assert color.blue() == 255
+    def test_color_monotonically_warms(self, color_mapper):
+        """Green channel should monotonically non-decrease from vmin to vmax (viridis)."""
+        prev_green = 0
+        for val in [0, 20, 40, 60, 80, 100]:
+            color = color_mapper.get_color(val)
+            assert color.green() >= prev_green
+            prev_green = color.green()
+
+    def test_color_at_stop_boundary(self, color_mapper):
+        # normalized=0.2 on [0,100] -> value=20 -> blue-purple stop
+        color = color_mapper.get_color(20)
+        assert color.red() == 65
+        assert color.green() == 68
+        assert color.blue() == 135
 
 
 class TestColorMapperEdgeCases:
-    def test_vmin_equals_vmax_returns_blue(self):
+    def test_vmin_equals_vmax_returns_dark_purple(self):
         mapper = ColorMapper(vmin=50.0, vmax=50.0)
         color = mapper.get_color(50)
-        # _normalize returns 0.0, which maps to COLOR_LOW (blue)
-        assert color.red() == 0
-        assert color.blue() == 255
+        # _normalize returns 0.0, which maps to first stop (dark purple)
+        assert color.red() == 68
+        assert color.green() == 1
+        assert color.blue() == 84
 
-    def test_value_below_range_clamps_to_blue(self, color_mapper):
+    def test_value_below_range_clamps_to_dark_purple(self, color_mapper):
         color = color_mapper.get_color(-10)
-        assert color.red() == 0
-        assert color.blue() == 255
+        assert color.red() == 68
+        assert color.green() == 1
+        assert color.blue() == 84
 
-    def test_value_above_range_clamps_to_red(self, color_mapper):
+    def test_value_above_range_clamps_to_yellow(self, color_mapper):
         color = color_mapper.get_color(200)
-        assert color.red() == 255
-        assert color.blue() == 0
+        assert color.red() == 253
+        assert color.green() == 231
+        assert color.blue() == 37
 
-    def test_nan_value_returns_blue(self, color_mapper):
-        # _normalize returns 0.0 for NaN -> maps to COLOR_LOW (blue)
+    def test_nan_value_returns_dark_purple(self, color_mapper):
+        # _normalize returns 0.0 for NaN -> maps to first stop
         color = color_mapper.get_color(float("nan"))
-        assert color.red() == 0
-        assert color.green() == 0
-        assert color.blue() == 255
+        assert color.red() == 68
+        assert color.green() == 1
+        assert color.blue() == 84
 
-    def test_inf_value_returns_blue(self, color_mapper):
-        # _normalize returns 0.0 for inf -> maps to COLOR_LOW (blue)
+    def test_inf_value_returns_dark_purple(self, color_mapper):
+        # _normalize returns 0.0 for inf -> maps to first stop
         color = color_mapper.get_color(float("inf"))
-        assert color.red() == 0
-        assert color.green() == 0
-        assert color.blue() == 255
+        assert color.red() == 68
+        assert color.green() == 1
+        assert color.blue() == 84
 
-    def test_negative_inf_value_returns_blue(self, color_mapper):
-        # _normalize returns 0.0 for -inf -> maps to COLOR_LOW (blue)
+    def test_negative_inf_value_returns_dark_purple(self, color_mapper):
+        # _normalize returns 0.0 for -inf -> maps to first stop
         color = color_mapper.get_color(float("-inf"))
-        assert color.red() == 0
-        assert color.green() == 0
-        assert color.blue() == 255
+        assert color.red() == 68
+        assert color.green() == 1
+        assert color.blue() == 84
 
     def test_set_range_inverted_swaps(self):
         mapper = ColorMapper()
@@ -135,7 +138,44 @@ class TestColorMapperEdgeCases:
         mapper = ColorMapper()
         mapper.set_range(50.0, 0.0)
         # After swap: vmin=0, vmax=50
+        color_low = mapper.get_color(0)
+        assert color_low.red() == 68  # dark purple at low end
+        color_high = mapper.get_color(50)
+        assert color_high.red() == 253  # yellow at high end
+
+
+class TestColorMapperLogScale:
+    def test_log_scale_property(self):
+        mapper = ColorMapper(log_scale=True)
+        assert mapper.log_scale is True
+
+    def test_log_scale_default_false(self):
+        mapper = ColorMapper()
+        assert mapper.log_scale is False
+
+    def test_log_zero_is_dark_purple(self):
+        mapper = ColorMapper(vmin=0, vmax=10000, log_scale=True)
         color = mapper.get_color(0)
-        assert color.blue() == 255  # low end = blue
-        color = mapper.get_color(50)
-        assert color.red() == 255  # high end = red
+        assert color.red() == 68  # dark purple
+
+    def test_log_vmax_is_yellow(self):
+        mapper = ColorMapper(vmin=0, vmax=10000, log_scale=True)
+        color = mapper.get_color(10000)
+        assert color.red() == 253  # bright yellow
+
+    def test_log_spreads_mid_values(self):
+        log_mapper = ColorMapper(vmin=0, vmax=10000, log_scale=True)
+        lin_mapper = ColorMapper(vmin=0, vmax=10000, log_scale=False)
+
+        log_color = log_mapper.get_color(100)
+        lin_color = lin_mapper.get_color(100)
+
+        assert log_color.green() > lin_color.green() + 50
+
+    def test_log_monotonically_warms(self):
+        """Green channel should monotonically non-decrease as values increase."""
+        mapper = ColorMapper(vmin=0, vmax=10000, log_scale=True)
+        values = [0, 1, 10, 100, 1000, 10000]
+        greens = [mapper.get_color(v).green() for v in values]
+        for i in range(len(greens) - 1):
+            assert greens[i] <= greens[i + 1]

--- a/tests/displays/cavity_display/frontend/heatmap/test_fault_data_fetcher.py
+++ b/tests/displays/cavity_display/frontend/heatmap/test_fault_data_fetcher.py
@@ -1,0 +1,307 @@
+from datetime import datetime
+from unittest.mock import Mock
+
+from sc_linac_physics.displays.cavity_display.backend.fault import FaultCounter
+from sc_linac_physics.displays.cavity_display.frontend.heatmap.fault_data_fetcher import (
+    CavityFaultResult,
+    FaultDataFetcher,
+)
+
+from tests.displays.cavity_display.frontend.heatmap.conftest import (
+    make_machine,
+    make_result,
+)
+
+
+class TestCavityFaultResult:
+    def test_successful_result_counts(self):
+        result = make_result(alarm=5, warning=2, invalid=1, ok=100)
+        assert result.alarm_count == 5
+        assert result.warning_count == 2
+        assert result.invalid_count == 1
+        assert result.ok_count == 100
+
+    def test_error_result(self):
+        result = CavityFaultResult(
+            cm_name="01", cavity_num=1, error="Connection timeout"
+        )
+        assert result.is_error is True
+        assert result.error == "Connection timeout"
+
+    def test_is_error_false_when_no_error(self):
+        result = make_result()
+        assert result.is_error is False
+
+    def test_empty_fault_counts_all_zeros(self):
+        result = CavityFaultResult(
+            cm_name="01", cavity_num=1, fault_counts_by_tlc={}
+        )
+        assert result.alarm_count == 0
+        assert result.warning_count == 0
+        assert result.invalid_count == 0
+        assert result.ok_count == 0
+
+    def test_none_fault_counts_all_zeros(self):
+        result = CavityFaultResult(cm_name="01", cavity_num=1)
+        assert result.alarm_count == 0
+        assert result.warning_count == 0
+
+    def test_multiple_tlcs_sum_correctly(self):
+        result = CavityFaultResult(
+            cm_name="01",
+            cavity_num=1,
+            fault_counts_by_tlc={
+                "BCS": FaultCounter(5, 100, 1, 2),
+                "SSA": FaultCounter(3, 50, 2, 4),
+            },
+        )
+        assert result.alarm_count == 8
+        assert result.warning_count == 6
+        assert result.invalid_count == 3
+        assert result.ok_count == 150
+
+    def test_to_fault_counter(self):
+        result = make_result(alarm=5, warning=2, invalid=1, ok=100)
+        counter = result.to_fault_counter()
+        assert isinstance(counter, FaultCounter)
+        assert counter.alarm_count == 5
+        assert counter.warning_count == 2
+        assert counter.invalid_count == 1
+        assert counter.ok_count == 100
+
+
+# -- FaultDataFetcher tests --
+
+
+class TestFaultDataFetcherSignals:
+    def test_progress_emitted_for_each_cavity(self):
+        machine = make_machine(num_cavities=3)
+        fetcher = FaultDataFetcher(machine, datetime.now(), datetime.now())
+
+        spy = Mock()
+        fetcher.progress.connect(spy)
+        fetcher.run()
+
+        assert spy.call_count == 3
+        spy.assert_any_call(1, 3)
+        spy.assert_any_call(2, 3)
+        spy.assert_any_call(3, 3)
+
+    def test_cavity_result_emitted_for_each(self):
+        machine = make_machine(num_cavities=3)
+        fetcher = FaultDataFetcher(machine, datetime.now(), datetime.now())
+
+        spy = Mock()
+        fetcher.cavity_result.connect(spy)
+        fetcher.run()
+
+        assert spy.call_count == 3
+
+    def test_finished_all_emitted_once(self):
+        machine = make_machine(num_cavities=3)
+        fetcher = FaultDataFetcher(machine, datetime.now(), datetime.now())
+
+        spy = Mock()
+        fetcher.finished_all.connect(spy)
+        fetcher.run()
+
+        spy.assert_called_once()
+        results = spy.call_args[0][0]
+        assert len(results) == 3
+
+    def test_fetch_error_on_enumeration_failure(self):
+        machine = Mock()
+        machine.linacs = Mock(side_effect=RuntimeError("Bad machine"))
+
+        fetcher = FaultDataFetcher(machine, datetime.now(), datetime.now())
+        spy = Mock()
+        fetcher.fetch_error.connect(spy)
+        fetcher.run()
+
+        spy.assert_called_once()
+        assert "Failed to enumerate" in spy.call_args[0][0]
+
+    def test_fetch_error_on_empty_machine(self):
+        machine = Mock()
+        linac = Mock()
+        linac.cryomodules = {}
+        machine.linacs = [linac]
+
+        fetcher = FaultDataFetcher(machine, datetime.now(), datetime.now())
+        spy = Mock()
+        fetcher.fetch_error.connect(spy)
+        fetcher.run()
+
+        spy.assert_called_once()
+        assert "No cavities found" in spy.call_args[0][0]
+
+
+class TestFaultDataFetcherAbort:
+    def test_is_abort_requested_initially_false(self):
+        machine = make_machine()
+        fetcher = FaultDataFetcher(machine, datetime.now(), datetime.now())
+        assert fetcher.is_abort_requested is False
+
+    def test_abort_sets_flag(self):
+        machine = make_machine()
+        fetcher = FaultDataFetcher(machine, datetime.now(), datetime.now())
+        fetcher.abort()
+        assert fetcher.is_abort_requested is True
+
+    def test_abort_stops_iteration(self):
+        machine = make_machine(num_cavities=5)
+        fetcher = FaultDataFetcher(machine, datetime.now(), datetime.now())
+
+        call_count = 0
+
+        def abort_after_two(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                fetcher.abort()
+            return {"BCS": FaultCounter(1, 10, 0, 0)}
+
+        for cav in machine.linacs[0].cryomodules["01"].cavities.values():
+            cav.get_fault_counts = abort_after_two
+
+        result_spy = Mock()
+        finished_spy = Mock()
+        fetcher.cavity_result.connect(result_spy)
+        fetcher.finished_all.connect(finished_spy)
+        fetcher.run()
+
+        assert 1 <= result_spy.call_count < 5
+        finished_spy.assert_called_once()
+
+
+class TestFaultDataFetcherErrors:
+    def test_single_cavity_exception_continues(self):
+        machine = make_machine(num_cavities=3)
+        cavities = machine.linacs[0].cryomodules["01"].cavities
+        cavities[2].get_fault_counts = Mock(
+            side_effect=RuntimeError("PV timeout")
+        )
+
+        fetcher = FaultDataFetcher(machine, datetime.now(), datetime.now())
+        finished_spy = Mock()
+        fetcher.finished_all.connect(finished_spy)
+        fetcher.run()
+
+        finished_spy.assert_called_once()
+        results = finished_spy.call_args[0][0]
+        assert len(results) == 3
+
+        error_results = [r for r in results if r.is_error]
+        ok_results = [r for r in results if not r.is_error]
+        assert len(error_results) == 1
+        assert len(ok_results) == 2
+        assert "PV timeout" in error_results[0].error
+
+
+class TestFaultDataFetcherFilter:
+    def test_no_filter_fetches_all(self):
+        machine = make_machine(num_cavities=3)
+        fetcher = FaultDataFetcher(machine, datetime.now(), datetime.now())
+        finished_spy = Mock()
+        fetcher.finished_all.connect(finished_spy)
+        fetcher.run()
+
+        results = finished_spy.call_args[0][0]
+        assert len(results) == 3
+
+    def test_filter_limits_cavities(self):
+        machine = make_machine(num_cavities=5)
+        cavity_filter = {("01", 1), ("01", 3)}
+        fetcher = FaultDataFetcher(
+            machine,
+            datetime.now(),
+            datetime.now(),
+            cavity_filter=cavity_filter,
+        )
+        finished_spy = Mock()
+        fetcher.finished_all.connect(finished_spy)
+        fetcher.run()
+
+        results = finished_spy.call_args[0][0]
+        assert len(results) == 2
+        result_keys = {(r.cm_name, r.cavity_num) for r in results}
+        assert result_keys == {("01", 1), ("01", 3)}
+
+    def test_filter_with_nonexistent_cavity(self):
+        machine = make_machine(num_cavities=3)
+        cavity_filter = {("01", 99)}
+        fetcher = FaultDataFetcher(
+            machine,
+            datetime.now(),
+            datetime.now(),
+            cavity_filter=cavity_filter,
+        )
+        spy = Mock()
+        fetcher.fetch_error.connect(spy)
+        fetcher.run()
+
+        spy.assert_called_once()
+        assert "No cavities found" in spy.call_args[0][0]
+
+    def test_progress_reflects_filtered_total(self):
+        machine = make_machine(num_cavities=5)
+        cavity_filter = {("01", 2), ("01", 4)}
+        fetcher = FaultDataFetcher(
+            machine,
+            datetime.now(),
+            datetime.now(),
+            cavity_filter=cavity_filter,
+        )
+        progress_spy = Mock()
+        fetcher.progress.connect(progress_spy)
+        fetcher.run()
+
+        assert progress_spy.call_count == 2
+        progress_spy.assert_any_call(1, 2)
+        progress_spy.assert_any_call(2, 2)
+
+
+class TestFaultDataFetcherParallel:
+    def test_parallel_fetch_all_results_collected(self):
+        machine = make_machine(num_cavities=8)
+        for cav in machine.linacs[0].cryomodules["01"].cavities.values():
+            cav.get_fault_counts = Mock(
+                return_value={"BCS": FaultCounter(1, 10, 0, 0)}
+            )
+
+        fetcher = FaultDataFetcher(machine, datetime.now(), datetime.now())
+        finished_spy = Mock()
+        fetcher.finished_all.connect(finished_spy)
+        fetcher.run()
+
+        finished_spy.assert_called_once()
+        results = finished_spy.call_args[0][0]
+        assert len(results) == 8
+
+    def test_parallel_mixed_errors_and_successes(self):
+        machine = make_machine(num_cavities=4)
+        cavities = machine.linacs[0].cryomodules["01"].cavities
+        cavities[1].get_fault_counts = Mock(
+            return_value={"BCS": FaultCounter(1, 10, 0, 0)}
+        )
+        cavities[2].get_fault_counts = Mock(
+            side_effect=RuntimeError("PV timeout")
+        )
+        cavities[3].get_fault_counts = Mock(
+            return_value={"SSA": FaultCounter(2, 5, 0, 0)}
+        )
+        cavities[4].get_fault_counts = Mock(
+            side_effect=RuntimeError("Connection refused")
+        )
+
+        fetcher = FaultDataFetcher(machine, datetime.now(), datetime.now())
+        finished_spy = Mock()
+        fetcher.finished_all.connect(finished_spy)
+        fetcher.run()
+
+        results = finished_spy.call_args[0][0]
+        assert len(results) == 4
+        error_results = [r for r in results if r.is_error]
+        ok_results = [r for r in results if not r.is_error]
+        assert len(error_results) == 2
+        assert len(ok_results) == 2

--- a/tests/displays/cavity_display/frontend/heatmap/test_fault_heatmap_display.py
+++ b/tests/displays/cavity_display/frontend/heatmap/test_fault_heatmap_display.py
@@ -1,0 +1,830 @@
+from datetime import datetime, timedelta
+from unittest.mock import Mock, patch
+
+import pytest
+
+from sc_linac_physics.displays.cavity_display.backend.fault import FaultCounter
+from sc_linac_physics.displays.cavity_display.frontend.heatmap.fault_data_fetcher import (
+    CavityFaultResult,
+)
+from sc_linac_physics.displays.cavity_display.frontend.heatmap.fault_heatmap_display import (
+    FaultHeatmapDisplay,
+    HEATMAP_ROWS,
+)
+from tests.displays.cavity_display.frontend.heatmap.conftest import (
+    make_result,
+    make_error_result,
+    make_machine,
+)
+
+
+def _count_expected_cm_widgets():
+    total = 0
+    for row_sections in HEATMAP_ROWS:
+        for _, cm_names in row_sections:
+            total += len(cm_names)
+    return total
+
+
+@pytest.fixture
+def display():
+    disp = FaultHeatmapDisplay()
+    yield disp
+    disp.close()
+
+
+class TestFaultHeatmapDisplayInit:
+    def test_creates_without_crash(self, display):
+        assert display is not None
+
+    def test_correct_number_of_cm_widgets(self, display):
+        expected = _count_expected_cm_widgets()
+        assert len(display._cm_widgets) == expected
+
+    def test_initial_button_states(self, display):
+        assert display._refresh_btn.isEnabled()
+        assert not display._abort_btn.isEnabled()
+        assert not display._fetch_selected_btn.isEnabled()
+        assert not display._clear_selection_btn.isEnabled()
+
+    def test_filter_checkboxes_default_on(self, display):
+        assert display._cb_alarms.isChecked()
+        assert display._cb_warnings.isChecked()
+        assert display._cb_invalid.isChecked()
+
+    def test_window_title(self, display):
+        assert display.windowTitle() == "LCLS-II Fault Heatmap"
+
+    def test_progress_bar_initial_state(self, display):
+        assert display._progress_bar.value() == 0
+
+
+class TestTimeRange:
+    def test_default_range_is_one_hour(self, display):
+        """Spec §4.3: default range = last 1 hour."""
+        start = display._start_dt.dateTime().toPyDateTime()
+        end = display._end_dt.dateTime().toPyDateTime()
+        diff = end - start
+        assert abs(diff.total_seconds() - 3600) < 5
+
+    def test_set_quick_range_30min(self, display):
+        display._set_quick_range(minutes=30)
+        start = display._start_dt.dateTime().toPyDateTime()
+        end = display._end_dt.dateTime().toPyDateTime()
+        diff = end - start
+        assert abs(diff.total_seconds() - 1800) < 5
+
+    def test_set_quick_range_24hours(self, display):
+        display._set_quick_range(hours=24)
+        start = display._start_dt.dateTime().toPyDateTime()
+        end = display._end_dt.dateTime().toPyDateTime()
+        diff = end - start
+        assert abs(diff.total_seconds() - 86400) < 5
+
+    def test_set_quick_range_1_week(self, display):
+        display._set_quick_range(days=7)
+        start = display._start_dt.dateTime().toPyDateTime()
+        end = display._end_dt.dateTime().toPyDateTime()
+        diff = end - start
+        assert abs(diff.total_seconds() - 7 * 86400) < 5
+
+    def test_get_time_range_returns_datetimes(self, display):
+        start, end = display._get_time_range()
+        assert isinstance(start, datetime)
+        assert isinstance(end, datetime)
+        assert start < end
+
+    def test_get_time_range_raises_on_invalid(self, display):
+        now = datetime.now()
+        display._start_dt.setDateTime(now)
+        display._end_dt.setDateTime(now - timedelta(hours=1))
+        with pytest.raises(
+            ValueError, match="Start time must be before end time"
+        ):
+            display._get_time_range()
+
+
+class TestFilterChanged:
+    def test_filter_with_no_results_no_crash(self, display):
+        display._cb_alarms.setChecked(False)
+
+    def test_filter_change_recalculates(self, display):
+        results = [
+            make_result(
+                cm_name="01", cavity_num=1, alarm=10, warning=5, invalid=3
+            )
+        ]
+        display._results = results
+        display._apply_results_to_heatmap(results)
+
+        initial_count = display._get_filtered_count(results[0])
+        assert initial_count == 18
+
+        display._cb_warnings.setChecked(False)
+        new_count = display._get_filtered_count(results[0])
+        assert new_count == 13
+
+
+class TestFetchLifecycle:
+    @patch(
+        "sc_linac_physics.displays.cavity_display.frontend.heatmap"
+        ".fault_heatmap_display.QMessageBox"
+    )
+    def test_refresh_without_machine_shows_dialog(self, mock_msgbox, display):
+        display._on_refresh_clicked()
+        mock_msgbox.information.assert_called_once()
+
+    @patch(
+        "sc_linac_physics.displays.cavity_display.frontend.heatmap"
+        ".fault_heatmap_display.QMessageBox"
+    )
+    def test_refresh_with_invalid_time_range_shows_warning(
+        self, mock_msgbox, display
+    ):
+        now = datetime.now()
+        display._start_dt.setDateTime(now)
+        display._end_dt.setDateTime(now - timedelta(hours=1))
+        display._on_refresh_clicked()
+        mock_msgbox.warning.assert_called_once()
+
+    def test_on_fetch_progress_updates_bar(self, display):
+        display._on_fetch_progress(5, 16)
+        assert display._progress_bar.value() == 5
+        assert display._progress_bar.maximum() == 16
+
+    def test_on_fetch_error_shows_message(self, display):
+        display._on_fetch_error("Network timeout")
+        assert "Network timeout" in display._status_label.text()
+        assert display._refresh_btn.isEnabled()
+        assert not display._abort_btn.isEnabled()
+
+    def test_on_fetch_error_resets_progress_bar(self, display):
+        display._progress_bar.setValue(5)
+        display._on_fetch_error("Error")
+        assert display._progress_bar.value() == 0
+
+    def test_set_idle_state(self, display):
+        display._refresh_btn.setEnabled(False)
+        display._abort_btn.setEnabled(True)
+        display._start_dt.setEnabled(False)
+        display._end_dt.setEnabled(False)
+        display._fetcher = Mock()
+
+        display._set_idle_state()
+
+        assert display._refresh_btn.isEnabled()
+        assert not display._abort_btn.isEnabled()
+        assert display._start_dt.isEnabled()
+        assert display._end_dt.isEnabled()
+        assert display._fetcher is None
+
+    def test_on_abort_clicked(self, display):
+        mock_fetcher = Mock()
+        display._fetcher = mock_fetcher
+
+        display._on_abort_clicked()
+
+        mock_fetcher.abort.assert_called_once()
+        assert not display._abort_btn.isEnabled()
+        assert "Aborting" in display._status_label.text()
+
+    def test_refresh_while_fetcher_running_is_noop(self, display):
+        mock_fetcher = Mock()
+        mock_fetcher.isRunning.return_value = True
+        display._fetcher = mock_fetcher
+
+        display._on_refresh_clicked()
+
+        # Should return early without creating a new fetcher
+        assert display._fetcher is mock_fetcher
+
+    def test_on_cavity_result_error_sets_error_state(self, display):
+        error_result = make_error_result(
+            cm_name="01", cavity_num=1, error="PV timeout"
+        )
+        display._on_cavity_result(error_result)
+        widget = display._cm_widgets.get("01")
+        if widget:
+            assert "PV timeout" in widget.cavity_widgets[1].toolTip()
+
+    def test_on_cavity_result_success_shows_pending(self, display):
+        ok_result = make_result(cm_name="01", cavity_num=1, alarm=5)
+        display._on_cavity_result(ok_result)
+        widget = display._cm_widgets.get("01")
+        if widget:
+            assert "Data received" in widget.cavity_widgets[1].toolTip()
+
+    def test_on_cavity_result_unknown_cm_no_crash(self, display):
+        result = make_result(cm_name="ZZNONEXISTENT", cavity_num=1)
+        display._on_cavity_result(result)
+
+
+class TestOnFetchFinished:
+    def test_with_valid_results(self, display):
+        results = [
+            make_result(
+                cm_name="01", cavity_num=1, alarm=10, warning=0, invalid=0
+            ),
+            make_result(
+                cm_name="01", cavity_num=2, alarm=0, warning=0, invalid=0
+            ),
+        ]
+        display._fetcher = Mock()
+        display._fetcher.is_abort_requested = False
+
+        display._on_fetch_finished(results)
+
+        status = display._status_label.text()
+        assert "faulted" in status
+        assert "OK" in status
+        assert "Max:" in status
+        assert display._refresh_btn.isEnabled()
+
+    def test_all_errors(self, display):
+        results = [
+            make_error_result(cm_name="01", cavity_num=1),
+            make_error_result(cm_name="01", cavity_num=2),
+        ]
+        display._fetcher = Mock()
+        display._fetcher.is_abort_requested = False
+
+        display._on_fetch_finished(results)
+
+        status = display._status_label.text()
+        assert "0 cavities loaded" in status
+        assert "2 errors" in status
+
+    def test_mixed_valid_and_errors_shows_error_count(self, display):
+        results = [
+            make_result(
+                cm_name="01", cavity_num=1, alarm=10, warning=0, invalid=0
+            ),
+            make_error_result(cm_name="01", cavity_num=2),
+        ]
+        display._fetcher = Mock()
+        display._fetcher.is_abort_requested = False
+
+        display._on_fetch_finished(results)
+
+        status = display._status_label.text()
+        assert "1 errors" in status or "1 error" in status
+        assert "faulted" in status
+
+    def test_aborted_shows_in_status(self, display):
+        results = [make_result(cm_name="01", cavity_num=1)]
+        display._fetcher = Mock()
+        display._fetcher.is_abort_requested = True
+
+        display._on_fetch_finished(results)
+
+        assert "(aborted)" in display._status_label.text()
+
+    def test_status_includes_timestamp(self, display):
+        results = [make_result(cm_name="01", cavity_num=1)]
+        display._fetcher = Mock()
+        display._fetcher.is_abort_requested = False
+
+        display._on_fetch_finished(results)
+
+        assert "Updated" in display._status_label.text()
+
+
+class TestApplyResults:
+    def test_normal_results_color_mapped(self, display):
+        results = [
+            make_result(cm_name="01", cavity_num=1, alarm=10),
+            make_result(cm_name="01", cavity_num=2, alarm=5),
+        ]
+        display._apply_results_to_heatmap(results)
+        assert display._color_mapper.vmax > 0
+
+    def test_all_zero_counts_vmax_set_to_one(self, display):
+        results = [
+            make_result(
+                cm_name="01", cavity_num=1, alarm=0, warning=0, invalid=0
+            ),
+        ]
+        display._apply_results_to_heatmap(results)
+        assert display._color_mapper.vmax == 1
+
+    def test_all_errors_returns_early(self, display):
+        results = [make_error_result(cm_name="01", cavity_num=1)]
+        display._apply_results_to_heatmap(results)
+
+    def test_highlight_threshold_applied(self, display):
+        # vmax=100, threshold = ceil(0.75 * 100) = 75
+        # alarm=100 >= 75 AND > 0 -> highlight=True
+        # alarm=10 < 75 -> highlight=False
+        results = [
+            make_result(
+                cm_name="01", cavity_num=1, alarm=100, warning=0, invalid=0
+            ),
+            make_result(
+                cm_name="01", cavity_num=2, alarm=10, warning=0, invalid=0
+            ),
+        ]
+        display._apply_results_to_heatmap(results)
+
+        cav1 = display._cm_widgets["01"].cavity_widgets[1]
+        cav2 = display._cm_widgets["01"].cavity_widgets[2]
+        assert cav1._highlight is True
+        assert cav2._highlight is False
+
+    def test_highlight_threshold_ceil_boundary(self, display):
+        """Verify ceil prevents false positives: vmax=3, ceil(0.75*3)=3."""
+        results = [
+            make_result(
+                cm_name="01", cavity_num=1, alarm=3, warning=0, invalid=0
+            ),
+            make_result(
+                cm_name="01", cavity_num=2, alarm=2, warning=0, invalid=0
+            ),
+        ]
+        display._apply_results_to_heatmap(results)
+
+        cav1 = display._cm_widgets["01"].cavity_widgets[1]
+        cav2 = display._cm_widgets["01"].cavity_widgets[2]
+        # ceil(0.75 * 3) = ceil(2.25) = 3; only 3 >= 3
+        assert cav1._highlight is True
+        assert cav2._highlight is False
+
+    def test_error_result_mixed_with_valid(self, display):
+        results = [
+            make_result(cm_name="01", cavity_num=1, alarm=10),
+            make_error_result(cm_name="01", cavity_num=2),
+        ]
+        display._apply_results_to_heatmap(results)
+        tooltip = display._cm_widgets["01"].cavity_widgets[2].toolTip()
+        assert "PV timeout" in tooltip or "Error" in tooltip
+
+    def test_unknown_cm_name_skipped_gracefully(self, display):
+        """Result for a CM not in the display layout is silently skipped."""
+        results = [
+            make_result(cm_name="01", cavity_num=1, alarm=10),
+            make_result(cm_name="ZZNONEXISTENT", cavity_num=1, alarm=5),
+        ]
+        display._apply_results_to_heatmap(results)
+
+
+class TestBuildTooltip:
+    def test_tooltip_contains_all_info(self, display):
+        result = make_result(
+            cm_name="01", cavity_num=3, alarm=10, warning=5, invalid=2
+        )
+        tooltip = display._build_tooltip(result, filtered_count=17)
+        assert "CM01" in tooltip
+        assert "Cavity 3" in tooltip
+        assert "10" in tooltip
+        assert "5" in tooltip
+        assert "2" in tooltip
+        assert "17" in tooltip
+
+    def test_tooltip_includes_total(self, display):
+        """Spec §4.6: tooltip shows total = alarm + warning + invalid."""
+        result = make_result(
+            cm_name="01", cavity_num=1, alarm=10, warning=5, invalid=3
+        )
+        tooltip = display._build_tooltip(result, filtered_count=18)
+        assert "Total:    18" in tooltip
+
+    def test_tooltip_with_hl_name(self, display):
+        result = make_result(
+            cm_name="H1", cavity_num=5, alarm=3, warning=1, invalid=0
+        )
+        tooltip = display._build_tooltip(result, filtered_count=4)
+        assert "H1" in tooltip
+        assert "Cavity 5" in tooltip
+
+
+class TestSelectionState:
+    def test_initial_selection_empty(self, display):
+        assert len(display._selection) == 0
+
+    def test_cavity_click_adds_to_selection(self, display):
+        display._on_cavity_clicked("01", 3)
+        assert ("01", 3) in display._selection
+
+    def test_cavity_click_toggle_removes(self, display):
+        display._on_cavity_clicked("01", 3)
+        display._on_cavity_clicked("01", 3)
+        assert ("01", 3) not in display._selection
+
+    def test_cavity_click_updates_widget_selected(self, display):
+        display._on_cavity_clicked("01", 3)
+        assert display._cm_widgets["01"].cavity_widgets[3].selected is True
+
+    def test_cavity_click_toggle_updates_widget_deselected(self, display):
+        display._on_cavity_clicked("01", 3)
+        display._on_cavity_clicked("01", 3)
+        assert display._cm_widgets["01"].cavity_widgets[3].selected is False
+
+    def test_multiple_cavities_selectable(self, display):
+        display._on_cavity_clicked("01", 1)
+        display._on_cavity_clicked("01", 5)
+        assert ("01", 1) in display._selection
+        assert ("01", 5) in display._selection
+        assert len(display._selection) == 2
+
+    def test_fetch_selected_btn_enabled_after_selection(self, display):
+        display._on_cavity_clicked("01", 1)
+        assert display._fetch_selected_btn.isEnabled()
+
+    def test_fetch_selected_btn_disabled_after_deselect(self, display):
+        display._on_cavity_clicked("01", 1)
+        display._on_cavity_clicked("01", 1)
+        assert not display._fetch_selected_btn.isEnabled()
+
+    def test_clear_selection_btn_enabled_after_selection(self, display):
+        display._on_cavity_clicked("01", 1)
+        assert display._clear_selection_btn.isEnabled()
+
+    def test_clear_selection_btn_disabled_initially(self, display):
+        assert not display._clear_selection_btn.isEnabled()
+
+    def test_status_label_shows_selection_count(self, display):
+        display._on_cavity_clicked("01", 1)
+        assert "1 cavity selected" in display._selection_label.text()
+
+    def test_status_label_plural_selection(self, display):
+        display._on_cavity_clicked("01", 1)
+        display._on_cavity_clicked("01", 2)
+        assert "2 cavities selected" in display._selection_label.text()
+
+    def test_clear_selection_resets_all(self, display):
+        display._on_cavity_clicked("01", 1)
+        display._on_cavity_clicked("01", 3)
+        display._clear_selection()
+        assert len(display._selection) == 0
+        assert not display._fetch_selected_btn.isEnabled()
+        assert not display._clear_selection_btn.isEnabled()
+
+    def test_clear_selection_deselects_widgets(self, display):
+        display._on_cavity_clicked("01", 1)
+        display._clear_selection()
+        assert display._cm_widgets["01"].cavity_widgets[1].selected is False
+
+
+class TestCMLabel:
+    def test_cm_label_click_selects_all_eight(self, display):
+        display._on_cm_label_clicked("01")
+        assert len(display._selection) == 8
+        for cav_num in range(1, 9):
+            assert ("01", cav_num) in display._selection
+
+    def test_cm_label_click_all_selected_deselects(self, display):
+        display._on_cm_label_clicked("01")
+        display._on_cm_label_clicked("01")
+        for cav_num in range(1, 9):
+            assert ("01", cav_num) not in display._selection
+
+    def test_cm_label_partial_selection_selects_all(self, display):
+        display._on_cavity_clicked("01", 1)
+        display._on_cavity_clicked("01", 3)
+        display._on_cm_label_clicked("01")
+        # Should select all 8 since not all were selected
+        for cav_num in range(1, 9):
+            assert ("01", cav_num) in display._selection
+
+    def test_cm_label_updates_widgets(self, display):
+        display._on_cm_label_clicked("01")
+        for cav_num in range(1, 9):
+            assert (
+                display._cm_widgets["01"].cavity_widgets[cav_num].selected
+                is True
+            )
+
+    def test_cm_label_unknown_cm_no_crash(self, display):
+        display._on_cm_label_clicked("ZZNONEXISTENT")
+
+
+class TestFetchSelected:
+    @patch(
+        "sc_linac_physics.displays.cavity_display.frontend.heatmap"
+        ".fault_heatmap_display.QMessageBox"
+    )
+    def test_fetch_selected_without_machine_shows_dialog(
+        self, mock_msgbox, display
+    ):
+        display._on_cavity_clicked("01", 1)
+        display._on_fetch_selected_clicked()
+        mock_msgbox.information.assert_called_once()
+
+    def test_fetch_selected_with_no_selection_is_noop(self, display):
+        display._on_fetch_selected_clicked()
+        # Should not crash or change state
+        assert display._fetcher is None
+
+    def test_fetch_selected_while_fetcher_running_is_noop(self, display):
+        display._on_cavity_clicked("01", 1)
+        mock_fetcher = Mock()
+        mock_fetcher.isRunning.return_value = True
+        display._fetcher = mock_fetcher
+        display._on_fetch_selected_clicked()
+        assert display._fetcher is mock_fetcher
+
+    def test_result_merging_replaces_matching(self, display):
+        """New fetch results for same (cm, cav) replace old ones."""
+        old_result = make_result(cm_name="01", cavity_num=1, alarm=5)
+        display._results = [old_result]
+
+        new_results = [
+            make_result(cm_name="01", cavity_num=1, alarm=20),
+        ]
+        display._fetcher = Mock()
+        display._fetcher.is_abort_requested = False
+        display._on_fetch_finished(new_results)
+
+        assert len(display._results) == 1
+        assert display._results[0].alarm_count == 20
+
+    def test_result_merging_preserves_existing(self, display):
+        """Existing results for non-fetched cavities are kept."""
+        existing = make_result(cm_name="01", cavity_num=1, alarm=5)
+        display._results = [existing]
+
+        new_results = [
+            make_result(cm_name="01", cavity_num=2, alarm=10),
+        ]
+        display._fetcher = Mock()
+        display._fetcher.is_abort_requested = False
+        display._on_fetch_finished(new_results)
+
+        assert len(display._results) == 2
+        keys = {(r.cm_name, r.cavity_num) for r in display._results}
+        assert keys == {("01", 1), ("01", 2)}
+
+    @patch(
+        "sc_linac_physics.displays.cavity_display.frontend.heatmap"
+        ".fault_heatmap_display.QMessageBox"
+    )
+    def test_load_all_clears_selection(self, mock_msgbox, display):
+        """Load Faults clears the selection set before starting."""
+        display._on_cavity_clicked("01", 1)
+        display._on_cavity_clicked("01", 3)
+        assert len(display._selection) == 2
+
+        # _on_refresh_clicked clears selection (but won't start fetch without a machine)
+        display._on_refresh_clicked()
+        assert len(display._selection) == 0
+
+    def test_partial_clear_only_clears_filtered_cavities(self, display):
+        """start_fetch with filter only clears the filtered widgets."""
+        r1 = make_result(cm_name="01", cavity_num=1, alarm=10)
+        r2 = make_result(cm_name="01", cavity_num=2, alarm=20)
+        display._results = [r1, r2]
+        display._apply_results_to_heatmap([r1, r2])
+
+        # Verify cav 2 has data before partial clear
+        assert (
+            display._cm_widgets["01"].cavity_widgets[2]._fault_count is not None
+        )
+
+        # Simulate a partial clear for cavity 1 only
+        cavity_filter = {("01", 1)}
+        display._results = [
+            r
+            for r in display._results
+            if (r.cm_name, r.cavity_num) not in cavity_filter
+        ]
+        for cm_name, cav_num in cavity_filter:
+            cm_w = display._cm_widgets.get(cm_name)
+            if cm_w:
+                cav_w = cm_w.cavity_widgets.get(cav_num)
+                if cav_w:
+                    cav_w.clear()
+
+        # Cavity 1 was cleared
+        assert display._cm_widgets["01"].cavity_widgets[1]._fault_count is None
+        # Cavity 2 was NOT cleared
+        assert (
+            display._cm_widgets["01"].cavity_widgets[2]._fault_count is not None
+        )
+        # Results list only has cavity 2
+        assert len(display._results) == 1
+        assert display._results[0].cavity_num == 2
+
+
+class TestCleanup:
+    def test_close_with_no_fetcher(self, display):
+        display.close()
+
+    def test_close_with_running_fetcher_graceful(self, display):
+        mock_fetcher = Mock()
+        mock_fetcher.isRunning.return_value = True
+        mock_fetcher.wait.return_value = True  # graceful stop
+        display._fetcher = mock_fetcher
+
+        display.close()
+
+        mock_fetcher.abort.assert_called_once()
+        mock_fetcher.wait.assert_called_once()
+        mock_fetcher.terminate.assert_not_called()
+
+    def test_close_with_running_fetcher_force_terminate(self, display):
+        mock_fetcher = Mock()
+        mock_fetcher.isRunning.return_value = True
+        mock_fetcher.wait.return_value = False  # timed out
+        display._fetcher = mock_fetcher
+
+        display.close()
+
+        mock_fetcher.abort.assert_called_once()
+        mock_fetcher.terminate.assert_called_once()
+        assert mock_fetcher.wait.call_count == 2
+
+
+class TestDoubleClick:
+    def test_double_click_without_machine_no_crash(self, display):
+        display._on_cavity_double_clicked("01", 1)
+
+    def test_double_click_calls_show_fault_display(self, display):
+        machine = make_machine(num_cavities=3)
+        cavity = machine.linacs[0].cryomodules["01"].cavities[1]
+        cavity.show_fault_display = Mock()
+        display._machine = machine
+        display._on_cavity_double_clicked("01", 1)
+        cavity.show_fault_display.assert_called_once()
+
+    def test_double_click_unknown_cm_no_crash(self, display):
+        machine = make_machine(num_cavities=3)
+        display._machine = machine
+        display._on_cavity_double_clicked("NONEXISTENT", 1)
+
+
+def _make_multi_tlc_result(
+    cm_name: str = "01",
+    cavity_num: int = 1,
+    tlc_counts: dict = None,
+) -> CavityFaultResult:
+    """Create a CavityFaultResult with multiple TLC entries.
+
+    Args:
+        tlc_counts: dict mapping TLC code -> (alarm, warning, invalid, ok)
+    """
+    if tlc_counts is None:
+        tlc_counts = {"PZT": (5, 0, 0, 100), "QPT": (3, 1, 0, 200)}
+    fault_counts_by_tlc = {}
+    for tlc, (alarm, warning, invalid, ok) in tlc_counts.items():
+        fault_counts_by_tlc[tlc] = FaultCounter(alarm, ok, invalid, warning)
+    return CavityFaultResult(
+        cm_name=cm_name,
+        cavity_num=cavity_num,
+        fault_counts_by_tlc=fault_counts_by_tlc,
+    )
+
+
+class TestLinacSummaryBar:
+    def test_section_labels_created(self, display):
+        expected_sections = set()
+        for row_sections in HEATMAP_ROWS:
+            for section_name, _ in row_sections:
+                expected_sections.add(section_name)
+        assert set(display._section_labels.keys()) == expected_sections
+
+    def test_initial_labels_show_dash(self, display):
+        for label in display._section_labels.values():
+            assert "\u2014" in label.text()  # em-dash
+
+    def test_summary_updates_after_apply(self, display):
+        results = [
+            make_result(cm_name="01", cavity_num=1, alarm=10),
+            make_result(cm_name="01", cavity_num=2, alarm=5),
+        ]
+        display._results = results
+        display._apply_results_to_heatmap(results)
+        assert "L0B: 15" in display._section_labels["L0B"].text()
+
+    def test_summary_ignores_errors(self, display):
+        results = [
+            make_result(cm_name="01", cavity_num=1, alarm=10),
+            make_error_result(cm_name="01", cavity_num=2),
+        ]
+        display._results = results
+        display._apply_results_to_heatmap(results)
+        assert "L0B: 10" in display._section_labels["L0B"].text()
+
+    def test_summary_zero_for_section_with_no_results(self, display):
+        results = [
+            make_result(cm_name="01", cavity_num=1, alarm=5),
+        ]
+        display._results = results
+        display._apply_results_to_heatmap(results)
+        assert "L3B: 0" in display._section_labels["L3B"].text()
+
+
+class TestTLCCombo:
+    def test_combo_exists_with_default(self, display):
+        assert display._tlc_combo.currentText() == "All Fault Types"
+
+    def test_combo_has_one_item_initially(self, display):
+        assert display._tlc_combo.count() == 1
+
+    def test_populate_tlc_combo(self, display):
+        display._results = [
+            _make_multi_tlc_result(
+                cm_name="01",
+                cavity_num=1,
+                tlc_counts={
+                    "PZT": (5, 0, 0, 100),
+                    "QPT": (3, 0, 0, 200),
+                    "MGT": (1, 0, 0, 50),
+                },
+            )
+        ]
+        display._populate_tlc_combo()
+        items = [
+            display._tlc_combo.itemText(i)
+            for i in range(display._tlc_combo.count())
+        ]
+        assert items == ["All Fault Types", "MGT", "PZT", "QPT"]
+
+    def test_populate_preserves_selection(self, display):
+        display._results = [
+            _make_multi_tlc_result(
+                tlc_counts={"PZT": (5, 0, 0, 0), "QPT": (3, 0, 0, 0)}
+            )
+        ]
+        display._populate_tlc_combo()
+        display._tlc_combo.setCurrentText("PZT")
+
+        display._populate_tlc_combo()
+        assert display._tlc_combo.currentText() == "PZT"
+
+    def test_populate_resets_to_all_if_removed(self, display):
+        display._results = [
+            _make_multi_tlc_result(
+                tlc_counts={"PZT": (5, 0, 0, 0), "QPT": (3, 0, 0, 0)}
+            )
+        ]
+        display._populate_tlc_combo()
+        display._tlc_combo.setCurrentText("QPT")
+
+        # Rebuild without QPT
+        display._results = [
+            _make_multi_tlc_result(tlc_counts={"PZT": (5, 0, 0, 0)})
+        ]
+        display._populate_tlc_combo()
+        assert display._tlc_combo.currentText() == "All Fault Types"
+
+    def test_get_selected_tlc_default(self, display):
+        assert display._get_selected_tlc() is None
+
+    def test_get_selected_tlc_specific(self, display):
+        display._results = [
+            _make_multi_tlc_result(
+                tlc_counts={"PZT": (5, 0, 0, 0), "QPT": (3, 0, 0, 0)}
+            )
+        ]
+        display._populate_tlc_combo()
+        display._tlc_combo.setCurrentText("PZT")
+        assert display._get_selected_tlc() == "PZT"
+
+    def test_get_filtered_count_all_tlcs(self, display):
+        result = _make_multi_tlc_result(
+            tlc_counts={
+                "PZT": (5, 0, 0, 100),
+                "QPT": (3, 1, 0, 200),
+            }
+        )
+        count = display._get_filtered_count(result)
+        assert count == 5 + 3 + 1  # alarm + alarm + warning = 9
+
+    def test_get_filtered_count_specific_tlc(self, display):
+        result = _make_multi_tlc_result(
+            tlc_counts={
+                "PZT": (5, 0, 0, 100),
+                "QPT": (3, 1, 0, 200),
+            }
+        )
+        display._results = [result]
+        display._populate_tlc_combo()
+        display._tlc_combo.setCurrentText("PZT")
+        count = display._get_filtered_count(result)
+        assert count == 5  # only PZT alarms
+
+    def test_get_filtered_count_missing_tlc(self, display):
+        result = _make_multi_tlc_result(tlc_counts={"PZT": (5, 0, 0, 100)})
+        # Manually add a TLC that doesn't exist in results
+        display._tlc_combo.addItem("XYZ")
+        display._tlc_combo.setCurrentText("XYZ")
+        count = display._get_filtered_count(result)
+        assert count == 0
+
+    def test_tlc_filter_updates_heatmap(self, display):
+        """Selecting a specific TLC re-colors the heatmap."""
+        result = _make_multi_tlc_result(
+            cm_name="01",
+            cavity_num=1,
+            tlc_counts={
+                "PZT": (10, 0, 0, 100),
+                "QPT": (2, 0, 0, 200),
+            },
+        )
+        display._results = [result]
+        display._populate_tlc_combo()
+
+        display._apply_results_to_heatmap(display._results)
+        assert display._cm_widgets["01"]._cavity_counts[1] == 12
+
+        display._tlc_combo.setCurrentText("PZT")
+        assert display._cm_widgets["01"]._cavity_counts[1] == 10

--- a/tests/displays/cavity_display/frontend/heatmap/test_heatmap_cm_widget.py
+++ b/tests/displays/cavity_display/frontend/heatmap/test_heatmap_cm_widget.py
@@ -111,6 +111,10 @@ class TestClickableCMLabel:
     def test_label_has_pointing_hand_cursor(self, cm_widget):
         assert cm_widget._label.cursor().shape() == Qt.PointingHandCursor
 
+    def test_label_has_select_all_tooltip(self, cm_widget):
+        assert "select" in cm_widget._label.toolTip().lower()
+        assert "deselect" in cm_widget._label.toolTip().lower()
+
 
 class TestSelectionMethods:
     def test_set_cavity_selected(self, cm_widget):


### PR DESCRIPTION
Added a new PyDM display that shows fault activity across all LCLS cavities as a color coded grid. Now users can pick a time range, fetch fault counts from the archiver, and see at a glance which cavities are faulting.

## What it does

- Grid layout matching the linac: L0B, L1B, L2B, L3B, L4B, with each cryomodule as a column of 8 cavities
- Time range picker with quick buttons (30m, 1h, 4h, 24h, 1w)
- Filter by severity (alarms, warnings, invalid) and by TLC fault type
- Click cavities or CM labels to build a selection
- Per CM select all button next to the label, plus per section select all buttons
- Per CM status bar (green/orange/red) for quick scanning
- Color bar legend with log scale support
- Progress bar and abort button during fetches

## Other changes

- Swapped the color palette in `color_mapper.py` to viridis so the heatmap is colorblind safe
- Added a small select all button next to each CM label for discoverability 
- Bumped `FaultDataFetcher.MAX_WORKERS` from 2 to 8 so fetches run faster

## Tests

Added tests for the new files and everything is passing.
## Screenshots
Empty state:
![Image 4-8-26 at 5 50 PM](https://github.com/user-attachments/assets/37f37dac-4b80-459a-9dd0-906d3869135a)
With L2B fault data loaded (June 2 2025, 30 minute window):
![Image 4-8-26 at 5 49 PM](https://github.com/user-attachments/assets/04db2457-ac2e-458f-8bc0-6f43bd909c09)
