### PR TITLE
docs: add codebase documentation for onboarding 

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,103 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Run all tests (headless Qt required)
+QT_QPA_PLATFORM=offscreen pytest
+
+# Run a single test file
+QT_QPA_PLATFORM=offscreen pytest tests/test_cli.py -v
+
+# Run with coverage report (80% minimum enforced in CI)
+QT_QPA_PLATFORM=offscreen pytest --cov=sc_linac_physics --cov-report=term-missing
+
+# Lint
+flake8 . --count --max-complexity=10 --max-line-length=120 --show-source --statistics
+black --check .
+
+# Format
+black .
+
+# Install for development
+pip install -e ".[dev,test]"
+```
+
+Set `PYDM_DEFAULT_PROTOCOL=fake` to run UI code without live EPICS hardware.
+
+## Documentation
+
+Full documentation lives in [`docs/`](docs/index.md):
+- [`docs/utils/linac_model.md`](docs/utils/linac_model.md) — hardware model, PV naming, all constants
+- [`docs/utils/shared_utilities.md`](docs/utils/shared_utilities.md) — EPICS `PV`/`PVBatch`, logger, Qt helpers
+- [`docs/applications/auto_setup.md`](docs/applications/auto_setup.md) — automated cavity turn-on
+- [`docs/applications/rf_commissioning.md`](docs/applications/rf_commissioning.md) — phase-gated acceptance workflow
+- [`docs/applications/q0.md`](docs/applications/q0.md), [`microphonics.md`](docs/applications/microphonics.md), [`quench_processing.md`](docs/applications/quench_processing.md), [`tuning.md`](docs/applications/tuning.md)
+- [`docs/displays/cavity_display.md`](docs/displays/cavity_display.md), [`srf_home.md`](docs/displays/srf_home.md)
+
+See also `AGENTS.md` at the repo root for architectural conventions enforced across the codebase.
+
+## Architecture
+
+This package provides controls, displays, and analysis tools for the SLAC SC Linac (superconducting RF linac). It is built on PyDM/PyQt5 and uses EPICS (via caproto/pyepics) for hardware communication.
+
+```
+src/sc_linac_physics/
+├── applications/       # Major standalone applications
+├── displays/           # PyDM-based operator displays
+├── cli/                # Unified launcher CLI (sc-linac entry point)
+└── utils/              # Shared infrastructure (EPICS, Qt, logging, linac model)
+```
+
+### Linac Hardware Model (`utils/sc_linac/`)
+
+The full hierarchy is `Machine → Linac → Cryomodule → Rack → Cavity` (+ `SSA`, `StepperTuner`, `Piezo` per cavity). `linac_utils.py` defines cryomodule groupings (L0B–L4B), all EPICS PV naming conventions, and hardware constants. All applications build a module-level `Machine` subclass singleton (e.g., `SETUP_MACHINE`) at import time.
+
+### EPICS Integration (`utils/epics/`)
+
+Use `PV` (never raw `pyepics.PV`) — it adds retry/backoff, typed exceptions, and never returns `None`. For bulk reads across many cavities, use `PVBatch.get_values()`. PV objects are always lazily instantiated on first property access to avoid connecting to hardware at import time.
+
+Platform-aware paths (log dirs, database dirs) live in `utils/platform_paths.py`.
+
+### Displays (`displays/`)
+
+All displays inherit from `pydm.Display`. They are launched either from `.ui` files or as Python classes. The `@display` decorator in `cli/launchers.py` registers them for the unified CLI and handles standalone vs. embedded modes.
+
+### Applications (`applications/`)
+
+Each major application follows a three-layer pattern:
+- `backend/` — business logic and EPICS communication, no Qt dependency
+- `frontend/` — PyQt5 widgets
+- `launcher/` — CLI entry point(s)
+
+### Hierarchical Setup (`applications/auto_setup/`)
+
+`SetupMachine` → `SetupLinac` → `SetupCryomodule` → `SetupCavity` mirrors the physical hierarchy. CLI commands at each level (`sc-setup-all`, `sc-setup-linac`, `sc-setup-cm`, `sc-setup-cav`) map to corresponding backend classes. Request flags (SSA cal, auto-tune, characterization, RF ramp) are EPICS PVs set by GUI/CLI before triggering start.
+
+### RF Commissioning (`applications/rf_commissioning/`)
+
+Nine-phase gated acceptance workflow (PIEZO_PRE_RF → SSA_CHAR → … → ONE_HOUR_RUN → COMPLETE). `CommissioningSession` is the application facade; `PhaseBase` is the abstract base for all phases; `WorkflowService` orchestrates normalized phase instances; `CommissioningDatabase` (SQLite) stores records with optimistic locking. See the three `.md` files inside `applications/rf_commissioning/` for detailed architecture docs.
+
+### Threading
+
+Long-running operations use `Worker(QThread)` from `utils/qt.py`, which emits `finished`, `progress`, `error`, and `status` signals. Never run blocking EPICS calls on the main Qt thread.
+
+### Logging
+
+`utils/logger.py` provides `custom_logger()` with rotating file handlers. Use `utils/platform_paths.py` to get the correct base log directory (`/home/physics/srf/logfiles` on Linux, `~/` on macOS).
+
+## Testing Notes
+
+- Headless Qt tests require `QT_QPA_PLATFORM=offscreen` (set automatically in CI via Xvfb).
+- `conftest.py` redirects `/home/physics` to a temp directory so tests never write to real paths.
+- EPICS PVs are mocked via `unittest.mock`; no hardware connection is required.
+- `pytest-asyncio` is configured with `asyncio_mode = auto`.
+- The 80% coverage threshold is enforced by CI — check coverage before opening a PR.
+
+## Conventions
+
+- Black 80-character line length; Flake8 allows up to 120 (the two tools have different limits — this is intentional).
+- Releases use conventional commits (`feat`, `fix`, `perf`, `refactor`) and are published to GitHub Releases (not PyPI) via `python-semantic-release`.
+- Packaged data (`.ui` files, `faults.csv`, Q0 calibration/example data) must be listed in `pyproject.toml` under `[tool.setuptools.package-data]` — CI verifies the built wheel contains them.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include *.md
+recursive-include docs *.md
 include LICENSE
 include pyproject.toml
 

--- a/README.md
+++ b/README.md
@@ -1,462 +1,159 @@
 # sc_linac_physics
 
-Controls, analysis, and displays for SC Linac operations.
+Operator displays, analysis tools, and command-line interface for the LCLS-II superconducting (SC) linac at SLAC.
 
-- Python: 3.12+ (tested on 3.12 and 3.13)
-- GUI stack: PyDM + PyQt5/Qt
-- Includes packaged displays, configuration YAML/JSON, and example data
+[![CI](https://github.com/slaclab/sc_linac_physics/actions/workflows/python-app.yml/badge.svg?branch=main)](https://github.com/slaclab/sc_linac_physics/actions/workflows/python-app.yml)
+[![Release](https://github.com/slaclab/sc_linac_physics/actions/workflows/release.yml/badge.svg?branch=main)](https://github.com/slaclab/sc_linac_physics/actions/workflows/release.yml)
 
-### Badges:
-
-CI: [![CI](https://github.com/slaclab/sc_linac_physics/actions/workflows/python-app.yml/badge.svg?branch=main)](https://github.com/slaclab/sc_linac_physics/actions/workflows/python-app.yml)
-
-Release: [![Release](https://github.com/slaclab/sc_linac_physics/actions/workflows/release.yml/badge.svg?branch=main)](https://github.com/slaclab/sc_linac_physics/actions/workflows/release.yml)
+The SC linac accelerates the LCLS-II electron beam through five sections (L0B–L4B) containing 60 cryomodules and 296 superconducting RF cavities. This package provides the software used by operators and physicists to control, monitor, and commission those cavities: PyDM-based GUIs, hierarchical setup automation, fault monitoring, and analysis tools for Q0 measurement, microphonics, and tuning.
 
 For architecture documentation and per-application guides, see [`docs/`](docs/index.md).
 
-## Features
-
-- PyDM-based operator displays for SC Linac
-- Unified command-line interface for all displays and applications
-- Hierarchical setup control (global → linac → cryomodule → cavity)
-- Analysis utilities using NumPy/SciPy/scikit-learn
-- Plotting with matplotlib and pyqtgraph
-- EPICS/Channel Access via caproto and pyepics
-- Configuration with YAML/JSON
-- Packaged calibration and example data
-- Simulated EPICS IOC service for testing and development
-
-## Requirements
-
-- Python >= 3.12
-- Qt runtime (PyQt5)
-- On Linux headless environments (CI/containers), Xvfb or offscreen Qt
-
-Core dependencies (installed automatically):
-
-- pydm, PyQt5, qtpy, pyqtgraph
-- numpy, scipy, scikit-learn, matplotlib
-- pydantic, pyyaml, h5py
-- requests, urllib3, caproto
-- lcls-tools and edmbutton from GitHub
-
-System packages (Linux, recommended for headless testing):
-
-- xvfb, libxkbcommon-x11-0, libglu1-mesa, libxcb-xinerama0
-
 ## Installation
 
-From PyPI (if published):
-
-```bash
-pip install sc_linac_physics
-```
-
-From source:
+Requires Python 3.12+. Install from source (not published to PyPI):
 
 ```bash
 git clone git@github.com:slaclab/sc_linac_physics.git
 cd sc_linac_physics
-pip install -U pip setuptools wheel
-# Development + testing tools:
-pip install -e ".[dev,test]"
-# Or just the package:
-# pip install -e .
+pip install -e ".[dev,test]"   # development + testing
+# pip install -e .             # package only
 ```
 
-Notes:
+> Two dependencies (`edmbutton`, `lcls-tools`) install from `github.com/slaclab` and require network access.
 
-- If behind a firewall, ensure access to GitHub for dependency sources:
-    - https://github.com/slaclab/edmbutton.git
-    - https://github.com/slaclab/lcls-tools.git
+## Displays and Applications
 
-## Quick Start
+All GUIs require PyQt5. Use `sc-linac list` to see everything available.
 
-### Command Line Tools
+| Command | Description |
+|---------|-------------|
+| `sc-srf-home` | Main operator dashboard — launches other tools, manages background watchers |
+| `sc-cavity` | Real-time fault monitoring across all 296 cavities with heatmap visualization |
+| `sc-faults` | Cavity fault decoder |
+| `sc-fcount` | Fault count statistics |
+| `sc-setup` | Automated cavity setup GUI (SSA cal → auto-tune → characterization → RF ramp) |
+| `sc-q0` | Q0 (cavity quality factor) measurement |
+| `sc-tune` | Cavity frequency tuning interface |
+| `sc-quench` | Quench processing — auto-resets false trips, logs real quenches |
 
-After installation, the following commands are available:
+The unified launcher `sc-linac <command>` is an alternative entry point for all of the above.
 
-#### General Launcher Utility
+## Setup Commands
+
+Setup commands automate cavity turn-on across four hierarchy levels. Append `--shutdown` (or `-off`) to any command to reverse it.
 
 ```bash
-# List all available applications
-sc-linac list
-
-# Launch displays and applications
-sc-linac cavity-display      # Launch the cavity control display.
-sc-linac fault-count         # Launch the fault count display.
-sc-linac fault-decoder       # Launch the fault decoder display.
-sc-linac srf-home            # Launch the SRF home display.
-
-sc-linac auto-setup          # Launch the auto setup GUI.
-sc-linac microphonics        # Launch the microphonics GUI.
-sc-linac q0-measurement      # Launch the Q0 measurement GUI.
-sc-linac quench-processing   # Launch the quench processing GUI.
-sc-linac tuning              # Launch the tuning GUI.
-```
-
-#### Display Launcher Shortcuts
-
-```bash
-sc-srf-home          # SRF home overview display - main control interface
-sc-cavity            # Cavity control and monitoring display
-sc-faults            # Cavity fault decoder with detailed diagnostics
-sc-fcount            # Cavity fault count display and statistics
-```
-
-#### Application Launcher Shortcuts
-
-```bash
-sc-quench            # Quench processing application
-sc-setup             # Automated cavity setup (GUI)
-sc-q0                # Q0 measurement application
-sc-tune              # Cavity tuning interface
-```
-
-#### Setup Commands (Hierarchical Control)
-
-The setup commands provide hierarchical control from global (entire machine) down to individual cavities:
-
-**Global Level - Entire Machine**
-
-```bash
-sc-setup-all                    # Setup all cryomodules
-sc-setup-all --no_hl            # Setup all except HL cryomodules
-sc-setup-all --shutdown         # Shutdown all cryomodules
-```
-
-**Linac Level**
-
-```bash
-sc-setup-linac -l 0             # Setup Linac 0 (all cryomodules in linac)
-sc-setup-linac -l 1             # Setup Linac 1
-sc-setup-linac -l 2 --shutdown  # Shutdown Linac 2
-```
-
-**Cryomodule Level**
-
-```bash
-sc-setup-cm -cm 01              # Setup Cryomodule 01 (all cavities)
-sc-setup-cm -cm 02              # Setup Cryomodule 02
-sc-setup-cm -cm H1 --shutdown   # Shutdown Cryomodule H1
-sc-setup-cm -cm 03 -off         # Shutdown Cryomodule 03 (short form)
-```
-
-**Cavity Level**
-
-```bash
-sc-setup-cav -cm 01 -cav 1      # Setup specific cavity
-sc-setup-cav -cm 02 -cav 3      # Setup CM02, cavity 3
-sc-setup-cav -cm 01 -cav 2 -off # Shutdown specific cavity
-```
-
-#### Simulation Service
-
-For testing and development without live hardware:
-
-```bash
-sc-sim                 # Start simulated IOC service
-sc-sim --list-pvs      # List all available PVs
-sc-sim --interfaces=127.0.0.1  # Run on localhost only
-```
-
-#### Tune Status Polling
-
-Persist `TUNE_CONFIG` and `DF_COLD` snapshots/version history to SQLite + JSON:
-
-```bash
-sc-tune-status-poll
-sc-tune-status-poll --base-dir /home/physics/srf
-sc-tune-status-poll --db-path /home/physics/srf/databases/tune_status.sqlite --json-path /home/physics/srf/tune_status.json
-```
-
-Query the generated SQLite database interactively or with inline SQL:
-
-```bash
-sc-tune-status-query
-sc-tune-status-query "select cavity_id, tune_config_label, df_cold from cavity_state limit 10;"
-sc-tune-status-query --db /home/physics/srf/databases/tune_status.sqlite "select count(*) as cavities from cavity_state;"
-```
-
-
-If you just pulled new CLI entries, reinstall in editable mode to refresh scripts:
-
-```bash
-pip install -e .
-```
-
-### Python API
-
-Python import check:
-
-```python
-import sc_linac_physics
-
-print("Package version:", getattr(sc_linac_physics, "__version__", "unknown"))
-```
-
-Programmatic display launching:
-
-```python
-
-from sc_linac_physics.cli import launchers
-
-# Launch displays programmatically
-launchers.launch_srf_home()
-launchers.launch_cavity_display()
-launchers.launch_fault_decoder()
-launchers.launch_fault_count()
-
-# Launch applications
-launchers.launch_quench_processing()
-launchers.launch_auto_setup()
-launchers.launch_q0_measurement()
-launchers.launch_tuning()
-```
-
-### Using PyDM directly
-
-You can also launch displays using PyDM directly:
-
-```bash
-pydm path/to/your_display.ui
-```
-
-Tip: Set PYDM_DEFAULT_PROTOCOL=fake to try displays without live PVs:
-
-```bash
-export PYDM_DEFAULT_PROTOCOL=fake
-sc-cavity
-```
-
-Headless usage (e.g., servers/CI):
-
-```bash
-export QT_QPA_PLATFORM=offscreen
-# or use Xvfb:
-xvfb-run -a sc-srf-home
-```
-
-## Command Reference
-
-### Complete Command List
-
-**Displays:**
-
-- `sc-srf-home` - SRF home overview display
-- `sc-cavity` - Cavity control and monitoring
-- `sc-faults` - Fault decoder
-- `sc-fcount` - Fault count display
-
-**Applications:**
-
-- `sc-quench` - Quench processing
-- `sc-setup` - Auto setup GUI
-- `sc-q0` - Q0 measurement
-- `sc-tune` - Tuning application
-
-**Setup Commands:**
-
-- `sc-setup-all` - Global setup (all cryomodules)
-- `sc-setup-linac` - Linac level setup
-- `sc-setup-cm` - Cryomodule level setup
-- `sc-setup-cav` - Cavity level setup
-
-**Simulation:**
-
-- `sc-sim` - Simulated IOC service
-
-**Operations Polling:**
-
-- `sc-tune-status-poll` - Poll cavity tuning PVs and persist tune-status SQLite/JSON outputs
-- `sc-tune-status-query` - Query tune-status SQLite data (interactive or one-shot SQL)
-
-### Setup Command Examples
-
-```bash
-# Setup entire machine
+# Entire machine
 sc-setup-all
-
-# Setup all except high-level cryomodules
-sc-setup-all --no_hl
-
-# Setup specific linac
-sc-setup-linac -l 0
-
-# Setup specific cryomodule
-sc-setup-cm -cm 01
-
-# Setup specific cavity
-sc-setup-cav -cm 01 -cav 1
-
-# Shutdown examples (add --shutdown or -off to any command)
+sc-setup-all --no_hl        # exclude harmonic linearizer cryomodules
 sc-setup-all --shutdown
-sc-setup-linac -l 0 -off
-sc-setup-cm -cm 01 --shutdown
-sc-setup-cav -cm 01 -cav 1 -off
+
+# One linac section (0–4)
+sc-setup-linac -l 2
+sc-setup-linac -l 2 --shutdown
+
+# One cryomodule
+sc-setup-cm -cm 01
+sc-setup-cm -cm H1 --shutdown
+
+# One cavity
+sc-setup-cav -cm 01 -cav 3
+sc-setup-cav -cm 01 -cav 3 -off
 ```
 
-### Cryomodule and Cavity Numbers
+**Valid identifiers:**
+- Linacs: `0`–`4` (L0B, L1B, L2B, L3B, L4B)
+- Cryomodules: `01` (L0B) · `02`–`03` (L1B) · `H1`–`H2` (HL) · `04`–`15` (L2B) · `16`–`35` (L3B) · `37`–`59` (L4B)
+- Cavities: `1`–`8` — use the bare number (`01`, not `CM01`)
 
-- Linacs: `0` through `4` (L0B, L1B, L2B, L3B, L4B)
-- Cryomodules: `01` (L0B), `02`–`03` (L1B), `H1`–`H2` (HL), `04`–`15` (L2B), `16`–`35` (L3B), `37`–`59` (L4B — note: no `36`)
-- Cavities: `1` through `8`
-
-Examples:
+## Operations Polling
 
 ```bash
-sc-setup-cav -cm 01 -cav 1    # Cryomodule 01, cavity 1
-sc-setup-cav -cm H1 -cav 5    # High-level cryomodule H1, cavity 5
-sc-setup-cm -cm 15            # Cryomodule 15
+sc-tune-status-poll     # persist TUNE_CONFIG + DF_COLD snapshots to SQLite + JSON
+sc-tune-status-query    # interactive or one-shot SQL query against the SQLite DB
+sc-sim                  # start simulated EPICS IOC for development without hardware
 ```
 
 ## Development
 
-Set up environment:
+### Setup
 
 ```bash
 git clone git@github.com:slaclab/sc_linac_physics.git
 cd sc_linac_physics
-pip install -U pip setuptools wheel
 pip install -e ".[dev,test]"
 ```
 
-Code style and lint:
+### Testing
+
+80% coverage is required and enforced in CI.
+
+```bash
+QT_QPA_PLATFORM=offscreen pytest
+QT_QPA_PLATFORM=offscreen pytest tests/test_cli.py -v   # single file
+```
+
+### Linting and formatting
 
 ```bash
 flake8 . --count --max-complexity=10 --max-line-length=120 --show-source --statistics
 black --check .
-# To auto-format:
-# black .
+black .                 # auto-format
 ```
 
-Run tests with coverage (Linux headless):
+### Running without live hardware
 
 ```bash
-export QT_QPA_PLATFORM=offscreen
-pytest
-
-# Run specific test files
-pytest tests/test_cli.py -v
-pytest tests/test_launchers.py -v
+export PYDM_DEFAULT_PROTOCOL=fake   # UI testing without EPICS
+export QT_QPA_PLATFORM=offscreen    # headless Qt (CI, servers)
+# or: xvfb-run -a sc-srf-home
 ```
 
-Combine multi-version coverage (if you test with multiple Python versions):
+### Architecture
 
-```bash
-python -m pip install --upgrade coverage
-coverage combine
-coverage report -m
-coverage html -d htmlcov
+```
+src/sc_linac_physics/
+├── utils/          Shared infrastructure: hardware model, EPICS wrappers, Qt utilities
+├── applications/   Standalone applications (auto_setup, q0, tuning, …)
+├── displays/       PyDM operator displays (cavity_display, srfhome, …)
+└── cli/            Unified entry-point launcher and watcher management
 ```
 
-### Adding New Displays
+The hardware model (`utils/sc_linac/`) defines a `Machine → Linac → Cryomodule → Rack → Cavity` hierarchy reused by every application. See [`docs/`](docs/index.md) for detailed per-module documentation.
 
-1. Create your display class in `src/sc_linac_physics/displays/`, inheriting from `pydm.Display`
-2. Register it with the `@display` decorator in `src/sc_linac_physics/cli/launchers.py`:
+### Adding a display
 
-```python
-from sc_linac_physics.cli.launchers import display, launch_python_display
+1. Create a `pydm.Display` subclass under `src/sc_linac_physics/displays/`
+2. Register it with the `@display` decorator in `cli/launchers.py`
+3. Add a `[project.scripts]` entry in `pyproject.toml`
+4. Add tests in `tests/`
 
-@display
-def launch_my_display():
-    from sc_linac_physics.displays.my_module.my_display import MyDisplay
-    return launch_python_display(MyDisplay)
+### Release process
+
+Releases are automated via `python-semantic-release` on pushes to `main`. Commits must follow the Angular convention — the version bump and changelog entry are derived automatically.
+
+```
+feat(q0): add automated calibration routine   → minor bump
+fix(display): prevent crash on PV disconnect   → patch bump
+BREAKING CHANGE: ...                           → major bump
 ```
 
-3. Add a script entry in `pyproject.toml`:
-
-```toml
-[project.scripts]
-sc-my-display = "sc_linac_physics.cli.launchers:launch_my_display"
-```
-
-4. Add tests in `tests/test_launchers.py`
-
-### Adding New CLI Tools
-
-1. Create your script with a `main()` function
-2. Add an entry in `pyproject.toml`:
-
-```toml
-[project.scripts]
-sc-my-tool = "sc_linac_physics.path.to.module:main"
-```
-
-3. Reinstall: `pip install -e .`
-4. Test: `sc-my-tool --help`
-
-## Release Process
-
-Releases are automated with semantic-release on pushes to the main branch.
-
-- Commit messages follow the Angular convention (examples below)
-- Version is derived from commit history and written to pyproject.toml
-- GitHub Releases are created with changelog and build artifacts (sdist/wheel)
-- Tags are formatted as v{version} (e.g., v0.2.3)
-
-Commit message examples:
-
-- `feat(q0): add automated calibration routine`
-- `feat(cli): add hierarchical setup commands`
-- `fix(display): prevent crash when PV is disconnected`
-- `docs: update operator instructions`
-- `refactor: simplify analysis pipeline`
-- `chore: update CI Python versions`
-- `perf: speed up data loading`
-- `test(cli): add comprehensive CLI test coverage`
-- `BREAKING CHANGE: rename module sc_linac_physics.foo to sc_linac_physics.bar`
-
-Note: Upload to PyPI is disabled by default; artifacts are attached to GitHub Releases.
-
-## Project Structure and Data
-
-Packaged data included under the distribution:
-
-- displays/*
-- applications/q0/calibrations/*
-- applications/q0/data/*
-- Any *.ui, *.yaml, *.yml, *.json files
-
-Access packaged files robustly via importlib.resources (Python 3.12+), not relative paths.
-
-Example:
-
-```python
-from importlib.resources import files
-
-base = files("sc_linac_physics")
-display_dir = base / "displays"
-for p in display_dir.iterdir():
-    if p.suffix == ".ui":
-        print("Found display:", p)
-```
+Artifacts (sdist + wheel) are attached to GitHub Releases. PyPI publishing is disabled.
 
 ## Troubleshooting
 
-- **Qt errors in headless environments:**
-    - Set `QT_QPA_PLATFORM=offscreen` or use Xvfb (`xvfb-run -a ...`)
-- **PV connections during development:**
-    - Use `PYDM_DEFAULT_PROTOCOL=fake` to test UI flow without EPICS
-- **Import issues when developing:**
-    - Ensure editable install (`-e`) or add src/ to PYTHONPATH
-- **CLI command not found after installation:**
-    - Reinstall with `pip install -e .` or check that your virtual environment is activated
-    - Verify console_scripts entry points in pyproject.toml
-- **Invalid cryomodule name:**
-    - Use just the number (e.g., `01`, `H1`) not `CM01`
-    - Valid choices shown in error message or help text
+| Problem | Fix |
+|---------|-----|
+| Qt errors in headless environments | `export QT_QPA_PLATFORM=offscreen` or `xvfb-run -a ...` |
+| PV connections during development | `export PYDM_DEFAULT_PROTOCOL=fake` |
+| `ImportError` after cloning | Use editable install: `pip install -e .` |
+| CLI command not found | Reinstall with `pip install -e .` and check your venv is active |
+| `Invalid cryomodule` error | Use bare number (`01`, `H1`), not `CM01` |
 
 ## Contributing
 
-- Open issues and pull requests are welcome
-- Please run black and flake8 locally before submitting
-- Add tests for new features/bugfixes where possible
-- Use conventional commit messages (Angular style) to drive automated releases
-
-## License
-
-This project is licensed under the terms described in the LICENSE file included with the repository.
+PRs and issues are welcome. Before submitting: run `black` and `flake8`, add tests for new behavior, and use conventional commit messages to keep the automated changelog accurate.
 
 ## Authors
 
@@ -465,17 +162,12 @@ This project is licensed under the terms described in the LICENSE file included 
 - Derikka Bisi (dabisi@slac.stanford.edu)
 - Haley Marts (hmarts@slac.stanford.edu)
 
-## Changelog
+See [CHANGELOG.md](CHANGELOG.md) for release notes.
 
-See CHANGELOG.md for release notes (auto-generated by semantic-release).
+## License
 
-## Copyright Notice:
+See [LICENSE](LICENSE).
 
-COPYRIGHT © SLAC National Accelerator Laboratory. All rights reserved. This work is supported in part by the U.S.
-Department of Energy, Office of Basic Energy Sciences under contract DE-AC02-76SF00515.
+COPYRIGHT © SLAC National Accelerator Laboratory. This work is supported in part by the U.S. Department of Energy, Office of Basic Energy Sciences under contract DE-AC02-76SF00515.
 
-## Usage Restrictions:
-
-Neither the name of the Leland Stanford Junior University, SLAC National Accelerator Laboratory, U.S. Department of
-Energy nor the names of its contributors may be used to endorse or promote products derived from this software without
-specific prior written permission.
+Neither the name of the Leland Stanford Junior University, SLAC National Accelerator Laboratory, U.S. Department of Energy nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ CI: [![CI](https://github.com/slaclab/sc_linac_physics/actions/workflows/python-
 
 Release: [![Release](https://github.com/slaclab/sc_linac_physics/actions/workflows/release.yml/badge.svg?branch=main)](https://github.com/slaclab/sc_linac_physics/actions/workflows/release.yml)
 
+For architecture documentation and per-application guides, see [`docs/`](docs/index.md).
+
 ## Features
 
 - PyDM-based operator displays for SC Linac
@@ -296,9 +298,9 @@ sc-setup-cav -cm 01 -cav 1 -off
 
 ### Cryomodule and Cavity Numbers
 
-- Cryomodules: `01`, `02`, `03`, `H1`, `H2`, `04`-`35`
+- Linacs: `0` through `4` (L0B, L1B, L2B, L3B, L4B)
+- Cryomodules: `01` (L0B), `02`–`03` (L1B), `H1`–`H2` (HL), `04`–`15` (L2B), `16`–`35` (L3B), `37`–`59` (L4B — note: no `36`)
 - Cavities: `1` through `8`
-- Linacs: `0` through `3`
 
 Examples:
 
@@ -350,26 +352,23 @@ coverage html -d htmlcov
 
 ### Adding New Displays
 
-1. Create your display file in `src/sc_linac_physics/displays/`
-2. Add a launcher function in `launchers.py`:
+1. Create your display class in `src/sc_linac_physics/displays/`, inheriting from `pydm.Display`
+2. Register it with the `@display` decorator in `src/sc_linac_physics/cli/launchers.py`:
 
 ```python
-def launch_my_display():
-    """Launch my custom display."""
-    from pydm import PyDMApplication
-    from pathlib import Path
+from sc_linac_physics.cli.launchers import display, launch_python_display
 
-    app = PyDMApplication()
-    display_path = Path(__file__).parent / "displays" / "my_display.ui"
-    app.make_main_window(str(display_path))
-    app.exec_()
+@display
+def launch_my_display():
+    from sc_linac_physics.displays.my_module.my_display import MyDisplay
+    return launch_python_display(MyDisplay)
 ```
 
 3. Add a script entry in `pyproject.toml`:
 
 ```toml
 [project.scripts]
-sc-my-display = "sc_linac_physics.launchers:launch_my_display"
+sc-my-display = "sc_linac_physics.cli.launchers:launch_my_display"
 ```
 
 4. Add tests in `tests/test_launchers.py`

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ sc-setup-cav -cm 01 -cav 3 -off
 ```
 
 **Valid identifiers:**
-- Linacs: `0`–`4` (L0B, L1B, L2B, L3B, L4B)
-- Cryomodules: `01` (L0B) · `02`–`03` (L1B) · `H1`–`H2` (HL) · `04`–`15` (L2B) · `16`–`35` (L3B) · `37`–`59` (L4B)
-- Cavities: `1`–`8` — use the bare number (`01`, not `CM01`)
+- Linacs (`sc-setup-linac -l`): `0`–`3` (L0B–L3B; L4B is not yet supported at this level)
+- Cryomodules (`-cm`): `01` (L0B) · `02`–`03` (L1B) · `H1`–`H2` (HL) · `04`–`15` (L2B) · `16`–`35` (L3B) · `37`–`59` (L4B) — use the bare number (`01` or `H1`, not `CM01`)
+- Cavities (`-cav`): `1`–`8`
 
 ## Operations Polling
 

--- a/docs/applications/auto_setup.md
+++ b/docs/applications/auto_setup.md
@@ -1,0 +1,116 @@
+# Auto Setup
+
+`applications/auto_setup/` automates cavity commissioning: from a cold, unpowered state to a cavity delivering RF to the beam. It provides both a GUI and command-line launchers at four levels of granularity (machine → linac → cryomodule → cavity).
+
+## What "setup" means
+
+For each cavity, setup runs up to four sequential operations:
+
+1. **SSA Calibration** — measures the solid-state amplifier's power transfer curve, sets DAC levels to 0, runs `ssa.calibrate()`
+2. **Auto Tune** — moves the cavity to resonance using the stepper tuner (`move_to_resonance(use_sela=False)`)
+3. **Cavity Characterization** — measures Q-loaded and scale factor via `cavity.characterize()`, then computes probe Q
+4. **RF Ramp** — enables piezo feedback, turns RF on in SELA mode, walks amplitude up to ACON target, centers piezo, switches to SELAP for closed-loop operation
+
+Each step is independently optional (controlled by request flags). The GUI and launchers set these flags before triggering start.
+
+## Class hierarchy
+
+```
+SetupMachine  (module singleton: SETUP_MACHINE)
+└── SetupLinac  (×4 linac sections)
+    └── SetupCryomodule  (×N per linac)
+        └── SetupCavity  (×8 per cryomodule)
+```
+
+All four classes multiply-inherit from their base linac class (`Machine`, `Linac`, `Cryomodule`, `Cavity`) **and** `SetupLinacObject`. The linac base provides hardware access; `SetupLinacObject` adds setup-specific request flags and trigger methods.
+
+### `SetupLinacObject` (`backend/setup_utils.py`)
+
+Mixin that adds four PV-backed boolean properties:
+
+| Property | PV suffix | Meaning |
+|----------|-----------|---------|
+| `ssa_cal_requested` | `AUTO:SETUP_SSAREQ` | Run SSA calibration |
+| `auto_tune_requested` | `AUTO:SETUP_TUNEREQ` | Run auto-tune |
+| `cav_char_requested` | `AUTO:SETUP_CHARREQ` | Run cavity characterization |
+| `rf_ramp_requested` | `AUTO:SETUP_RAMPREQ` | Ramp RF to ACON |
+
+These are written by the GUI/CLI before calling `trigger_start()`. The IOC script reads them to decide which steps to execute. All four flag PVs use the `auto_pv_addr()` pattern from `SCLinacObject`.
+
+### `SetupCavity.setup()` (`backend/setup_cavity.py`)
+
+The main state machine. Rough flow:
+
+```
+safety check (not running, is online)
+→ turn RF off
+→ turn SSA on, reset interlocks
+→ request_ssa_cal()      [progress: 0→25]
+→ request_auto_tune()    [progress: 25→50]
+→ request_characterization()  [progress: 50→70]
+→ request_ramp()         [progress: 70→100]
+→ set status READY
+```
+
+`check_abort()` is called between steps. If the abort PV is set (by GUI or operator), `CavityAbortError` is raised and the sequence stops cleanly.
+
+Key properties on `SetupCavity`:
+- `status` — `STATUS_READY_VALUE` / `STATUS_RUNNING_VALUE` / `STATUS_ERROR_VALUE`
+- `script_is_running` — `True` while setup is active
+- `progress` — 0–100 integer (drives GUI progress bar)
+- `status_message` — human-readable string shown in GUI
+
+### RF ramp detail
+
+The ramp step is the most sensitive: it starts RF at `min(2 MV, ACON)`, walks amplitude up in 0.1 MV steps to the full ACON target, centers piezo, then switches to SELAP mode. Piezo feedback must be enabled before RF turn-on to maintain resonance during ramping.
+
+`capture_acon()` copies the current ADES reading into ACON — used to "lock in" the current operating amplitude as the new target.
+
+## GUI (`frontend/setup_gui.py`)
+
+`SetupGUI` (PyDM Display) mirrors the physical hierarchy as nested `QTabWidget`s:
+
+```
+SetupGUI
+├── Machine-level controls (Set Up / Shut Down / Abort all)
+├── Checkboxes (SSA Cal, Auto Tune, Characterization, RF Ramp)
+└── Tabs: L0B | L1B | L2B | L3B
+    └── Tabs: CM01 | CM02 | …
+        └── Grid 4×2: GUICavity ×8
+            ├── ACON / AACT readbacks
+            ├── Set Up / Turn Off / Abort buttons
+            ├── Status message label
+            └── Progress bar
+```
+
+Machine-level and linac-level buttons show a confirmation popup before executing to prevent accidental machine-wide operations.
+
+Checkboxes are stored in a `Settings` dataclass passed down from `SetupGUI` to all child widgets, so they share a single source of truth for which steps are requested.
+
+## CLI launchers
+
+Four entry points, one per hierarchy level:
+
+| Command | Entry point | Required args |
+|---------|-------------|---------------|
+| `sc-setup-all` | `srf_global_setup_launcher.py` | `--no_hl` (optional), `--shutdown` (optional) |
+| `sc-setup-linac` | `srf_linac_setup_launcher.py` | `-l {0..3}` |
+| `sc-setup-cm` | `srf_cm_setup_launcher.py` | `-cm {01,02,H1,…}` |
+| `sc-setup-cav` | `srf_cavity_setup_launcher.py` | `-cm {CM} -cav {1..8}` |
+
+All launchers:
+1. Read current request flags from EPICS (inheriting whatever the GUI last set)
+2. Propagate flags from parent object down to cavities
+3. Call `setup()` or `shut_down()` on each cavity sequentially
+4. Sleep briefly between cavities to avoid IOC overload (0.1–0.5 s)
+5. Log structured entries with `extra_data` dicts to `logs/auto_setup/`
+
+Shutdown (`--shutdown` / `-off`) is simpler than setup: turns RF off, turns SSA off.
+
+## Non-obvious behaviors
+
+- **Offline cavities are skipped** — `is_online` check at setup start; cavity remains in `READY` state with a logged message, not `ERROR`.
+- **Already-running cavities are skipped** — if `script_is_running`, the launcher logs a warning and moves on.
+- **RF off before setup starts** — even when only requesting RF ramp, the sequence always turns RF off first to clear interlock state.
+- **ACON = 0 blocks ramp** — if ACON is zero the ramp step is skipped with an error message (no target to ramp to).
+- **`SETUP_MACHINE` is a module-level singleton** — all four launchers and the GUI share the same Python object; EPICS PVs are the ultimate source of truth for request flags.

--- a/docs/applications/microphonics.md
+++ b/docs/applications/microphonics.md
@@ -1,0 +1,66 @@
+# Microphonics
+
+`applications/microphonics/` captures and analyzes mechanical vibration noise that couples into cavity frequency. Microphonics appear as RF amplitude/phase jitter and must be understood and mitigated to maintain beam quality.
+
+## What it measures
+
+Mechanical vibrations (from cryo pumps, building HVAC, acoustic noise) couple through the cryomodule structure into cavity frequency. The microphonics application reads the cavity detuning PV (`DFBEST` or equivalent) at high sample rates and computes:
+
+- **RMS detuning** — overall noise level
+- **Peak detuning** — worst-case excursion
+- **FFT spectrum** — identifies dominant vibration frequencies
+- **Spectrogram** — time-frequency map showing transient or periodic sources
+- **Histogram** — detuning distribution (Gaussian = random noise, non-Gaussian = deterministic source)
+
+## GUI structure
+
+```
+MicrophonicsGUI (PyDM Display)
+├── Left panel (40%)
+│   ├── ConfigPanel — cavity selection, duration, sample rate, file output options
+│   └── StatusPanel — live RMS, peak, mean, variance
+└── Right panel (60%)
+    └── PlotPanel
+        ├── TimeSeries plot
+        ├── FFTPlot
+        ├── SpectrogramPlot
+        └── HistogramPlot (pyqtgraph)
+```
+
+## Key classes
+
+### `AsyncDataManager` (`gui/async_data_manager.py`)
+
+Worker thread pool managing data acquisition jobs. Emits:
+- `acquisitionProgress(int)` — 0–100 during acquisition
+- `acquisitionError(str)` — error message
+- `jobComplete(np.ndarray)` — measured detuning array when done
+
+### `ConfigPanel` (`gui/config_panel.py`)
+
+User inputs: cavity selector, measurement duration (seconds), sample rate (Hz), optional file output path. Produces a `MeasurementConfig` dataclass passed to the worker.
+
+### `DataLoader` (`gui/data_loader.py`)
+
+Reads previously saved measurements from `.npy` or HDF5 files and replays them through the same plot pipeline. Useful for offline analysis.
+
+### Plot classes (`plots/`)
+
+| Class | Notes |
+|-------|-------|
+| `TimeSeries` | Scrolling time-domain detuning |
+| `FFTPlot` | Single-sided amplitude spectrum |
+| `SpectrogramPlot` | Incremental sliding-window update (not full recalculation per frame) |
+| `HistogramPlot` | Distribution with Gaussian overlay |
+
+## Non-obvious design
+
+- **Incremental spectrogram**: The spectrogram appends new frequency bins as time advances rather than recomputing the full matrix each update. This keeps the GUI responsive for long (>60 s) acquisitions.
+- **PV batch fetch**: `format_pv_base()` converts cavity identifiers to standardized PV names; acquisition batches the channel-access requests to minimize round-trip latency.
+- **Worker isolation**: Errors in the acquisition worker are caught and re-emitted as signals — they never crash the GUI event loop.
+
+## Entry point
+
+```bash
+sc-microphonics   # (if registered) or launched from SRF Home
+```

--- a/docs/applications/q0.md
+++ b/docs/applications/q0.md
@@ -1,0 +1,74 @@
+# Q0 Measurement
+
+`applications/q0/` measures the intrinsic quality factor (Q0) of individual SRF cavities. Q0 quantifies how efficiently a cavity stores RF energy — higher Q0 means less cryogenic heat load for the same accelerating gradient.
+
+## Measurement principle
+
+Q0 is extracted by comparing RF power dissipation against a known thermal baseline:
+
+1. **Calibration phase** — with RF off, step heaters inside the cryomodule through a series of power levels (e.g., 1 W, 2 W, 3 W). Record the rate of change of liquid helium (LL) level at each heat load. Fit a linear relationship: ΔLL/Δt per watt.
+2. **RF measurement phase** — turn on cavity RF at a target amplitude. The measured ΔLL/Δt minus the thermal background (from calibration) gives the RF-induced heat load, and from that Q0 is computed:
+
+```
+Q0 = ω₀ × U / P_dissipated
+   = (amplitude² × R/Q) / P_dissipated
+```
+
+where `R/Q` is 1012 Ω (normal cavities) or 750 Ω (harmonic linearizers).
+
+## Main classes
+
+### `Q0Cryomodule` (`q0_cryomodule.py`)
+
+Extends `Cryomodule`. Manages:
+- Loading and saving calibration JSON files (path: `{database_dir}/q0/{cm_name}_calibration.json`)
+- JT valve reference position and heater setpoint state
+- Coordinating multi-cavity RF runs
+
+### `Q0Cavity` (`q0_cavity.py`)
+
+Extends `Cavity` with:
+- `r_over_q`: geometry constant (1012 or 750 depending on HL/normal)
+- `ready_for_q0`: flag indicating cavity can participate in RF measurement
+
+### `Calibration` (`calibration.py`)
+
+Holds one or more `HeaterRun` objects, each representing a single heat-load step. After all heater runs complete, linear regression on `(heat_load, ΔLL/Δt)` pairs produces the calibration slope used to subtract background in the RF measurement.
+
+### `Q0Measurement` (`rf_measurement.py`)
+
+Records one RF measurement run: which cavities participated, their amplitudes, and the measured ΔLL/Δt. Computes Q0 using the calibration slope.
+
+## Workflow
+
+```
+Q0GUI
+├── Select cryomodule + cavities
+├── Calibration tab
+│   ├── [Load existing calibration from JSON] or
+│   └── [Run new calibration]
+│       └── CalibrationWorker (QThread)
+│           → Heater sweeps at 1W, 2W, 3W steps
+│           → Each step: hold heater, record LL over time window
+│           → Save to JSON
+└── RF Measurement tab
+    ├── [Load existing RF run] or
+    └── [Run new measurement]
+        └── Q0Worker (QThread)
+            → Set cavity amplitudes
+            → Record LL over time window
+            → Compute Q0 using calibration slope
+            → Display results + pyqtgraph plots
+```
+
+Both the calibration and RF measurement run in background `Worker` threads. The GUI remains responsive during the multi-minute data collection windows.
+
+## Packaged calibration data
+
+The package ships example calibration data under `applications/q0/calibrations/` and example measurement data under `applications/q0/data/`. These are accessed via `importlib.resources` and are included in the built wheel (listed in `pyproject.toml` package-data). They serve as test fixtures and demonstration data.
+
+## Entry point
+
+```bash
+sc-q0
+```

--- a/docs/applications/quench_processing.md
+++ b/docs/applications/quench_processing.md
@@ -1,0 +1,58 @@
+# Quench Processing
+
+`applications/quench_processing/` monitors all cavities for quench events (loss of superconductivity) and automatically resets *fake* quenches (transient noise trips) while logging and preserving information about real quenches for operator review.
+
+## The fake vs. real quench problem
+
+When a cavity quenches, its interlock trips and RF turns off. Many trips are transient (noise, beam-induced, cosmic ray) and the cavity recovers immediately — these are "fake quenches". Resetting them automatically avoids lengthy manual recovery cycles. Real quenches (mechanical, thermal, magnetic flux entry) require investigation before reset.
+
+The distinction is made by re-reading the fault PV after a short delay (~100 ms):
+- If the fault clears on re-read → transient noise → send reset
+- If the fault persists → real quench → log warning, do NOT reset, alert operators
+
+## Main components
+
+### `quench_resetter.py` — monitoring loop
+
+`check_cavities()` is the main loop, called repeatedly by the watcher service:
+
+```
+for each cavity:
+    if fault PV is set:
+        if within cooldown window → skip
+        re-read after 100 ms delay
+        if fault cleared → fake quench → put(1) to interlock_reset_pv
+        if fault persists → real quench → log warning, record stats
+    increment heartbeat PV
+```
+
+### `CavityResetTracker`
+
+Per-cavity state: enforces a minimum cooldown between successive resets (default 3 s) to prevent rapid re-triggering on intermittent faults. Tracks:
+- Total resets sent
+- Real quenches detected
+- Timestamp of last reset
+
+### `QuenchCavity` (`quench_cavity.py`)
+
+Extends `Cavity` with:
+- `validate_quench()` — re-read fault PV after delay to classify quench type
+- `interlock_reset_pv` — the PV that sends the reset command
+
+### `QuenchGUI` / `QuenchWorker`
+
+GUI display showing quench history per cavity and live fault state. The worker thread manages the monitoring loop lifecycle (start/stop/pause) in response to GUI controls.
+
+## Key design choices
+
+- **Non-blocking reset** — `pv.put(1, wait=False)` keeps the monitor loop running without stalling on IOC acknowledgment.
+- **Heartbeat PV** — incremented every loop iteration. SRF Home watches this PV; a static value means the watcher process is stuck.
+- **Per-cavity cooldown** — prevents alert storms when a cavity has an intermittent contact fault that repeatedly trips.
+- **No database writes per cycle** — stats are in-memory counters, keeping the inner loop fast. Historical data is available from EPICS archiver queries.
+
+## Entry points
+
+```bash
+sc-quench          # GUI
+sc-watcher start quench_resetter  # background watcher (from SRF Home or CLI)
+```

--- a/docs/applications/rf_commissioning.md
+++ b/docs/applications/rf_commissioning.md
@@ -1,0 +1,101 @@
+# RF Commissioning
+
+`applications/rf_commissioning/` is the acceptance workflow system for newly-installed or returned cavities. It enforces a strictly sequential series of phases with checkpoints, measurement recording, and a persistent audit trail stored in SQLite.
+
+The architecture docs already in the source tree are also worth reading:
+- `src/sc_linac_physics/applications/rf_commissioning/ARCHITECTURE.md` — dependency rules, module layout
+- `src/sc_linac_physics/applications/rf_commissioning/PHASE_WORKFLOW.md` — phase contract details
+- `src/sc_linac_physics/applications/rf_commissioning/COMPLETE_WORKFLOW_EXAMPLE.md` — end-to-end walkthrough
+
+## Commissioning phases (fixed order)
+
+| # | Phase | Description |
+|---|-------|-------------|
+| 1 | `PIEZO_PRE_RF` | Piezo tuner validation without RF power — always restartable |
+| 2 | `SSA_CHAR` | Solid-state amplifier characterization |
+| 3 | `FREQUENCY_TUNING` | Frequency measurement and π-mode map |
+| 4 | `CAVITY_CHAR` | RF cavity characterization (Q-loaded, scale factor) |
+| 5 | `PIEZO_WITH_RF` | Piezo testing under RF load |
+| 6 | `HIGH_POWER_RAMP` | Initial high-power RF ramp |
+| 7 | `MP_PROCESSING` | Multipactor processing and quench tracking |
+| 8 | `ONE_HOUR_RUN` | One-hour RF stability run |
+| 9 | `COMPLETE` | Administrative sign-off and handoff to operations |
+
+Phases cannot be skipped, though a phase can be explicitly marked as skipped by an authorized operator (the skip is recorded in the audit trail).
+
+## Key classes
+
+### `CommissioningSession` (`session_manager.py`)
+
+The application-facing facade. Controllers (GUI or CLI) interact only with this class.
+
+```python
+session = CommissioningSession(cavity)
+session.start_phase(PhaseName.SSA_CHAR, operator="jdoe")
+session.record_measurement("Q_loaded", 4.1e7)
+session.complete_phase(operator="jdoe")
+session.get_current_record()  # → CommissioningRecord
+```
+
+Manages: database access, active record state, optimistic locking, phase lifecycle transitions.
+
+### `CommissioningRecord` (`models/data_models.py`)
+
+Dataclass holding:
+- Cavity identity (linac, CM, cavity number)
+- Current phase and phase status map
+- Checkpoint history (immutable, append-only)
+- Measurement history (decoupled from phase state, can be written concurrently)
+- `version` integer for optimistic locking
+
+### `PhaseBase` (`phases/phase_base.py`)
+
+Abstract base class all phase implementations inherit from. Defines the phase contract:
+- `validate()` — pre-execution checks (prerequisite phases complete, hardware in expected state)
+- `execute()` — the actual measurement/test steps
+- `create_checkpoint(operator, success, measurements, error_msg)` — writes to audit trail
+- `retry()` — restart a failed phase from the beginning
+
+### `WorkflowService` (`services/workflow_service.py`)
+
+Pure orchestration layer operating on normalized phase instances (stored in separate database tables from the legacy `CommissioningRecord`). Handles:
+- Prerequisite validation
+- Phase instance creation (each run of a phase is a discrete record)
+- Artifact storage (waveform files, measurement CSVs)
+- Phase advancement logic
+
+### `CommissioningDatabase` (`models/persistence/database.py`)
+
+SQLite backend (one file per cryomodule). Schema:
+- `commissioning_records` — one row per cavity, versioned
+- `phase_history` — append-only; every phase attempt is a row
+- `measurements` — append-only; measurement samples keyed by phase and timestamp
+- `notes` — operator notes attached to phases
+- `operators` — operator registry
+
+## Optimistic locking
+
+Every `CommissioningRecord` has a `version` integer. When `CommissioningSession.complete_phase()` saves the record, it checks that `version` in the database matches the loaded version. If another process modified the record in the meantime, a `RecordConflictError` is raised. The caller must reload the record and retry.
+
+This supports multi-user operation (multiple technicians entering measurements concurrently) without requiring row-level locks.
+
+## Repository pattern
+
+`models/persistence/repositories/` provides typed CRUD classes for each entity:
+
+| Repository | Entity |
+|------------|--------|
+| `CryomoduleRepository` | Cryomodule commissioning state |
+| `MeasurementRepository` | Individual measurements |
+| `RecordRepository` | `CommissioningRecord` persistence |
+| `NotesRepository` | Operator notes |
+| `OperatorRepository` | Operator registry |
+| `QueryRepository` | Cross-entity queries |
+
+## Non-obvious design decisions
+
+- **`COMPLETE` is administrative, not technical.** Technical work ends at `ONE_HOUR_RUN`. `COMPLETE` is a separate step for formal supervisor sign-off, allowing different operator roles and triggering handoff notifications.
+- **Normalized phase instances.** `WorkflowService` stores discrete phase *attempts* separately from the `CommissioningRecord`. This allows the UI to iterate rapidly without blocking record persistence, and enables full rerun history without overwriting previous results.
+- **Measurement decoupling.** Measurements append to a separate table from phase state. Concurrent measurement writes never conflict with phase transitions.
+- **Strict import direction.** The package enforces `models → phases → services → session_manager`. An architecture test (`test_session_workflow.py`) guards against circular imports.
+- **`PIEZO_PRE_RF` is always restartable.** It has no hardware side effects that would require recovery, so it's the one phase that can be freely rerun without administrative override.

--- a/docs/applications/tuning.md
+++ b/docs/applications/tuning.md
@@ -1,0 +1,60 @@
+# Tuning
+
+`applications/tuning/` manages cavity frequency control during operation. Cavities must stay near resonance (within ~20 Hz for normal operation) or be parked/landed to a cold reference frequency when not in use.
+
+## Cavity tuning states
+
+Each cavity has a `tune_config` PV with four possible states:
+
+| Value | Constant | Meaning |
+|-------|----------|---------|
+| 0 | `TUNE_CONFIG_RESONANCE_VALUE` | On resonance, ready for beam |
+| 1 | `TUNE_CONFIG_COLD_VALUE` | Landed at cold/parked frequency |
+| 2 | `TUNE_CONFIG_PARKED_VALUE` | Stepper parked at a defined reference |
+| 3 | `TUNE_CONFIG_OTHER_VALUE` | Transitioning or unknown |
+
+## `TuningGUI` (`tuning_gui.py`)
+
+PyDM Display showing a grid of `CavitySection` widgets — one per cavity across all cryomodules. Each `CavitySection` shows:
+- Tune state selector (enum combobox → writes `tune_config` PV)
+- Stepper offset spinbox (manual nudge)
+- Frequency detune readback (Hz)
+- Tuning mode indicator
+
+The GUI reads current state from EPICS and allows operators to manually command state transitions and issue stepper moves.
+
+## `state/` subpackage — background polling and persistence
+
+The `state/` subpackage runs as a background watcher service (`sc-watcher start tune_status_poll`). Its purpose is to persist a historical record of tuning state for trend analysis and offline replay.
+
+### `tune_status_poll.py`
+
+Each iteration (~every N seconds):
+1. Batch-reads all 296 cavity `tune_config` and `df_cold` PVs via `PVBatch.get_values()`
+2. Upserts current values into SQLite `cavity_state` table
+3. Appends a versioned snapshot to `df_cold_version` table (append-only, never updated)
+4. Writes a JSON summary to `{json_dir}/tune_status.json` for low-latency GUI consumption
+
+The dual-persistence approach (SQLite for historical queries + JSON file for live reads) avoids database overhead on every GUI refresh.
+
+### `tune_status_query.py`
+
+Query tool for retrieving historical snapshots. Used by operators investigating drift or step changes in cavity frequency.
+
+### `common.py`
+
+Shared DB connection setup, table definitions, and batch PV name construction.
+
+## Non-obvious design choices
+
+- **`PVBatch.get_values()` for bulk reads** — avoids creating 592 PV objects (296 cavities × 2 PVs) just for polling. PV objects have connection overhead; `caget_many()` is faster for one-shot reads.
+- **Versioned `df_cold` table** — every sample is a new row with a timestamp. Enables reconstruction of the full frequency drift history for each cavity without scanning archived PVs.
+- **JSON for GUI reads** — the tuning display reads the JSON file rather than querying SQLite directly, eliminating database lock contention during high-frequency UI refresh.
+
+## Entry points
+
+```bash
+sc-tune                               # GUI
+sc-watcher start tune_status_poll     # background polling service
+sc-cold-tune -cm 01 -cav 3           # manual cold-landing command
+```

--- a/docs/applications/tuning.md
+++ b/docs/applications/tuning.md
@@ -6,12 +6,12 @@
 
 Each cavity has a `tune_config` PV with four possible states:
 
-| Value | Constant | Meaning |
-|-------|----------|---------|
-| 0 | `TUNE_CONFIG_RESONANCE_VALUE` | On resonance, ready for beam |
-| 1 | `TUNE_CONFIG_COLD_VALUE` | Landed at cold/parked frequency |
+| Value | Constant | Meaning                               |
+|-------|----------|---------------------------------------|
+| 0 | `TUNE_CONFIG_RESONANCE_VALUE` | On resonance, ready for beam          |
+| 1 | `TUNE_CONFIG_COLD_VALUE` | At cold landing frequency             |
 | 2 | `TUNE_CONFIG_PARKED_VALUE` | Stepper parked at a defined reference |
-| 3 | `TUNE_CONFIG_OTHER_VALUE` | Transitioning or unknown |
+| 3 | `TUNE_CONFIG_OTHER_VALUE` | Transitioning or unknown              |
 
 ## `TuningGUI` (`tuning_gui.py`)
 

--- a/docs/displays/cavity_display.md
+++ b/docs/displays/cavity_display.md
@@ -1,0 +1,104 @@
+# Cavity Display
+
+`displays/cavity_display/` is the primary real-time fault monitoring dashboard for the SC Linac. It shows fault status across all 296 cavities organized in a hierarchical tree, with optional heatmap visualization and audio alerts for unacknowledged alarms.
+
+## Architecture overview
+
+```
+cavity_display/
+├── backend/
+│   ├── backend_cavity.py   — per-cavity fault collection and PV monitoring
+│   ├── backend_machine.py  — builds the BackendCavity hierarchy
+│   ├── fault.py            — individual fault condition (PV + threshold + description)
+│   └── runner.py           — continuous polling service
+├── frontend/
+│   ├── cavity_widget.py    — individual cavity tile (color-coded by severity)
+│   ├── gui_cavity.py       — cavity row in tree view
+│   ├── gui_cryomodule.py   — cryomodule section in tree view
+│   ├── gui_machine.py      — top-level display
+│   ├── alarm_sidebar.py    — persistent unacknowledged alarm list
+│   ├── audio_manager.py    — escalating audio alerts
+│   └── heatmap/            — alternative 2D grid visualization
+│       ├── color_mapper.py
+│       ├── heatmap_cavity_widget.py
+│       └── heatmap_cm_widget.py
+├── cavity_display.py       — PyDM Display entry point
+└── utils/
+    ├── faults.csv          — fault definitions (PV suffix, threshold, description)
+    └── utils.py
+```
+
+## Backend
+
+### `BackendCavity` (`backend/backend_cavity.py`)
+
+Extends `Cavity` with fault monitoring. Key methods:
+
+- `create_faults()` — parses `faults.csv` and instantiates `Fault` objects keyed by hash. Each fault knows its PV name, threshold, and human-readable description.
+- `_batch_pv_init()` — connects status output PVs using `PV.batch_create()`. Input fault PVs are read-only and fetched via `caget_many()` (no persistent PV objects).
+- `get_faults()` — returns current fault status by batch-reading fault input PVs.
+- `check_archives()` — queries the EPICS archiver for historical fault frequency over a configurable time window.
+
+### `Fault` (`backend/fault.py`)
+
+Represents one fault condition. Computes:
+- Current status (OK / WARNING / ALARM / INVALID) by comparing PV value to threshold
+- Severity (maps to PyDM alarm color conventions)
+- Description string for display
+
+### `runner.py`
+
+Continuous service loop:
+1. Calls `check_cavities()` on all `BackendCavity` objects
+2. Publishes fault summary to output PVs (for archiver and other displays)
+3. Sleeps `BACKEND_SLEEP_TIME` between iterations
+4. Handles Ctrl+C gracefully during initialization
+
+## Frontend
+
+### Tree view hierarchy
+
+```
+gui_machine.py (GUIMachine)
+└── gui_cryomodule.py (GUICryomodule)  ×60
+    └── gui_cavity.py (GUICavity)       ×8
+        └── cavity_widget.py (CavityWidget)
+```
+
+`CavityWidget` shows a colored tile — green (no alarm), yellow (warning), red (alarm), gray (invalid) — that reflects the worst current fault severity for that cavity. Clicking a tile expands a fault detail panel.
+
+### `AlarmSidebar` (`frontend/alarm_sidebar.py`)
+
+Persistent list of unacknowledged alarms across all cavities. Items remain until an operator explicitly acknowledges them. Provides a scrollable view separate from the main tree.
+
+### `AudioAlertManager` (`frontend/audio_manager.py`)
+
+Escalating audio alerts:
+- **ALARM** severity → sound immediately
+- **WARNING** severity → sound after 2-minute grace period
+- Per-cavity rate limiting: no more than one sound per cavity per 5 minutes, preventing alert storms
+- Logs alert events separately from the main application log
+
+### Heatmap (`frontend/heatmap/`)
+
+Alternative visualization showing all cavities as a 2D color grid:
+
+- `ColorMapper` — maps numeric fault count (0 to `vmax`) to a Blue → White → Red gradient using a non-linear normalized scale (0.5 = white = neutral)
+- `HeatmapCavityWidget` — single cavity cell
+- `HeatmapCMWidget` — one cryomodule row with 8 cavity cells
+- `SeverityFilter` — filters which fault severities are shown
+
+## Key design choices
+
+- **Fault PVs read via `caget_many()`** — fault *input* PVs are never stored as `PV` objects. Batch reads minimize connection overhead for 296 cavities × N faults.
+- **Only output PVs are `PV` objects** — needed for `put()` calls (publishing fault summaries); everything else is read-only via batch CA.
+- **Archive-based trend alerts** — historical fault frequency (e.g., "faulted 10 times today") supplements instantaneous severity for context-aware alerting.
+- **`faults.csv` drives fault definitions** — adding a new fault condition requires only a CSV row, no code change. The CSV is packaged in the wheel and verified in CI.
+
+## Entry points
+
+```bash
+sc-cavity           # cavity display
+sc-faults           # fault decoder sub-display
+sc-fcount           # fault count sub-display
+```

--- a/docs/displays/srf_home.md
+++ b/docs/displays/srf_home.md
@@ -1,0 +1,36 @@
+# SRF Home
+
+`displays/srfhome/` is the top-level operator dashboard for the SC Linac. It serves as the central hub for launching applications, monitoring watcher services, and accessing external resources.
+
+## Layout
+
+```
+SRFHome (PyDM Display)
+├── Mini Status Panel — key PV readbacks (linac summary, fault counts, cryogenic state)
+├── Links & Bookmarks Panel — buttons for Confluence, E-Log, EDM screens
+└── Watcher Groupboxes (one per configured watcher)
+    ├── Start / Stop buttons
+    ├── Status indicator (running / stopped / failed)
+    ├── Log tail (last N lines from service log file)
+    └── Heartbeat PV value
+```
+
+## Watcher management
+
+"Watchers" are long-running background services (e.g., `quench_resetter`, `tune_status_poll`) that run in tmux sessions and are monitored via EPICS heartbeat PVs.
+
+Watchers are defined in `cli/watcher_commands.py` (`WATCHER_CONFIGS` dict). SRF Home reads this config at startup and creates groupboxes dynamically — adding a new watcher requires only a `WATCHER_CONFIGS` entry, no display code change.
+
+Each watcher increments a heartbeat PV every loop cycle. SRF Home polls this PV; a static value (no increment for N seconds) signals a stalled process and is highlighted in the UI.
+
+`make_watcher_groupbox()` in `utils.py` is the factory function that builds each watcher control panel from a config entry.
+
+## Heartbeat detection logic
+
+The heartbeat PV is the primary health indicator for watcher services. External alerting (e.g., automated email or alarm PV) can also watch for a stale heartbeat. The SRF Home UI provides the first line of visibility.
+
+## Entry point
+
+```bash
+sc-srf-home
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,50 @@
+# SC Linac Physics — Documentation
+
+`sc_linac_physics` is the controls, analysis, and display software for the SLAC Superconducting (SC) Linac. It provides operator GUIs, command-line tools, and a Python library for interacting with the 296-cavity RF system via EPICS/Channel Access.
+
+## How the codebase is organized
+
+```
+src/sc_linac_physics/
+├── utils/          Shared infrastructure: hardware model, EPICS wrappers, Qt utilities
+├── applications/   Standalone applications (auto_setup, q0, tuning, …)
+├── displays/       PyDM operator displays (cavity_display, srfhome, …)
+└── cli/            Unified entry-point launcher (sc-linac) and watcher management
+```
+
+Everything in `applications/` and `displays/` is built on top of `utils/`. Start there if you're new.
+
+## Documentation pages
+
+### Infrastructure
+
+| Page | What it covers |
+|------|----------------|
+| [Linac Hardware Model](utils/linac_model.md) | `Machine → Linac → Cryomodule → Rack → Cavity` class hierarchy, PV naming, cryomodule groupings, all constants |
+| [Shared Utilities](utils/shared_utilities.md) | EPICS `PV` wrapper, `PVBatch`, `platform_paths`, `custom_logger`, Qt helpers |
+
+### Applications
+
+| Page | What it covers |
+|------|----------------|
+| [Auto Setup](applications/auto_setup.md) | Automated cavity turn-on: SSA calibration → auto-tune → characterization → RF ramp |
+| [RF Commissioning](applications/rf_commissioning.md) | Phase-gated acceptance workflow for newly-installed cavities |
+| [Q0 Measurement](applications/q0.md) | Cavity quality-factor measurement under thermal load |
+| [Microphonics](applications/microphonics.md) | Mechanical vibration noise acquisition and analysis |
+| [Quench Processing](applications/quench_processing.md) | Automated fake-quench reset and real-quench detection |
+| [Tuning](applications/tuning.md) | Cavity frequency control, state polling, and trend persistence |
+
+### Displays
+
+| Page | What it covers |
+|------|----------------|
+| [Cavity Display](displays/cavity_display.md) | Fault monitoring dashboard for all 296 cavities with heatmap and audio alerts |
+| [SRF Home](displays/srf_home.md) | Top-level launcher panel and watcher management |
+
+## Quick orientation
+
+- The physical machine hierarchy is defined once in `utils/sc_linac/` and reused by every application. Read [Linac Hardware Model](utils/linac_model.md) first.
+- EPICS PV names follow a strict naming convention derived from linac/cryomodule/cavity numbers. See [Linac Hardware Model § PV naming](utils/linac_model.md#pv-naming-conventions).
+- All applications create a module-level `Machine` subclass singleton (e.g., `SETUP_MACHINE`, `Q0_MACHINE`) that eagerly builds the full object tree at import time.
+- Background CLI scripts (quench_resetter, tune_status_poll) are managed as "watchers" from SRF Home or via `sc-watcher`.
+- See `AGENTS.md` at the repo root for architectural conventions (PV wrappers to use, logging format, platform path standards).

--- a/docs/utils/linac_model.md
+++ b/docs/utils/linac_model.md
@@ -152,11 +152,15 @@ Mixin added by all setup/commissioning classes. Provides:
 ### RF modes
 
 ```python
-RF_MODE_SELAP  = 0  # Self-Excited Loop Amplitude+Phase (closed-loop)
-RF_MODE_SELA   = 1  # Self-Excited Loop Amplitude (piezo + coarse)
-RF_MODE_SEL    = 2  # Self-Excited Loop (open-loop coarse)
-RF_MODE_PULSE  = 4  # Pulsed operation
-RF_MODE_CHIRP  = 5  # Frequency sweep
+RF_MODE_SEL    = 2  # Self-Excited Loop: tracks cavity frequency in open loop, no phase or
+                    # amplitude regulation.
+RF_MODE_SELA   = 1  # Self-Excited Loop Amplitude: RF tracks cavity frequency while maintaining
+                    # cavity amplitude with feedback-like parameters.
+RF_MODE_SELAP  = 0  # Self-Excited Loop Amplitude+Phase: maintains cavity
+                    # amplitude and phase. Temporarily enters SELA if detuning exceeds regulation limits.
+RF_MODE_CHIRP  = 5  # Frequency sweep within one waveform to quickly measure detune
+                    # over wide range. Used only during characterization.
+RF_MODE_PULSE  = 4  # Pulsed RF operation
 ```
 
 ### Hardware mode

--- a/docs/utils/linac_model.md
+++ b/docs/utils/linac_model.md
@@ -1,0 +1,211 @@
+# Linac Hardware Model
+
+`utils/sc_linac/` defines the Python object hierarchy that mirrors the physical SC Linac. Every application in the codebase instantiates a subclass of `Machine` and navigates this tree to read/write EPICS PVs.
+
+## Object hierarchy
+
+```
+Machine
+└── Linac  (×5: L0B, L1B, L2B, L3B, L4B)
+    └── Cryomodule  (up to 23 per linac, 60 total)
+        ├── Rack A  →  Cavities 1–4
+        │              └── SSA, StepperTuner, Piezo (one each)
+        ├── Rack B  →  Cavities 5–8
+        │              └── SSA, StepperTuner, Piezo (one each)
+        └── Magnets  (QUAD, XCOR, YCOR) — non-HL cryomodules only
+```
+
+All classes inherit from `SCLinacObject`, which provides:
+- Abstract property `pv_prefix` — every subclass builds its own prefix string
+- `pv_addr(suffix)` → full PV name
+- `auto_pv_addr(suffix)` → `{prefix}AUTO:{suffix}` automation PV name
+
+## PV naming conventions
+
+PV names are hierarchical strings encoding linac section, cryomodule number, and cavity number:
+
+| Level | Pattern | Example |
+|-------|---------|---------|
+| Linac | `ACCL:L{N}B:1:{suffix}` | `ACCL:L0B:1:HEARTBEAT` |
+| Cryomodule | `ACCL:L{N}B:{CM}00:{suffix}` | `ACCL:L1B:0200:DSSTAT` |
+| Cavity | `ACCL:L{N}B:{CM}{CAV}0:{suffix}` | `ACCL:L0B:0110:ADES` |
+| SSA | `ACCL:L{N}B:{CM}{CAV}0:SSA:{suffix}` | `ACCL:L0B:0110:SSA:STATUS` |
+| Stepper | `ACCL:L{N}B:{CM}{CAV}0:STEP:{suffix}` | `ACCL:L0B:0110:STEP:NSTEP` |
+| Piezo | `ACCL:L{N}B:{CM}{CAV}0:PZT:{suffix}` | `ACCL:L0B:0110:PZT:VOLTAGE` |
+| Magnet | `{TYPE}:L{N}B:{CM}85:{suffix}` | `QUAD:L0B:0185:BDES` |
+
+Helper functions in `linac_utils.py`:
+
+```python
+build_cavity_pv_base(linac_name, cm_name, cav_num)   # → "ACCL:L0B:0110"
+build_cavity_pv_prefix(linac_name, cm_name, cav_num)  # → "ACCL:L0B:0110:"
+build_cavity_pv(linac_name, cm_name, cav_num, suffix) # → full PV string
+```
+
+### Cryogenic subsystem prefixes (per cryomodule)
+
+| Prefix variable | Pattern | Subsystem |
+|-----------------|---------|-----------|
+| `cte_prefix` | `CTE:CM{name}:` | Temperature |
+| `cvt_prefix` | `CVT:CM{name}:` | Valve/temperature |
+| `cpv_prefix` | `CPV:CM{name}:` | Pressure/valve |
+| JT valve | `CLIC:CM{name}:3001:PVJT:` | |
+| Heater | `CPIC:CM{name}:0000:EHCV:` | |
+
+## Cryomodule groupings
+
+```python
+L0B    = ["01"]                              # 1 CM
+L1B    = ["02", "03"]                        # 2 CMs
+L1BHL  = ["H1", "H2"]                       # 2 Harmonic Linearizers (3.9 GHz)
+L2B    = ["04" … "15"]                       # 12 CMs
+L3B    = ["16" … "35"]                       # 20 CMs
+L4B    = ["37" … "59"]                       # 23 CMs (no "36")
+
+ALL_CRYOMODULES       = L0B + L1B + L1BHL + L2B + L3B + L4B  # 60 total
+ALL_CRYOMODULES_NO_HL = L0B + L1B + L2B + L3B + L4B           # 58 (no HL)
+LINAC_CM_MAP          = [L0B, L1B+L1BHL, L2B, L3B, L4B]       # indexed 0–4
+```
+
+Harmonic Linearizers (`H1`, `H2`) differ from normal cavities:
+- Frequency: **3.9 GHz** (normal: 1.3 GHz)
+- Cavity length: **0.346 m** (normal: 1.038 m)
+- SSA: 4 SSAs shared across 8 cavities via `HL_SSA_MAP = {1:1, 2:2, 3:3, 4:4, 5:1, 6:2, 7:3, 8:4}`
+- Q-loaded limits: 1.5×10⁷ – 3.5×10⁷ (normal: 2.5×10⁷ – 5.1×10⁷)
+- `cryo_name` maps `H1` → `HL01`, `H2` → `HL02`
+
+## Instantiation pattern
+
+`Machine.__init__` accepts optional class parameters for every level of the hierarchy, allowing applications to substitute their own subclasses:
+
+```python
+# Application-specific singleton
+SETUP_MACHINE = SetupMachine(
+    linac_class=SetupLinac,
+    cryomodule_class=SetupCryomodule,
+    cavity_class=SetupCavity,
+)
+
+# Generic access
+machine = Machine()  # uses base Linac, Cryomodule, Cavity
+cavity  = machine.cryomodules["01"].cavities[3]  # Cryomodule "01", Cavity 3
+```
+
+`Machine` exposes:
+- `machine.cryomodules` — flat dict of all 60 CMs (convenient shortcut)
+- `machine.linacs` — dict indexed by linac number (0–4)
+- `non_hl_iterator`, `hl_iterator`, `all_iterator` — generators over all cavities
+
+## Key classes
+
+### Cavity (`cavity.py`)
+
+The most feature-rich class. Key attributes and methods:
+
+| Member | Purpose |
+|--------|---------|
+| `ssa` | `SSA` sub-object (lazy) |
+| `stepper` | `StepperTuner` sub-object (lazy) |
+| `piezo` | `Piezo` sub-object (lazy) |
+| `turn_on()` / `turn_off()` | RF on/off |
+| `characterize()` | Cavity Q measurement sequence |
+| `move_to_resonance(use_sela)` | Piezo + stepper resonance finding |
+| `walk_amp(target, step)` | Gradual amplitude ramp |
+| `reset_interlocks()` | Clear hardware faults |
+| `is_online` | `hw_mode == HW_MODE_ONLINE_VALUE` |
+
+### SSA (`ssa.py`)
+
+```python
+ssa.turn_on()        # Powers on solid-state amplifier
+ssa.calibrate(drive_max)  # Full calibration sequence
+ssa.is_on            # bool property
+ssa.is_faulted       # bool property
+```
+
+### StepperTuner (`stepper.py`)
+
+```python
+stepper.move(num_steps, max_steps, speed)
+stepper.abort()
+stepper.motor_moving  # bool property
+stepper.hz_per_microstep  # frequency sensitivity
+```
+
+### Piezo (`piezo.py`)
+
+```python
+piezo.enable()
+piezo.enable_feedback()   # Closed-loop feedback
+piezo.disable_feedback()  # Open-loop manual
+piezo.voltage             # Current voltage (R/W)
+```
+
+### LauncherLinacObject (`linac_utils.py`)
+
+Mixin added by all setup/commissioning classes. Provides:
+- `trigger_start()`, `trigger_abort()`, `trigger_stop()`, `clear_abort()` via AUTO: PVs
+- These PVs are how the GUI/CLI signal the IOC scripts to begin or halt operations
+
+## Key constants
+
+### RF modes
+
+```python
+RF_MODE_SELAP  = 0  # Self-Excited Loop Amplitude+Phase (closed-loop)
+RF_MODE_SELA   = 1  # Self-Excited Loop Amplitude (piezo + coarse)
+RF_MODE_SEL    = 2  # Self-Excited Loop (open-loop coarse)
+RF_MODE_PULSE  = 4  # Pulsed operation
+RF_MODE_CHIRP  = 5  # Frequency sweep
+```
+
+### Hardware mode
+
+```python
+HW_MODE_ONLINE_VALUE      = 0  # Normal operation
+HW_MODE_MAINTENANCE_VALUE = 1
+HW_MODE_OFFLINE_VALUE     = 2
+```
+
+### Operation status
+
+```python
+STATUS_READY_VALUE   = 0
+STATUS_RUNNING_VALUE = 1
+STATUS_ERROR_VALUE   = 2
+```
+
+### SSA status
+
+```python
+SSA_STATUS_ON_VALUE      = 3
+SSA_STATUS_FAULTED_VALUE = 1
+SSA_STATUS_OFF_VALUE     = 2
+```
+
+### Tuning config
+
+```python
+TUNE_CONFIG_RESONANCE_VALUE = 0
+TUNE_CONFIG_COLD_VALUE      = 1
+TUNE_CONFIG_PARKED_VALUE    = 2
+TUNE_CONFIG_OTHER_VALUE     = 3
+```
+
+## Exception hierarchy
+
+All exceptions are defined in `linac_utils.py`:
+
+- `CavityAbortError` — abort flag was set; safe stop requested
+- `CavityFaultError` — cavity fault condition
+- `CavityHWModeError` — hardware not in expected mode
+- `QuenchError` — superconducting quench detected
+- `SSACalibrationError` / `SSACalibrationToleranceError`
+- `CavityQLoadedCalibrationError` / `CavityScaleFactorCalibrationError`
+- `DetuneError` — frequency out of tolerance
+- `StepperError` / `StepperAbortError`
+- `PulseError`
+
+## Simulation
+
+`utils/simulation/sc_linac_physics_service.py` is a caproto-based EPICS IOC that publishes simulated PVs for the entire linac. Run with `sc-sim`. Set `PYDM_DEFAULT_PROTOCOL=fake` to use PyDM's built-in fake protocol for UI testing without the simulation IOC.

--- a/docs/utils/shared_utilities.md
+++ b/docs/utils/shared_utilities.md
@@ -1,0 +1,140 @@
+# Shared Utilities
+
+Infrastructure modules under `utils/` used by every application and display.
+
+## EPICS wrappers (`utils/epics/`)
+
+### `PV` class (`core.py`)
+
+A thin but important wrapper around `epics.PV` (pyepics). Use this instead of raw pyepics throughout the codebase.
+
+Key improvements over the raw class:
+- **Never returns `None`** — raises a typed exception instead
+- **Retry with backoff** — configurable `max_retries` (default 3) and `retry_delay`
+- **Thread-safe reconnection** — reentrant lock around reconnect logic
+- **Typed exceptions** — `PVConnectionError`, `PVGetError`, `PVPutError`, `PVInvalidError`
+
+```python
+from sc_linac_physics.utils.epics import PV
+
+pv = PV("ACCL:L0B:0110:ADES")
+pv.put(5.0)           # write (default wait=True, timeout=30s)
+val = pv.get()        # read (default timeout=2s)
+pv.check_alarm()      # raises if severity >= MAJOR
+```
+
+Default timeouts (`PVConfig`):
+
+| Parameter | Default |
+|-----------|---------|
+| `connection_timeout` | 5 s |
+| `get_timeout` | 2 s |
+| `put_timeout` | 30 s |
+| `max_retries` | 3 |
+
+**Lazy-loading pattern** — PV objects are never created in `__init__`. They are created on first property access and cached:
+
+```python
+@property
+def ades_pv(self) -> PV:
+    if not self._ades_pv:
+        self._ades_pv = PV(self.pv_addr("ADES"))
+    return self._ades_pv
+```
+
+This keeps import time and test startup fast by avoiding hundreds of CA connections at module load.
+
+### `PVBatch` (`batch.py`)
+
+Use for bulk reads/writes. Internally calls `epics.caget_many()` to fetch many PVs in a single round-trip, with fallback to individual reads on partial failure.
+
+```python
+from sc_linac_physics.utils.epics.batch import PVBatch
+
+values = PVBatch.get_values(["ACCL:L0B:0110:ADES", "ACCL:L0B:0120:ADES"])
+# returns {pv_name: value, ...}
+
+PVBatch.put_values({"ACCL:L0B:0110:ADES": 5.0, "ACCL:L0B:0120:ADES": 5.0})
+```
+
+Prefer `PVBatch` when touching more than ~5 PVs at once (e.g., reading all 296 cavity amplitudes).
+
+### Exception types (`exceptions.py`)
+
+| Exception | When raised |
+|-----------|-------------|
+| `PVConnectionError` | CA connection failed after retries |
+| `PVGetError` | Read failed after retries |
+| `PVPutError` | Write failed after retries |
+| `PVInvalidError` | Value out of allowed range or alarm severity exceeded |
+
+## Platform paths (`utils/platform_paths.py`)
+
+Centralizes the paths that differ between Linux (production) and macOS (development):
+
+```python
+from sc_linac_physics.utils.platform_paths import get_log_base_dir, get_database_dir
+
+get_srf_base_dir()   # /home/physics/srf  (Linux) | ~/  (macOS)
+get_database_dir()   # /home/physics/srf/databases
+get_json_dir()       # /home/physics/srf/json
+get_log_base_dir()   # /home/physics/srf/logfiles
+```
+
+Always use these functions rather than hardcoding paths.
+
+## Logging (`utils/logger.py`)
+
+`custom_logger()` returns a `logging.Logger` with three sinks:
+
+1. **Colored console output** — human-readable, with `extra_data` rendered as `key=value`
+2. **Rotating `.log` file** — plain text, 10 MB max, 5 backups
+3. **Rotating `.jsonl` file** — JSON Lines, one record per line, for log aggregation
+
+```python
+from sc_linac_physics.utils.logger import custom_logger
+
+logger = custom_logger(
+    name="auto_setup",
+    log_filename="cavity_01_setup",
+    log_dir=get_log_base_dir() / "auto_setup",
+)
+
+logger.info("Starting SSA calibration", extra={"extra_data": {"cavity": "CM01:1", "drive_max": 0.8}})
+```
+
+Notable behaviors:
+- File creation uses a safe umask to set group-writable permissions
+- `RetryFileHandlerFilter` retries log file creation every 60 s if the directory is missing (handles NFS mounts)
+- Pass `enable_retry=False` in tests to skip retries
+
+## Qt utilities (`utils/qt.py`)
+
+### `Worker(QThread)`
+
+All long-running operations (EPICS sequences, data acquisition) run in a `Worker` to avoid blocking the Qt event loop. Signals:
+
+```python
+class Worker(QThread):
+    finished = pyqtSignal(str)   # emitted when done; carries result string
+    progress = pyqtSignal(int)   # 0–100
+    error    = pyqtSignal(str)   # exception message
+    status   = pyqtSignal(str)   # human-readable status update
+```
+
+### `make_sanity_check_popup(txt) -> bool`
+
+Shows a Yes/Cancel confirmation dialog. Returns `True` if user clicks Yes. Use before any destructive or machine-wide action.
+
+### `RFControls`
+
+Pre-built widget assembly for cavity RF control panels: SSA on/off, RF mode selector, amplitude spinbox + readback, SRF max spinbox + readback. Saves wiring up the same ~10 widgets in every cavity display.
+
+### Other helpers
+
+| Function | Purpose |
+|----------|---------|
+| `make_error_popup(title, msg)` | Critical error dialog |
+| `make_rainbow(n)` | HSV colormap with `n` colors for plotting |
+| `get_dimensions(options)` | Square-packing grid size for `n` widgets |
+| `CollapsibleGroupBox` | QGroupBox with expand/collapse toggle |

--- a/docs/utils/shared_utilities.md
+++ b/docs/utils/shared_utilities.md
@@ -51,10 +51,12 @@ Use for bulk reads/writes. Internally calls `epics.caget_many()` to fetch many P
 ```python
 from sc_linac_physics.utils.epics.batch import PVBatch
 
-values = PVBatch.get_values(["ACCL:L0B:0110:ADES", "ACCL:L0B:0120:ADES"])
-# returns {pv_name: value, ...}
+pv_names = ["ACCL:L0B:0110:ADES", "ACCL:L0B:0120:ADES"]
+values = PVBatch.get_values(pv_names)
+# returns [val_for_pv1, val_for_pv2] — same order as input; None for disconnected PVs
 
-PVBatch.put_values({"ACCL:L0B:0110:ADES": 5.0, "ACCL:L0B:0120:ADES": 5.0})
+PVBatch.put_values(pv_names, [5.0, 5.0])
+# returns [True, True] — per-PV success flags
 ```
 
 Prefer `PVBatch` when touching more than ~5 PVs at once (e.g., reading all 296 cavity amplitudes).

--- a/src/sc_linac_physics/applications/auto_setup/backend/setup_cavity.py
+++ b/src/sc_linac_physics/applications/auto_setup/backend/setup_cavity.py
@@ -107,8 +107,9 @@ class SetupCavity(Cavity, SetupLinacObject):
           4. RF ramp to ACON   (rf_ramp_requested)
 
         Always turns RF off first regardless of which steps are requested, to
-        clear any latched interlocks. Skips silently if already running or
-        offline. Sets status to ERROR on any unhandled exception.
+        clear any latched interlocks. Logs a warning and returns without
+        changing status if already running or offline. Sets status to ERROR on
+        any unhandled exception.
         """
         try:
             if self.script_is_running:
@@ -119,9 +120,8 @@ class SetupCavity(Cavity, SetupLinacObject):
 
             if not self.is_online:
                 self.set_status_message(
-                    f"{self} not online, not setting up", logging.ERROR
+                    f"{self} not online, skipping setup", logging.WARNING
                 )
-                self.status = STATUS_ERROR_VALUE
                 return
 
             self.clear_abort()

--- a/src/sc_linac_physics/applications/auto_setup/backend/setup_cavity.py
+++ b/src/sc_linac_physics/applications/auto_setup/backend/setup_cavity.py
@@ -18,6 +18,14 @@ from sc_linac_physics.utils.sc_linac.linac_utils import (
 
 
 class SetupCavity(Cavity, SetupLinacObject):
+    """RF cavity with automated setup logic.
+
+    Inherits hardware control from Cavity and setup request flags from
+    SetupLinacObject. The main entry point is setup(), which sequences
+    SSA calibration → auto-tune → cavity characterization → RF ramp based
+    on which request flags are set.
+    """
+
     def __init__(
         self,
         cavity_num,
@@ -36,12 +44,15 @@ class SetupCavity(Cavity, SetupLinacObject):
         )
 
     def capture_acon(self):
+        """Copy the current ADES value into ACON, locking in the operating amplitude."""
         self.acon = self.ades
 
     def clear_abort(self):
+        """Clear the abort PV so a subsequent setup() call is not immediately aborted."""
         self.abort_pv_obj.put(0)
 
     def trigger_abort(self):
+        """Request a safe mid-sequence abort if a script is running; no-op otherwise."""
         if self.script_is_running:
             self.set_status_message(
                 f"Requesting safe abort for {self}", logging.WARNING
@@ -53,6 +64,7 @@ class SetupCavity(Cavity, SetupLinacObject):
             )
 
     def check_abort(self):
+        """Raise CavityAbortError if the abort PV is set; clear the PV first so it doesn't re-trigger."""
         if self.abort_requested:
             self.clear_abort()
             err_msg = f"Abort requested for {self}"
@@ -60,6 +72,7 @@ class SetupCavity(Cavity, SetupLinacObject):
             raise linac_utils.CavityAbortError(err_msg)
 
     def shut_down(self):
+        """Turn RF and SSA off. Simpler than setup(); no abort polling needed."""
         if self.script_is_running:
             self.set_status_message(
                 f"{self} script already running", logging.WARNING
@@ -85,6 +98,18 @@ class SetupCavity(Cavity, SetupLinacObject):
             self.set_status_message(str(e), logging.ERROR)
 
     def setup(self):
+        """Run the full cavity setup sequence based on active request flags.
+
+        Steps (each gated by its request flag):
+          1. SSA calibration   (ssa_cal_requested)
+          2. Auto-tune         (auto_tune_requested)
+          3. Characterization  (cav_char_requested)
+          4. RF ramp to ACON   (rf_ramp_requested)
+
+        Always turns RF off first regardless of which steps are requested, to
+        clear any latched interlocks. Skips silently if already running or
+        offline. Sets status to ERROR on any unhandled exception.
+        """
         try:
             if self.script_is_running:
                 self.set_status_message(
@@ -137,6 +162,12 @@ class SetupCavity(Cavity, SetupLinacObject):
             self.set_status_message(str(e), logging.ERROR)
 
     def request_ramp(self):
+        """Ramp RF amplitude to ACON if rf_ramp_requested.
+
+        Enables piezo feedback, turns RF on in SELA mode, walks amplitude up
+        to ACON in 0.1 MV steps, centers piezo, then switches to SELAP for
+        closed-loop operation. Raises CavityFaultError if ACON <= 0.
+        """
         try:
             # Always check for abort first
             self.check_abort()
@@ -201,6 +232,7 @@ class SetupCavity(Cavity, SetupLinacObject):
             raise
 
     def request_characterization(self):
+        """Run cavity characterization (Q-loaded, scale factor) if cav_char_requested."""
         self.check_abort()
         if self.cav_char_requested:
             self.set_status_message(
@@ -214,6 +246,7 @@ class SetupCavity(Cavity, SetupLinacObject):
         self.progress = 75
 
     def request_auto_tune(self):
+        """Move cavity to resonance using stepper if auto_tune_requested."""
         self.check_abort()
         if self.auto_tune_requested:
             self.set_status_message(f"Tuning {self} to Resonance", logging.INFO)
@@ -222,6 +255,11 @@ class SetupCavity(Cavity, SetupLinacObject):
         self.progress = 50
 
     def request_ssa_cal(self):
+        """Run SSA calibration if ssa_cal_requested.
+
+        Resets RF DAC amplitudes to 0 before calibrating (required by the
+        calibration procedure). Uses drive_max from the SSA object.
+        """
         try:
             if self.ssa_cal_requested:
                 self.set_status_message(

--- a/src/sc_linac_physics/applications/auto_setup/backend/setup_cavity.py
+++ b/src/sc_linac_physics/applications/auto_setup/backend/setup_cavity.py
@@ -107,9 +107,9 @@ class SetupCavity(Cavity, SetupLinacObject):
           4. RF ramp to ACON   (rf_ramp_requested)
 
         Always turns RF off first regardless of which steps are requested, to
-        clear any latched interlocks. Logs a warning and returns without
-        changing status if already running or offline. Sets status to ERROR on
-        any unhandled exception.
+        clear any latched interlocks. Logs a warning and skips if already
+        running. Sets status to ERROR if the cavity is not online or on any
+        unhandled exception.
         """
         try:
             if self.script_is_running:
@@ -122,6 +122,7 @@ class SetupCavity(Cavity, SetupLinacObject):
                 self.set_status_message(
                     f"{self} not online, skipping setup", logging.WARNING
                 )
+                self.status = STATUS_ERROR_VALUE
                 return
 
             self.clear_abort()

--- a/src/sc_linac_physics/utils/sc_linac/linac_utils.py
+++ b/src/sc_linac_physics/utils/sc_linac/linac_utils.py
@@ -362,7 +362,8 @@ class LauncherLinacObject(SCLinacObject):
     """Mixin for objects that can be started, stopped, and aborted via AUTO: PVs.
 
     Provides trigger_start/trigger_stop/trigger_abort/clear_abort methods backed
-    by EPICS PVs at ``{pv_prefix}AUTO:{name}STRT``, ``{name}STOP``, and ``ABORT``.
+    by EPICS PVs at ``{pv_prefix}AUTO:{name}STRT``, ``{pv_prefix}AUTO:{name}STOP``,
+    and ``{pv_prefix}AUTO:ABORT``.
     Used by all setup/commissioning hierarchy classes.
     """
 

--- a/src/sc_linac_physics/utils/sc_linac/linac_utils.py
+++ b/src/sc_linac_physics/utils/sc_linac/linac_utils.py
@@ -261,17 +261,13 @@ def stepper_tol_factor(num_steps) -> float:
 
 
 class PulseError(Exception):
-    """
-    Exception thrown during cavity SSA calibration
-    """
+    """Exception thrown during pulsed cavity operation."""
 
     pass
 
 
 class StepperError(Exception):
-    """
-    Exception thrown during cavity SSA calibration
-    """
+    """Exception thrown when the stepper tuner motor fails or times out."""
 
     pass
 
@@ -325,9 +321,7 @@ class SSAPowerError(Exception):
 
 
 class SSAFaultError(Exception):
-    """
-    Exception thrown while trying to turn an SSA on or off
-    """
+    """Exception thrown when an SSA fault is detected and cannot be cleared."""
 
     pass
 
@@ -365,6 +359,13 @@ class CavityHWModeError(Exception):
 
 
 class LauncherLinacObject(SCLinacObject):
+    """Mixin for objects that can be started, stopped, and aborted via AUTO: PVs.
+
+    Provides trigger_start/trigger_stop/trigger_abort/clear_abort methods backed
+    by EPICS PVs at ``{pv_prefix}AUTO:{name}STRT``, ``{name}STOP``, and ``ABORT``.
+    Used by all setup/commissioning hierarchy classes.
+    """
+
     @property
     def pv_prefix(self):
         return super().pv_prefix


### PR DESCRIPTION
Add codebase documentation and README rewrite                                                  
                                                                                                 
  Summary                                                                                        
                                                                                                 
  - New docs/ directory with 11 pages covering every major application and display: linac        
  hardware model, EPICS utilities, auto_setup, RF commissioning, Q0, microphonics, quench
  processing, tuning, cavity display, and SRF home. Each page explains what the component does,  
  the main classes and their roles, and non-obvious design decisions that aren't derivable from
  reading the code.
  - New CLAUDE.md for AI-assisted development — architecture overview, commands, testing notes,
  and links to docs/.                                                                            
  - README rewrite — cut from 482 to 173 lines. Removed duplicate command listings, the
  non-existent PyPI install section, and generic boilerplate. Added a domain intro explaining    
  what the SC Linac is and who uses this software. Fixed two factual errors (linac range was 0–3,
   cryomodule range was missing all of L4B). Consolidated troubleshooting into a table.          
  - Docstrings added to SetupCavity methods and LauncherLinacObject; two stale exception
  docstrings in linac_utils.py fixed.                                                            
   
  Test plan                                                                                      
                                                            
  - MANIFEST.in updated — verify python -m build produces a wheel containing docs/*.md           
  - README renders correctly on GitHub (tables, badges, code blocks)
  - All links in docs/index.md resolve to their target pages 