### PR TITLE
feat(rf-commissioning): add backend models, phase framework, and workflow service

### DIFF
--- a/docs/applications/rf_commissioning.md
+++ b/docs/applications/rf_commissioning.md
@@ -1,101 +1,146 @@
 # RF Commissioning
 
-`applications/rf_commissioning/` is the acceptance workflow system for newly-installed or returned cavities. It enforces a strictly sequential series of phases with checkpoints, measurement recording, and a persistent audit trail stored in SQLite.
+`applications/rf_commissioning/` implements the acceptance workflow for newly-installed or returned cavities. It enforces an ordered, phase-gated process with persistent records, phase-attempt history, artifacts, and operator audit data in SQLite.
 
-The architecture docs already in the source tree are also worth reading:
-- `src/sc_linac_physics/applications/rf_commissioning/ARCHITECTURE.md` — dependency rules, module layout
-- `src/sc_linac_physics/applications/rf_commissioning/PHASE_WORKFLOW.md` — phase contract details
-- `src/sc_linac_physics/applications/rf_commissioning/COMPLETE_WORKFLOW_EXAMPLE.md` — end-to-end walkthrough
+Related in-source architecture docs:
+- `src/sc_linac_physics/applications/rf_commissioning/ARCHITECTURE.md`
+- `src/sc_linac_physics/applications/rf_commissioning/PHASE_WORKFLOW.md`
+- `src/sc_linac_physics/applications/rf_commissioning/COMPLETE_WORKFLOW_EXAMPLE.md`
+
+## How to launch
+
+- Direct launcher: `sc-rf-comm`
+- Unified launcher: `sc-linac rf-commissioning`
+- Python entry point: `sc_linac_physics.cli.launchers:launch_rf_commissioning`
+
+For UI-only development without live EPICS, set `PYDM_DEFAULT_PROTOCOL=fake`.
 
 ## Commissioning phases (fixed order)
 
-| # | Phase | Description |
-|---|-------|-------------|
-| 1 | `PIEZO_PRE_RF` | Piezo tuner validation without RF power — always restartable |
-| 2 | `SSA_CHAR` | Solid-state amplifier characterization |
-| 3 | `FREQUENCY_TUNING` | Frequency measurement and π-mode map |
-| 4 | `CAVITY_CHAR` | RF cavity characterization (Q-loaded, scale factor) |
-| 5 | `PIEZO_WITH_RF` | Piezo testing under RF load |
-| 6 | `HIGH_POWER_RAMP` | Initial high-power RF ramp |
-| 7 | `MP_PROCESSING` | Multipactor processing and quench tracking |
-| 8 | `ONE_HOUR_RUN` | One-hour RF stability run |
-| 9 | `COMPLETE` | Administrative sign-off and handoff to operations |
+| # | Enum member | Stored value | Description |
+|---|-------------|--------------|-------------|
+| 1 | `PIEZO_PRE_RF` | `piezo_pre_rf` | Piezo tuner validation without RF power (always restartable) |
+| 2 | `SSA_CHAR` | `ssa_char` | Solid-state amplifier characterization |
+| 3 | `FREQUENCY_TUNING` | `frequency_tuning` | Frequency measurement and pi-mode map |
+| 4 | `CAVITY_CHAR` | `cavity_char` | RF cavity characterization (loaded Q, scale factor) |
+| 5 | `PIEZO_WITH_RF` | `piezo_with_rf` | Piezo testing under RF load |
+| 6 | `HIGH_POWER_RAMP` | `high_power_ramp` | Initial high-power RF ramp |
+| 7 | `MP_PROCESSING` | `mp_processing` | Multipactor processing and quench tracking |
+| 8 | `ONE_HOUR_RUN` | `one_hour_run` | One-hour RF stability run |
+| 9 | `COMPLETE` | `complete` | Administrative sign-off and handoff |
 
-Phases cannot be skipped, though a phase can be explicitly marked as skipped by an authorized operator (the skip is recorded in the audit trail).
+Phases are sequential. In normalized workflow validation, the previous phase must be `complete` (or explicitly `skipped`) before the next phase can start. In the current session helper (`CommissioningSession.can_run_phase`), the previous phase must be `complete`. `PIEZO_PRE_RF` is the only phase intentionally restartable at any time.
 
-## Key classes
+## Session API (current usage)
+
+`CommissioningSession` (`session_manager.py`) is the facade used by GUI/CLI controllers.
+
+```python
+from sc_linac_physics.applications.rf_commissioning.models.data_models import (
+	CommissioningPhase,
+)
+from sc_linac_physics.applications.rf_commissioning.session_manager import (
+	CommissioningSession,
+)
+
+session = CommissioningSession()
+
+# Load or create the cavity record and make it active
+record, record_id, created_new = session.start_new_record(
+	cryomodule="02",
+	cavity_number=3,
+)
+
+# Start a normalized phase-attempt instance
+result = session.start_active_phase_instance(
+	phase=CommissioningPhase.SSA_CHAR,
+	operator="jdoe",
+)
+
+if result is not None:
+	session.add_measurement_to_history(
+		phase=CommissioningPhase.SSA_CHAR,
+		measurement_data={"max_drive": 0.82},
+		operator="jdoe",
+		phase_instance_id=result.phase_instance_id,
+	)
+
+	session.complete_active_phase_instance(
+		phase_instance_id=result.phase_instance_id,
+		phase=CommissioningPhase.SSA_CHAR,
+		artifact_payload={"summary": "SSA characterization completed"},
+	)
+```
+
+## Core components
 
 ### `CommissioningSession` (`session_manager.py`)
 
-The application-facing facade. Controllers (GUI or CLI) interact only with this class.
-
-```python
-session = CommissioningSession(cavity)
-session.start_phase(PhaseName.SSA_CHAR, operator="jdoe")
-session.record_measurement("Q_loaded", 4.1e7)
-session.complete_phase(operator="jdoe")
-session.get_current_record()  # → CommissioningRecord
-```
-
-Manages: database access, active record state, optimistic locking, phase lifecycle transitions.
+Owns:
+- `CommissioningDatabase` connection and initialization
+- Active `CommissioningRecord` and optimistic-lock version tracking
+- Normalized phase-instance lifecycle methods (`start/complete/fail`)
+- Measurement history and notes helpers
 
 ### `CommissioningRecord` (`models/data_models.py`)
 
-Dataclass holding:
-- Cavity identity (linac, CM, cavity number)
-- Current phase and phase status map
-- Checkpoint history (immutable, append-only)
-- Measurement history (decoupled from phase state, can be written concurrently)
-- `version` integer for optimistic locking
+Legacy wide-record model containing:
+- Cavity identity (`linac`, `cryomodule`, `cavity_number`)
+- `current_phase` and per-phase `PhaseStatus`
+- Phase payload fields (`ssa_char`, `frequency_tuning`, etc.)
+- Append-only checkpoint history (`phase_history`)
 
-### `PhaseBase` (`phases/phase_base.py`)
-
-Abstract base class all phase implementations inherit from. Defines the phase contract:
-- `validate()` — pre-execution checks (prerequisite phases complete, hardware in expected state)
-- `execute()` — the actual measurement/test steps
-- `create_checkpoint(operator, success, measurements, error_msg)` — writes to audit trail
-- `retry()` — restart a failed phase from the beginning
+The normalized run/phase-instance tables are the source of truth for progression.
+`CommissioningRecord.current_phase` is retained for compatibility and reporting.
 
 ### `WorkflowService` (`services/workflow_service.py`)
 
-Pure orchestration layer operating on normalized phase instances (stored in separate database tables from the legacy `CommissioningRecord`). Handles:
-- Prerequisite validation
-- Phase instance creation (each run of a phase is a discrete record)
-- Artifact storage (waveform files, measurement CSVs)
-- Phase advancement logic
+Normalized orchestration layer for discrete phase attempts. Handles:
+- Prerequisite validation from phase-instance state
+- Attempt-numbered phase starts
+- Completion/failure transitions
+- Artifact and workflow-event writes
 
-### `CommissioningDatabase` (`models/persistence/database.py`)
+## Database model (important tables)
 
-SQLite backend (one file per cryomodule). Schema:
-- `commissioning_records` — one row per cavity, versioned
-- `phase_history` — append-only; every phase attempt is a row
-- `measurements` — append-only; measurement samples keyed by phase and timestamp
-- `notes` — operator notes attached to phases
-- `operators` — operator registry
+`CommissioningDatabase` (`models/persistence/database.py`) initializes schema from `models/persistence/database_schema.py`.
+
+- `commissioning_records`: one wide record per cavity (versioned)
+- `measurement_history`: append-only measurement log, optional `phase_instance_id` link
+- `commissioning_runs`: one normalized run per record
+- `commissioning_phase_instances`: one row per phase attempt
+- `commissioning_phase_artifacts`: structured payloads per phase attempt
+- `commissioning_workflow_events`: append-only workflow event stream
+- `operators`: approved operator registry
 
 ## Optimistic locking
 
-Every `CommissioningRecord` has a `version` integer. When `CommissioningSession.complete_phase()` saves the record, it checks that `version` in the database matches the loaded version. If another process modified the record in the meantime, a `RecordConflictError` is raised. The caller must reload the record and retry.
+`commissioning_records.version` is used to prevent lost updates across users/processes.
 
-This supports multi-user operation (multiple technicians entering measurements concurrently) without requiring row-level locks.
+- `CommissioningSession.save_active_record()` writes with `expected_version`
+- Note updates (`append_general_note`, `update_general_note`) also check version
+- On mismatch, a `RecordConflictError` is raised and caller should reload before retrying
 
-## Repository pattern
+Because measurements are appended in `measurement_history`, concurrent measurement writes do not require record-level conflict resolution.
 
-`models/persistence/repositories/` provides typed CRUD classes for each entity:
+## Repository layer
+
+`models/persistence/repositories/` provides typed accessors:
 
 | Repository | Entity |
 |------------|--------|
 | `CryomoduleRepository` | Cryomodule commissioning state |
-| `MeasurementRepository` | Individual measurements |
+| `MeasurementRepository` | Measurement history records |
 | `RecordRepository` | `CommissioningRecord` persistence |
 | `NotesRepository` | Operator notes |
 | `OperatorRepository` | Operator registry |
 | `QueryRepository` | Cross-entity queries |
 
-## Non-obvious design decisions
+## Design notes
 
-- **`COMPLETE` is administrative, not technical.** Technical work ends at `ONE_HOUR_RUN`. `COMPLETE` is a separate step for formal supervisor sign-off, allowing different operator roles and triggering handoff notifications.
-- **Normalized phase instances.** `WorkflowService` stores discrete phase *attempts* separately from the `CommissioningRecord`. This allows the UI to iterate rapidly without blocking record persistence, and enables full rerun history without overwriting previous results.
-- **Measurement decoupling.** Measurements append to a separate table from phase state. Concurrent measurement writes never conflict with phase transitions.
-- **Strict import direction.** The package enforces `models → phases → services → session_manager`. An architecture test (`test_session_workflow.py`) guards against circular imports.
-- **`PIEZO_PRE_RF` is always restartable.** It has no hardware side effects that would require recovery, so it's the one phase that can be freely rerun without administrative override.
+- `COMPLETE` is administrative, not a technical measurement phase.
+- Normalized phase attempts preserve full rerun history and support artifact/event trails.
+- Import direction is enforced: `models -> phases -> services -> session_manager`.
+- `PIEZO_PRE_RF` is intentionally restartable because it has no high-power RF side effects.
+- UI defaults currently show the `PIEZO_PRE_RF` tab only; placeholder tabs for later
+  phases can be enabled in phase spec configuration.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,6 +155,7 @@ sc-linac = "sc_linac_physics.cli.cli:main"
 
 # ============================================================================
 # Display Launchers
+sc-rf-comm = "sc_linac_physics.cli.launchers:launch_rf_commissioning"
 # ============================================================================
 sc-srf-home = "sc_linac_physics.cli.launchers:launch_srf_home"
 sc-cavity = "sc_linac_physics.cli.launchers:launch_cavity_display"

--- a/src/sc_linac_physics/applications/rf_commissioning/ARCHITECTURE.md
+++ b/src/sc_linac_physics/applications/rf_commissioning/ARCHITECTURE.md
@@ -9,8 +9,10 @@ This document defines package boundaries for
 - `phases`: phase execution logic and result contracts
 - `services`: orchestration and workflow lifecycle
 - `session_manager`: application-facing session facade
-- `controllers`: UI behavior and phase execution wiring
 - `ui`: widgets, dialogs, screens, and presentation helpers
+  - `ui/controllers`: UI behavior and phase execution wiring
+  - `ui/container`: multi-phase shell orchestration helpers
+  - `ui/displays`: per-phase display implementations
 
 ## Dependency Direction
 
@@ -20,13 +22,13 @@ Allowed direction:
 2. `phases` -> `models`
 3. `services` -> `models`
 4. `session_manager` -> `models`, `services`
-5. `controllers` -> `models`, `phases`, `session_manager`
-6. `ui` -> `models`, `controllers`, `session_manager`
+5. `ui/controllers` -> `models`, `phases`, `session_manager`
+6. `ui` -> `models`, `ui/controllers`, `session_manager`
 
 Disallowed direction examples:
 
-- `models` importing from `ui` or `controllers`
-- `services` importing from `ui` or `controllers`
+- `models` importing from `ui`
+- `services` importing from `ui`
 - internal modules importing symbols from package root
   `sc_linac_physics.applications.rf_commissioning`
 
@@ -54,7 +56,7 @@ the chance of circular import regressions.
 Recent refactors extracted cohesive UI/controller responsibilities into helper
 modules while preserving existing method entry points:
 
-- `controllers/piezo_pre_rf_pv.py`: cavity selection and PV wiring helpers
+- `ui/controllers/piezo_pre_rf_pv.py`: cavity selection and PV wiring helpers
 - `ui/container/progress_panel.py`: compact progress panel build/update logic
 
 This keeps large orchestration classes readable while preserving runtime
@@ -68,7 +70,7 @@ flowchart LR
     P[phases]
     S[services]
     SM[session_manager]
-    C[controllers]
+    C[ui/controllers]
     U[ui]
 
     P --> M

--- a/src/sc_linac_physics/applications/rf_commissioning/COMPLETE_WORKFLOW_EXAMPLE.md
+++ b/src/sc_linac_physics/applications/rf_commissioning/COMPLETE_WORKFLOW_EXAMPLE.md
@@ -1,314 +1,155 @@
 # Complete RF Commissioning Workflow Example
 
-This example demonstrates a full cavity commissioning workflow from start to finish, including the COMPLETE phase for final acceptance.
+This example demonstrates the current session-first lifecycle:
+
+- create/load the canonical record for one cavity,
+- start explicit phase attempts,
+- complete/fail attempts with artifacts,
+- and finish with the `COMPLETE` approval phase.
 
 ## Scenario
 
-Commissioning cavity **CM02_CAV5** in cryomodule **CM02** with phase-by-phase execution and proper handoff to operations.
+Commission cavity `02_CAV5` in cryomodule `02` and hand it off to operations.
 
-## Full Workflow
+## End-to-End Example
 
 ```python
-from datetime import datetime
-from sc_linac_physics.applications.rf_commissioning import (
-    CommissioningRecord,
+from sc_linac_physics.applications.rf_commissioning.models.data_models import (
     CommissioningPhase,
-    PhaseStatus,
-    CommissioningDatabase,
-    PhaseCheckpoint,
+)
+from sc_linac_physics.applications.rf_commissioning.session_manager import (
+    CommissioningSession,
 )
 
-# ============================================================================
-# SETUP: Initialize database and create record
-# ============================================================================
 
-db = CommissioningDatabase("commissioning.db")
-db.initialize()
+def run_phase(
+    session: CommissioningSession,
+    phase: CommissioningPhase,
+    operator: str,
+    measurement_data: dict,
+    artifact_payload: dict,
+) -> None:
+    can_run, reason = session.can_run_phase(phase)
+    if not can_run:
+        raise RuntimeError(f"Cannot run {phase.value}: {reason}")
 
-record = CommissioningRecord(
-    linac=1,
+    started = session.start_active_phase_instance(phase=phase, operator=operator)
+    if started is None:
+        raise RuntimeError(f"Failed to start {phase.value}")
+
+    # Optional: append measurement history while the phase is in progress.
+    session.add_measurement_to_history(
+        phase=phase,
+        measurement_data=measurement_data,
+        operator=operator,
+        phase_instance_id=started.phase_instance_id,
+    )
+
+    ok = session.complete_active_phase_instance(
+        phase_instance_id=started.phase_instance_id,
+        phase=phase,
+        artifact_payload=artifact_payload,
+    )
+    if not ok:
+        raise RuntimeError(f"Failed to complete {phase.value}")
+
+
+session = CommissioningSession(db_path="commissioning.db")
+
+record, record_id, created_new = session.start_new_record(
     cryomodule="02",
     cavity_number=5,
 )
 
-# Save initial record
-record_id = db.save_record(record)
-print(f"Started commissioning: {record.full_cavity_name}")
-print(f"Record ID: {record_id}")
-print(f"Initial phase: {record.current_phase.value}")
+print(f"Record ID: {record_id} (created_new={created_new})")
+print(f"Cavity: {record.full_cavity_name}")
 
-# ============================================================================
-# PHASE 1: PIEZO_PRE_RF - Piezo tuner checkout without RF
-# ============================================================================
-
-print("\n--- Phase 1: PIEZO_PRE_RF ---")
-
-# Run automated test (in actual code, this would call PiezoPreRFPhase.run())
-# ... test executes ...
-
-# Record results
-from sc_linac_physics.applications.rf_commissioning import PiezoPreRFCheck
-
-record.piezo_pre_rf = PiezoPreRFCheck(
-    capacitance_a=2.3e-9,
-    capacitance_b=2.4e-9,
-    channel_a_passed=True,
-    channel_b_passed=True,
-    timestamp=datetime.now(),
-    notes="Both channels passed within specs"
-)
-
-# Add checkpoint
-checkpoint = PhaseCheckpoint(
+# Phase 1: PIEZO_PRE_RF
+run_phase(
+    session=session,
     phase=CommissioningPhase.PIEZO_PRE_RF,
-    timestamp=datetime.now(),
     operator="tech_user",
-    step_name="final_validation",
-    success=True,
-    notes="Piezo test completed successfully",
-    measurements={
-        "cap_a": 2.3e-9,
-        "cap_b": 2.4e-9
-    }
+    measurement_data={"capacitance_a": 2.3e-9, "capacitance_b": 2.4e-9},
+    artifact_payload={"summary": "piezo pre-rf pass"},
 )
-record.add_checkpoint(checkpoint)
 
-# Mark phase complete and advance
-record.set_phase_status(CommissioningPhase.PIEZO_PRE_RF, PhaseStatus.COMPLETE)
-success, message = record.advance_to_next_phase()
-print(f"Advanced to: {record.current_phase.value}")
+# Phase 2: SSA_CHAR (show one failure + retry)
+ssa_start = session.start_active_phase_instance(
+    phase=CommissioningPhase.SSA_CHAR,
+    operator="tech_user",
+)
+if ssa_start is None:
+    raise RuntimeError("Failed to start ssa_char")
 
-# Save progress
-db.save_record(record, record_id)
+failed = session.fail_active_phase_instance(
+    phase_instance_id=ssa_start.phase_instance_id,
+    phase=CommissioningPhase.SSA_CHAR,
+    error_message="Drive limit interlock",
+    artifact_payload={"fault": "interlock"},
+)
+if not failed:
+    raise RuntimeError("Failed to mark ssa_char failed")
 
-# ============================================================================
-# PHASE 2-8: Continue through remaining technical phases
-# ============================================================================
+# Retry creates the next attempt_number for the same phase.
+run_phase(
+    session=session,
+    phase=CommissioningPhase.SSA_CHAR,
+    operator="tech_user",
+    measurement_data={"max_drive": 0.85, "attempt": "retry"},
+    artifact_payload={"summary": "ssa characterization pass"},
+)
 
-# For brevity, showing abbreviated workflow for middle phases
-
-phases_workflow = [
-    (CommissioningPhase.SSA_CHAR, "SSA characterized, max drive = 0.85"),
-    (CommissioningPhase.FREQUENCY_TUNING, "Frequency tuning completed with 8π/9 and 7π/9 modes measured"),
-    (CommissioningPhase.CAVITY_CHAR, "Cavity Q measured, QL = 2.8e7"),
-    (CommissioningPhase.PIEZO_WITH_RF, "Piezo with RF tested, gains within spec"),
-    (CommissioningPhase.HIGH_POWER_RAMP, "High power initial ramp complete"),
-    (CommissioningPhase.MP_PROCESSING, "MP processing complete with acceptable quench spacing"),
-    (CommissioningPhase.ONE_HOUR_RUN, "1-hour run complete at target amplitude"),
-]
-
-for phase, notes in phases_workflow:
-    print(f"\n--- Phase: {phase.value.upper()} ---")
-
-    # ... actual phase execution would happen here ...
-
-    # Record completion
-    checkpoint = PhaseCheckpoint(
+# Continue technical phases.
+for phase, measurement in [
+    (CommissioningPhase.FREQUENCY_TUNING, {"final_detune_hz": 5.0}),
+    (CommissioningPhase.CAVITY_CHAR, {"loaded_q": 2.8e7}),
+    (CommissioningPhase.PIEZO_WITH_RF, {"detune_gain": 0.10}),
+    (CommissioningPhase.HIGH_POWER_RAMP, {"max_amplitude_reached": 17.5}),
+    (CommissioningPhase.MP_PROCESSING, {"quench_count": 3}),
+    (CommissioningPhase.ONE_HOUR_RUN, {"one_hour_complete": True}),
+]:
+    run_phase(
+        session=session,
         phase=phase,
-        timestamp=datetime.now(),
         operator="tech_user",
-        step_name="phase_completion",
-        success=True,
-        notes=notes
+        measurement_data=measurement,
+        artifact_payload={"summary": f"{phase.value} pass"},
     )
-    record.add_checkpoint(checkpoint)
 
-    record.set_phase_status(phase, PhaseStatus.COMPLETE)
+# Phase 9: COMPLETE (typically approver/supervisor role)
+run_phase(
+    session=session,
+    phase=CommissioningPhase.COMPLETE,
+    operator="supervisor_user",
+    measurement_data={"handoff": "operations"},
+    artifact_payload={"approved_by": "supervisor_user"},
+)
 
-    # Advance to next phase
-    success, message = record.advance_to_next_phase()
-    if success:
-        print(f"✓ {phase.value} complete, advanced to: {record.current_phase.value}")
-    else:
-        print(f"✗ Cannot advance: {message}")
-        break
+session.append_general_note("supervisor_user", "Commissioning accepted")
+session.save_active_record()
 
-    # Save progress after each phase
-    db.save_record(record, record_id)
+projection = session.get_active_phase_projection()
+if projection is None:
+    raise RuntimeError("Expected active projection")
 
-# ============================================================================
-# PHASE 9: COMPLETE - Final acceptance and handoff
-# ============================================================================
+print(f"Run status: {projection['run']['status']}")
+print(f"Current phase: {projection['current_phase'].value}")
 
-print("\n--- Phase 9: COMPLETE (Final Acceptance) ---")
-
-# Verify we're at COMPLETE phase
-if record.current_phase == CommissioningPhase.COMPLETE:
-
-    # Perform final acceptance activities
-    print("Performing final acceptance checks...")
-
-    # 1. Set end time
-    record.end_time = datetime.now()
-
-    # 2. Update overall status
-    record.overall_status = "operational"
-
-    # 3. Add final checkpoint
-    final_checkpoint = PhaseCheckpoint(
-        phase=CommissioningPhase.COMPLETE,
-        timestamp=datetime.now(),
-        operator="supervisor_user",  # Note: different operator for approval
-        step_name="final_acceptance",
-        success=True,
-        notes="Cavity accepted for operations. All tests passed.",
-        measurements={
-            "total_duration_hours": record.elapsed_time,
-            "final_status": "operational"
-        }
-    )
-    record.add_checkpoint(final_checkpoint)
-
-    # 4. Mark COMPLETE phase as done
-    record.set_phase_status(CommissioningPhase.COMPLETE, PhaseStatus.COMPLETE)
-
-    # 5. Save final state
-    db.save_record(record, record_id)
-
-    # 6. Generate summary
-    print("\n" + "="*60)
-    print("✓ COMMISSIONING COMPLETE")
-    print("="*60)
-    print(f"Cavity:          {record.full_cavity_name}")
-    print(f"Cryomodule:      {record.cryomodule}")
-    print(f"Started:         {record.start_time}")
-    print(f"Completed:       {record.end_time}")
-    print(f"Duration:        {record.elapsed_time:.1f} hours")
-    print(f"Status:          {record.overall_status}")
-    print(f"Total phases:    {len([p for p in CommissioningPhase if record.get_phase_status(p) == PhaseStatus.COMPLETE])}")
-    print(f"Record complete: {record.is_complete}")
-
-    # 7. Optional: Send notifications, update EPICS, etc.
-    # send_commissioning_notification(record)
-    # update_cavity_epics_status(record.full_cavity_name, "operational")
-    # generate_final_report(record_id)
-
-    print("\n✓ Cavity handed off to operations team")
-
-# ============================================================================
-# VERIFICATION: Check completion status
-# ============================================================================
-
-print("\n--- Verification ---")
-
-# Reload from database to verify persistence
-verified_record = db.load_record(record_id)
-
-print(f"Record is complete: {verified_record.is_complete}")
-print(f"Current phase: {verified_record.current_phase.value}")
-print(f"Overall status: {verified_record.overall_status}")
-
-# Show phase history
-print(f"\nTotal checkpoints: {len(verified_record.phase_history)}")
-for i, cp in enumerate(verified_record.get_checkpoints(), 1):
-    status = "✓" if cp.success else "✗"
-    print(f"  {i}. [{cp.phase.value}] {cp.step_name}: {status} - {cp.notes}")
-
-# Verify cannot advance past COMPLETE
-success, message = verified_record.advance_to_next_phase()
-print(f"\nCan advance further: {success} ({message})")
-
-print("\n" + "="*60)
-print("Workflow demonstration complete!")
-print("="*60)
+for phase, status in projection["phase_status"].items():
+    print(f"  {phase.value}: {status.value}")
 ```
 
-## Expected Output
+## What to Verify
 
-```
-Started commissioning: L1B_CM02_CAV5
-Record ID: 1
-Initial phase: piezo_pre_rf
+1. `session.start_new_record(...)` reuses the same canonical record for the same cavity.
+2. Every phase transition is represented by explicit rows in `commissioning_phase_instances`.
+3. Fail/retry creates a new attempt number for that phase.
+4. Completing `COMPLETE` sets run status to `complete` in `commissioning_runs`.
+5. Measurement data is append-only in `measurement_history`.
 
---- Phase 1: PIEZO_PRE_RF ---
-Advanced to: ssa_char
+## Notes
 
---- Phase: SSA_CHAR ---
-✓ ssa_char complete, advanced to: frequency_tuning
-
---- Phase: FREQUENCY_TUNING ---
-✓ frequency_tuning complete, advanced to: cavity_char
-
---- Phase: CAVITY_CHAR ---
-✓ cavity_char complete, advanced to: piezo_with_rf
-
---- Phase: PIEZO_WITH_RF ---
-✓ piezo_with_rf complete, advanced to: high_power_ramp
-
---- Phase: HIGH_POWER_RAMP ---
-✓ high_power_ramp complete, advanced to: mp_processing
-
---- Phase: MP_PROCESSING ---
-✓ mp_processing complete, advanced to: one_hour_run
-
---- Phase: ONE_HOUR_RUN ---
-✓ one_hour_run complete, advanced to: complete
-
---- Phase 9: COMPLETE (Final Acceptance) ---
-Performing final acceptance checks...
-
-============================================================
-✓ COMMISSIONING COMPLETE
-============================================================
-Cavity:          L1B_CM02_CAV5
-Cryomodule:      02
-Started:         2026-02-25 10:00:00
-Completed:       2026-02-25 16:30:00
-Duration:        6.5 hours
-Status:          operational
-Total phases:    9
-Record complete: True
-
-✓ Cavity handed off to operations team
-
---- Verification ---
-Record is complete: True
-Current phase: complete
-Overall status: operational
-
-Total checkpoints: 9
-  1. [piezo_pre_rf] final_validation: ✓ - Piezo test completed successfully
-    2. [ssa_char] phase_completion: ✓ - SSA characterized, max drive = 0.85
-    3. [frequency_tuning] phase_completion: ✓ - Frequency tuning completed with cold landing detune = 5 Hz and 8π/9 and 7π/9 modes measured
-    4. [cavity_char] phase_completion: ✓ - Cavity Q measured, QL = 2.8e7
-    5. [piezo_with_rf] phase_completion: ✓ - Piezo with RF tested, gains within spec
-    6. [high_power_ramp] phase_completion: ✓ - High power initial ramp complete
-    7. [mp_processing] phase_completion: ✓ - MP processing complete with acceptable quench spacing
-    8. [one_hour_run] phase_completion: ✓ - 1-hour run complete at target amplitude
-    9. [complete] final_acceptance: ✓ - Cavity accepted for operations. All tests passed.
-
-Can advance further: False (complete is the final phase)
-
-============================================================
-Workflow demonstration complete!
-============================================================
-```
-
-## Key Takeaways
-
-1. **COMPLETE phase separates technical work from administrative acceptance**
-    - Technical work ends at ONE_HOUR_RUN
-   - COMPLETE is for formal sign-off and handoff
-
-2. **Different operators for work vs. approval**
-    - Technician runs tests through ONE_HOUR_RUN
-   - Supervisor/physicist approves in COMPLETE phase
-
-3. **Final checkpoint records acceptance**
-   - Who approved it
-   - When it was accepted
-   - Final measurements/summary
-
-4. **Clean status checking**
-   - `record.is_complete` means COMPLETE has status `PhaseStatus.COMPLETE`
-   - `record.current_phase == COMPLETE` only means final acceptance has started
-   - `record.overall_status = "operational"` is set during COMPLETE
-
-5. **Audit trail preserved**
-   - All phases tracked in `phase_history`
-   - Can review who did what and when
-   - Supports compliance/quality assurance
-
-6. **Cannot accidentally re-run**
-   - Once at COMPLETE, cannot advance further
-   - Clear terminal state for the workflow
+- Use cryomodule identifiers like `02` / `H1` (not `CM02`) in API calls.
+- Progression happens through phase-instance completion, not by directly editing
+  `CommissioningRecord.current_phase`.
+- Use `session.get_active_phase_projection()` for UI/state display.

--- a/src/sc_linac_physics/applications/rf_commissioning/PHASE_WORKFLOW.md
+++ b/src/sc_linac_physics/applications/rf_commissioning/PHASE_WORKFLOW.md
@@ -2,338 +2,208 @@
 
 ## Overview
 
-The RF commissioning system enforces **strict sequential phase execution** to ensure proper cavity commissioning. Each phase must complete successfully before the next phase can begin.
+RF commissioning uses a **normalized phase-instance lifecycle**.
+
+- A cavity has one canonical `commissioning_records` row.
+- Workflow state lives in `commissioning_runs` and
+  `commissioning_phase_instances`.
+- Each phase attempt is explicit and append-only.
+- Progression happens by completing phase instances, not by mutating
+  `CommissioningRecord.current_phase` directly.
 
 ## Phase Order
 
-Phases must be executed in this exact order:
+Phases execute in fixed order:
 
-1. **PIEZO_PRE_RF** - Piezo tuner validation without RF
-2. **SSA_CHAR** - Solid-state amplifier characterization
-3. **FREQUENCY_TUNING** - Frequency measurement, tuning to resonance, and π-mode measurements
-4. **CAVITY_CHAR** - RF cavity characterization
-5. **PIEZO_WITH_RF** - Piezo tuner testing with RF power
-6. **HIGH_POWER_RAMP** - High power initial ramp
-7. **MP_PROCESSING** - Multipactor processing and quench tracking
-8. **ONE_HOUR_RUN** - One-hour stability run at high power
-9. **COMPLETE** - Final acceptance and handoff to operations
+1. `PIEZO_PRE_RF`
+2. `SSA_CHAR`
+3. `FREQUENCY_TUNING`
+4. `CAVITY_CHAR`
+5. `PIEZO_WITH_RF`
+6. `HIGH_POWER_RAMP`
+7. `MP_PROCESSING`
+8. `ONE_HOUR_RUN`
+9. `COMPLETE`
 
-The **COMPLETE** phase is an administrative step that:
-- Marks the cavity as fully commissioned and operational
-- Sets the final `end_time` and `overall_status`
-- Provides a clear handoff point from commissioning to operations
-- Can trigger automated reporting, notifications, or data archival
-- Separates technical work (ONE_HOUR_RUN) from formal acceptance
+`COMPLETE` is administrative sign-off after technical work is done.
 
-## Enforcement Mechanisms
+## Lifecycle API (Session-First)
 
-### 1. Automatic Phase Ordering Validation
-
-When starting any phase, the system automatically checks:
+Use `CommissioningSession` as the primary interface from GUI/CLI layers.
 
 ```python
-# PhaseBase.run() checks ordering BEFORE phase-specific prerequisites
-can_start, message = self.context.record.can_start_phase(self.phase_type)
-if not can_start:
-    # Phase is blocked - previous phase must complete first
-    return False
-```
-
-### 2. Manual Phase Advancement
-
-Use `advance_to_next_phase()` to safely move between phases:
-
-```python
-from sc_linac_physics.applications.rf_commissioning import (
-    CommissioningRecord,
+from sc_linac_physics.applications.rf_commissioning.models.data_models import (
     CommissioningPhase,
-    PhaseStatus,
+)
+from sc_linac_physics.applications.rf_commissioning.session_manager import (
+    CommissioningSession,
 )
 
-# Create new commissioning record
-record = CommissioningRecord(
-    linac=1,
+session = CommissioningSession()
+
+# Create or load canonical record for cavity
+record, record_id, created = session.start_new_record(
     cryomodule="02",
     cavity_number=3,
 )
 
-# Complete current phase (PIEZO_PRE_RF is the first phase)
-record.set_phase_status(CommissioningPhase.PIEZO_PRE_RF, PhaseStatus.COMPLETE)
+# Validate prerequisites for target phase
+can_run, reason = session.can_run_phase(CommissioningPhase.PIEZO_PRE_RF)
+if not can_run:
+    raise RuntimeError(reason)
 
-# Advance to next phase (with validation)
-success, message = record.advance_to_next_phase()
-if success:
-    print(f"Now at: {record.current_phase.value}")
-    # Output: "Now at: ssa_char"
-else:
-    print(f"Cannot advance: {message}")
+# Start phase attempt
+start = session.start_active_phase_instance(
+    phase=CommissioningPhase.PIEZO_PRE_RF,
+    operator="jdoe",
+)
+if start is None:
+    raise RuntimeError("No active record")
+
+# Persist measurements as append-only history (optional during run)
+session.add_measurement_to_history(
+    phase=CommissioningPhase.PIEZO_PRE_RF,
+    measurement_data={"capacitance_a": 2.3e-9, "capacitance_b": 2.4e-9},
+    operator="jdoe",
+    phase_instance_id=start.phase_instance_id,
+)
+
+# Complete attempt and advance workflow
+session.complete_active_phase_instance(
+    phase_instance_id=start.phase_instance_id,
+    phase=CommissioningPhase.PIEZO_PRE_RF,
+    artifact_payload={"summary": "piezo pre-rf pass"},
+)
+
+# Save wide record fields (notes, phase payload dataclass fields, etc.)
+session.save_active_record()
 ```
 
-### 3. Phase Start Validation
+## Enforcement Rules
 
-Check if a specific phase can be started:
+### Prerequisite enforcement
 
-```python
-# Check if FREQUENCY_TUNING can start
-can_start, reason = record.can_start_phase(CommissioningPhase.FREQUENCY_TUNING)
+`WorkflowService` checks the latest attempt of the previous phase.
 
-if can_start:
-    print(f"✓ Can start FREQUENCY_TUNING: {reason}")
-else:
-    print(f"✗ Blocked: {reason}")
-    # Example: "✗ Blocked: Previous phase ssa_char must complete first"
-```
+- Allowed previous statuses: `complete`, `skipped`
+- Blocked previous statuses: `not_started`, `in_progress`, `failed`
+- `PIEZO_PRE_RF` is always restartable
+
+`CommissioningSession.can_run_phase(...)` currently enforces a stricter
+check (`complete` prerequisite) for non-`PIEZO_PRE_RF` phases.
+
+### Advancement model
+
+Advancement is automatic on completion:
+
+- `complete_phase_instance(...)` updates the attempt status
+- Workflow run moves to the next phase (`commissioning_runs.current_phase`)
+- If current phase is `COMPLETE`, run status becomes `complete`
 
 ## Resume Capability
 
-### Saving State
-
-The database automatically persists all phase progress:
+Resume by loading the record into an active session and inspecting projection.
 
 ```python
-from sc_linac_physics.applications.rf_commissioning import CommissioningDatabase
+session = CommissioningSession(db_path="commissioning.db")
 
-db = CommissioningDatabase("commissioning.db")
-db.initialize()
+loaded = session.load_record(record_id)
+if loaded is None:
+    raise ValueError("Record not found")
 
-# Save record (includes current_phase, phase_status, phase_history)
-record_id = db.save_record(record)
+projection = session.get_active_phase_projection()
+if projection is not None:
+    print("Current phase:", projection["current_phase"].value)
+    print("Run status:", projection["run"]["status"])
+    for phase, status in projection["phase_status"].items():
+        print(phase.value, status.value)
 ```
 
-### Resuming Sessions
+## Failure and Retry
 
-Load interrupted sessions and continue from where you left off:
-
-```python
-# Option 1: Load specific record
-record = db.load_record(record_id)
-print(f"Resume at: {record.current_phase.value}")
-
-# Option 2: Find all interrupted sessions
-active_sessions = db.get_active_records()
-for session in active_sessions:
-    print(f"Resume {session.cavity_name} at {session.current_phase.value}")
-
-    # Check what phases are complete
-    for phase in CommissioningPhase.get_phase_order():
-        status = session.get_phase_status(phase)
-        print(f"  {phase.value}: {status.value}")
-```
-
-### Example: Multi-Session Workflow
+Retry means starting another attempt for the same phase.
 
 ```python
-# ===== Session 1: Start commissioning =====
-record = CommissioningRecord(linac=1, cryomodule="02", cavity_number=3)
-
-# Run PIEZO_PRE_RF phase
-# ... phase completes successfully ...
-record.set_phase_status(CommissioningPhase.PIEZO_PRE_RF, PhaseStatus.COMPLETE)
-
-# Save and close
-record_id = db.save_record(record)
-# Session ends
-
-# ===== Session 2: Resume next day =====
-record = db.load_record(record_id)
-
-# Advance to next phase
-record.advance_to_next_phase()  # Now at SSA_CHAR
-
-# Run SSA_CHAR phase
-# ... phase completes ...
-record.set_phase_status(CommissioningPhase.SSA_CHAR, PhaseStatus.COMPLETE)
-
-# Save progress
-db.save_record(record, record_id)
-# Session ends
-
-# ===== Session 3: Continue =====
-record = db.load_record(record_id)
-record.advance_to_next_phase()  # Now at FREQUENCY_TUNING
-# ... continue commissioning ...
-
-# ===== Final session: Complete commissioning =====
-# After ONE_HOUR_RUN phase completes successfully
-record.set_phase_status(CommissioningPhase.ONE_HOUR_RUN, PhaseStatus.COMPLETE)
-record.advance_to_next_phase()  # Now at COMPLETE
-
-# Complete phase: final acceptance and handoff
-record.set_phase_status(CommissioningPhase.COMPLETE, PhaseStatus.COMPLETE)
-record.end_time = datetime.now()
-record.overall_status = "operational"
-db.save_record(record, record_id)
-
-# Cavity is now officially operational
-print(f"Commissioning complete! Total time: {record.elapsed_time:.1f} hours")
-```
-
-## Phase History & Checkpoints
-
-Every step of every phase is recorded in an append-only audit log:
-
-```python
-from sc_linac_physics.applications.rf_commissioning import PhaseCheckpoint
-from datetime import datetime
-
-# Phases automatically create checkpoints
-checkpoint = PhaseCheckpoint(
-    phase=CommissioningPhase.PIEZO_PRE_RF,
-    timestamp=datetime.now(),
-    operator="operator_name",
-    step_name="trigger_test",
-    success=True,
-    measurements={"capacitance_a": 2.3e-9, "capacitance_b": 2.4e-9}
-)
-record.add_checkpoint(checkpoint)
-
-# Query checkpoints later
-piezo_checkpoints = record.get_checkpoints(CommissioningPhase.PIEZO_PRE_RF)
-for cp in piezo_checkpoints:
-    print(f"{cp.step_name}: {'✓' if cp.success else '✗'} - {cp.notes}")
-
-# Get latest checkpoint for debugging
-latest = record.get_latest_checkpoint(CommissioningPhase.PIEZO_PRE_RF)
-if not latest.success:
-    print(f"Last failure: {latest.error_message}")
-```
-
-## Error Recovery
-
-### Failed Phase
-
-If a phase fails, it must be retried before advancing:
-
-```python
-# Phase fails
-record.set_phase_status(CommissioningPhase.SSA_CHAR, PhaseStatus.FAILED)
-
-# Cannot advance past failed phase
-success, message = record.advance_to_next_phase()
-# success = False
-# message = "Cannot advance: ssa_char is not complete (status: failed)"
-
-# Fix issue and retry the same phase
-record.set_phase_status(CommissioningPhase.SSA_CHAR, PhaseStatus.IN_PROGRESS)
-# ... re-run phase ...
-record.set_phase_status(CommissioningPhase.SSA_CHAR, PhaseStatus.COMPLETE)
-
-# Now can advance
-record.advance_to_next_phase()  # ✓ Success
-```
-
-### Skipped Phase
-
-Phases can be marked as skipped (counts as complete for ordering):
-
-```python
-# Skip a phase (still allows advancement to next phase)
-record.set_phase_status(CommissioningPhase.CAVITY_CHAR, PhaseStatus.SKIPPED)
-
-# Can still advance (SKIPPED is treated as complete for ordering)
-record.advance_to_next_phase()  # Can advance to PIEZO_WITH_RF
-```
-
-## Integration with PhaseBase
-
-The `PhaseBase` class automatically enforces ordering:
-
-```python
-from sc_linac_physics.applications.rf_commissioning.phases import (
-    PhaseBase,
-    PhaseContext,
-    PiezoPreRFPhase
+start = session.start_active_phase_instance(
+    phase=CommissioningPhase.SSA_CHAR,
+    operator="jdoe",
 )
 
-# Create context
-context = PhaseContext(
-    record=record,
-    operator="operator_name",
-    parameters={"cavity": cavity_obj}
+if start is None:
+    raise RuntimeError("Failed to start phase")
+
+session.fail_active_phase_instance(
+    phase_instance_id=start.phase_instance_id,
+    phase=CommissioningPhase.SSA_CHAR,
+    error_message="Drive limit interlock",
+    artifact_payload={"fault": "interlock"},
 )
 
-# Create phase instance
-phase = PiezoPreRFPhase(context)
-
-# Run phase (automatically checks ordering + prerequisites)
-success = phase.run()
-
-# If previous phase not complete:
-# - Creates checkpoint: "phase_ordering_check" with success=False
-# - Returns False
-# - Record unchanged
+# Later retry creates attempt_number + 1
+retry = session.start_active_phase_instance(
+    phase=CommissioningPhase.SSA_CHAR,
+    operator="jdoe",
+)
 ```
 
-## COMPLETE Phase Workflow
+## COMPLETE Phase Pattern
 
-The COMPLETE phase is typically handled manually as the final administrative step:
+`COMPLETE` is handled like any other phase attempt, but typically by an
+approver/operator role distinct from technical execution.
 
 ```python
-# After all technical phases finish
-if record.current_phase == CommissioningPhase.ONE_HOUR_RUN:
-    if record.get_phase_status(CommissioningPhase.ONE_HOUR_RUN) == PhaseStatus.COMPLETE:
-        # Advance to COMPLETE phase
-        success, message = record.advance_to_next_phase()
+start = session.start_active_phase_instance(
+    phase=CommissioningPhase.COMPLETE,
+    operator="supervisor",
+)
 
-        if success:
-            # Perform final acceptance activities
-            record.end_time = datetime.now()
-            record.overall_status = "operational"
+session.complete_active_phase_instance(
+    phase_instance_id=start.phase_instance_id,
+    phase=CommissioningPhase.COMPLETE,
+    artifact_payload={"handoff": "operations", "approved_by": "supervisor"},
+)
 
-            # Optional: Generate final report
-            # Optional: Update cavity EPICS status
-            # Optional: Send notification to operations team
-
-            # Mark as complete
-            record.set_phase_status(CommissioningPhase.COMPLETE, PhaseStatus.COMPLETE)
-            db.save_record(record, record_id)
-
-            print(f"✓ Cavity {record.full_cavity_name} commissioned successfully!")
-            print(f"  Duration: {record.elapsed_time:.1f} hours")
+session.append_general_note("supervisor", "Commissioning accepted")
+session.save_active_record()
 ```
 
 ## Best Practices
 
-### ✅ DO:
-- Always use `advance_to_next_phase()` to move between phases
-- Check `can_start_phase()` before allowing user to start a phase
-- Save record to database after each phase completes
-- Use `get_active_records()` to find interrupted sessions
-- Create checkpoints with detailed measurements and notes
+### Do
 
-### ❌ DON'T:
-- Manually set `record.current_phase` without validation
-- Skip phase ordering checks
-- Forget to mark phases complete before advancing
-- Lose the database file (contains all history)
+- Use `CommissioningSession` for controller/UI interactions.
+- Start/complete/fail explicit phase instances for all phase transitions.
+- Store technical outputs as `measurement_history` and/or artifacts.
+- Save active record after modifying wide-record fields.
+- Use `get_active_phase_projection()` for UI state.
+
+### Do Not
+
+- Do not manually force phase progression by editing `current_phase`.
+- Do not infer readiness from checkpoint text alone.
+- Do not skip prerequisite checks in custom tooling.
 
 ## API Quick Reference
 
 ```python
-# Phase navigation
-CommissioningPhase.get_phase_order() -> List[CommissioningPhase]
-phase.get_next_phase() -> Optional[CommissioningPhase]
-phase.get_previous_phase() -> Optional[CommissioningPhase]
+# Session lifecycle
+session.start_new_record(cryomodule, cavity_number, linac=None)
+session.load_record(record_id)
+session.save_active_record()
 
-# Phase validation
-record.can_start_phase(phase) -> (bool, str)
-record.advance_to_next_phase() -> (bool, str)
+# Phase lifecycle
+session.can_run_phase(phase)
+session.start_active_phase_instance(phase, operator)
+session.complete_active_phase_instance(phase_instance_id=..., phase=...)
+session.fail_active_phase_instance(phase_instance_id=..., phase=..., error_message=...)
 
-# Phase status
-record.get_phase_status(phase) -> PhaseStatus
-record.set_phase_status(phase, status) -> None
-
-# Checkpoints
-record.add_checkpoint(checkpoint) -> None
-record.get_checkpoints(phase=None) -> List[PhaseCheckpoint]
-record.get_latest_checkpoint(phase=None) -> Optional[PhaseCheckpoint]
-
-# Database
-db.save_record(record, record_id=None) -> int
-db.load_record(record_id) -> Optional[CommissioningRecord]
-db.get_active_records() -> List[CommissioningRecord]
+# Projection / history
+session.get_active_phase_projection()
+session.get_active_phase_instances()
+session.add_measurement_to_history(phase, measurement_data, ...)
+session.get_measurement_history(phase=None)
 ```
 
-## Example: Complete Workflow
+## See Also
 
-See `src/sc_linac_physics/applications/rf_commissioning/COMPLETE_WORKFLOW_EXAMPLE.md` for a complete end-to-end commissioning example with proper phase ordering and final acceptance.
+See `src/sc_linac_physics/applications/rf_commissioning/COMPLETE_WORKFLOW_EXAMPLE.md` for an end-to-end example aligned to this lifecycle.

--- a/src/sc_linac_physics/applications/rf_commissioning/__init__.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/__init__.py
@@ -1,1 +1,35 @@
 """RF commissioning application package."""
+
+from .models import (
+    CavityCharacterization,
+    CommissioningDatabase,
+    CommissioningPhase,
+    CommissioningRecord,
+    FrequencyTuningData,
+    HighPowerRampData,
+    MPProcessingData,
+    OneHourRunData,
+    PhaseCheckpoint,
+    PhaseStatus,
+    PiezoPreRFCheck,
+    PiezoWithRFTest,
+    SSACharacterization,
+)
+from .services import WorkflowService
+
+__all__ = [
+    "CavityCharacterization",
+    "CommissioningDatabase",
+    "CommissioningPhase",
+    "CommissioningRecord",
+    "FrequencyTuningData",
+    "HighPowerRampData",
+    "MPProcessingData",
+    "OneHourRunData",
+    "PhaseCheckpoint",
+    "PhaseStatus",
+    "PiezoPreRFCheck",
+    "PiezoWithRFTest",
+    "SSACharacterization",
+    "WorkflowService",
+]

--- a/src/sc_linac_physics/applications/rf_commissioning/models/__init__.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/models/__init__.py
@@ -1,5 +1,30 @@
 """Data models and persistence for RF commissioning."""
 
+from .commissioning_piezo import CommissioningPiezo
+from .data_models import (
+    CommissioningPhase,
+    PhaseStatus,
+    CommissioningRecord,
+    PhaseCheckpoint,
+    PiezoPreRFCheck,
+    FrequencyTuningData,
+    SSACharacterization,
+    CavityCharacterization,
+    PiezoWithRFTest,
+    HighPowerRampData,
+    MPProcessingQuenchEvent,
+    MPProcessingData,
+    OneHourRunData,
+)
+from .cryomodule_models import (
+    CRYOMODULE_PHASE_REGISTRY,
+    CryomoduleCheckoutRecord,
+    CryomodulePhase,
+    CryomodulePhaseStatus,
+    MagnetCheckoutData,
+)
+from .persistence.database import CommissioningDatabase
+
 __all__ = [
     "CommissioningPhase",
     "PhaseStatus",

--- a/src/sc_linac_physics/applications/rf_commissioning/models/commissioning_piezo.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/models/commissioning_piezo.py
@@ -1,0 +1,178 @@
+"""
+Commissioning-specific Piezo extension.
+
+Adds PVs and functionality needed specifically for RF commissioning procedures.
+"""
+
+from typing import TYPE_CHECKING
+
+from sc_linac_physics.utils.epics import PV
+from sc_linac_physics.utils.sc_linac.piezo import Piezo
+
+if TYPE_CHECKING:
+    from sc_linac_physics.utils.sc_linac.cavity import Cavity
+
+
+class CommissioningPiezo(Piezo):
+    """
+    Extended Piezo class with commissioning-specific PVs.
+
+    Adds pre-RF and with-RF test functionality for cavity commissioning.
+    """
+
+    def __init__(self, cavity: "Cavity"):
+        super().__init__(cavity)
+
+        # Pre-RF Test PVs
+        self.prerf_test_start_pv: str = self.pv_addr("TESTSTRT")
+        self._prerf_test_start_pv_obj: PV | None = None
+
+        self.prerf_test_status_pv: str = self.pv_addr("TESTSTS")
+        self._prerf_test_status_pv_obj: PV | None = None
+
+        self.prerf_cha_status_pv: str = self.pv_addr("CHA_TESTSTAT")
+        self._prerf_cha_status_pv_obj: PV | None = None
+
+        self.prerf_chb_status_pv: str = self.pv_addr("CHB_TESTSTAT")
+        self._prerf_chb_status_pv_obj: PV | None = None
+
+        self.prerf_cha_testmsg_pv: str = self.pv_addr("CHA_TESTMSG1")
+        self._prerf_cha_testmsg_pv_obj: PV | None = None
+
+        self.prerf_chb_testmsg_pv: str = self.pv_addr("CHA_TESTMSG2")
+        self._prerf_chb_testmsg_pv_obj: PV | None = None
+
+        self.capacitance_a_pv: str = self.pv_addr("CHA_C")
+        self._capacitance_a_pv_obj: PV | None = None
+
+        self.capacitance_b_pv: str = self.pv_addr("CHB_C")
+        self._capacitance_b_pv_obj: PV | None = None
+
+        # With-RF Test PVs
+        self.withrf_run_check_pv: str = self.pv_addr("RFTESTSTRT")
+        self._withrf_run_check_pv_obj: PV | None = None
+
+        self.withrf_check_status_pv: str = self.pv_addr("RFTESTSTS")
+        self._withrf_check_status_pv_obj: PV | None = None
+
+        self.withrf_status_pv: str = self.pv_addr("RFSTESTSTAT")
+        self._withrf_status_pv_obj: PV | None = None
+
+        self.amplifiergain_a_pv: str = self.pv_addr("CHA_AMPGAIN")
+        self._amplifiergain_a_pv_obj: PV | None = None
+
+        self.amplifiergain_b_pv: str = self.pv_addr("CHB_AMPGAIN")
+        self._amplifiergain_b_pv_obj: PV | None = None
+
+        self.withrf_push_dfgain_pv: str = self.pv_addr("PUSH_DFGAIN.PROC")
+        self._withrf_push_dfgain_pv_obj: PV | None = None
+
+        self.withrf_save_dfgain_pv: str = self.pv_addr("SAVE_DFGAIN.PROC")
+        self._withrf_save_dfgain_pv_obj: PV | None = None
+
+        self.detunegain_new_pv: str = self.pv_addr("DFGAIN_NEW")
+        self._detunegain_new_pv_obj: PV | None = None
+
+    # =========================================================================
+    # Pre-RF Test Properties
+    # =========================================================================
+
+    @property
+    def prerf_test_start_pv_obj(self) -> PV:
+        if not self._prerf_test_start_pv_obj:
+            self._prerf_test_start_pv_obj = PV(self.prerf_test_start_pv)
+        return self._prerf_test_start_pv_obj
+
+    @property
+    def prerf_test_status_pv_obj(self) -> PV:
+        if not self._prerf_test_status_pv_obj:
+            self._prerf_test_status_pv_obj = PV(self.prerf_test_status_pv)
+        return self._prerf_test_status_pv_obj
+
+    @property
+    def prerf_cha_status_pv_obj(self) -> PV:
+        if not self._prerf_cha_status_pv_obj:
+            self._prerf_cha_status_pv_obj = PV(self.prerf_cha_status_pv)
+        return self._prerf_cha_status_pv_obj
+
+    @property
+    def prerf_chb_status_pv_obj(self) -> PV:
+        if not self._prerf_chb_status_pv_obj:
+            self._prerf_chb_status_pv_obj = PV(self.prerf_chb_status_pv)
+        return self._prerf_chb_status_pv_obj
+
+    @property
+    def prerf_cha_testmsg_pv_obj(self) -> PV:
+        if not self._prerf_cha_testmsg_pv_obj:
+            self._prerf_cha_testmsg_pv_obj = PV(self.prerf_cha_testmsg_pv)
+        return self._prerf_cha_testmsg_pv_obj
+
+    @property
+    def prerf_chb_testmsg_pv_obj(self) -> PV:
+        if not self._prerf_chb_testmsg_pv_obj:
+            self._prerf_chb_testmsg_pv_obj = PV(self.prerf_chb_testmsg_pv)
+        return self._prerf_chb_testmsg_pv_obj
+
+    @property
+    def capacitance_a_pv_obj(self) -> PV:
+        if not self._capacitance_a_pv_obj:
+            self._capacitance_a_pv_obj = PV(self.capacitance_a_pv)
+        return self._capacitance_a_pv_obj
+
+    @property
+    def capacitance_b_pv_obj(self) -> PV:
+        if not self._capacitance_b_pv_obj:
+            self._capacitance_b_pv_obj = PV(self.capacitance_b_pv)
+        return self._capacitance_b_pv_obj
+
+    # =========================================================================
+    # With-RF Test Properties
+    # =========================================================================
+
+    @property
+    def withrf_run_check_pv_obj(self) -> PV:
+        if not self._withrf_run_check_pv_obj:
+            self._withrf_run_check_pv_obj = PV(self.withrf_run_check_pv)
+        return self._withrf_run_check_pv_obj
+
+    @property
+    def withrf_check_status_pv_obj(self) -> PV:
+        if not self._withrf_check_status_pv_obj:
+            self._withrf_check_status_pv_obj = PV(self.withrf_check_status_pv)
+        return self._withrf_check_status_pv_obj
+
+    @property
+    def withrf_status_pv_obj(self) -> PV:
+        if not self._withrf_status_pv_obj:
+            self._withrf_status_pv_obj = PV(self.withrf_status_pv)
+        return self._withrf_status_pv_obj
+
+    @property
+    def amplifiergain_a_pv_obj(self) -> PV:
+        if not self._amplifiergain_a_pv_obj:
+            self._amplifiergain_a_pv_obj = PV(self.amplifiergain_a_pv)
+        return self._amplifiergain_a_pv_obj
+
+    @property
+    def amplifiergain_b_pv_obj(self) -> PV:
+        if not self._amplifiergain_b_pv_obj:
+            self._amplifiergain_b_pv_obj = PV(self.amplifiergain_b_pv)
+        return self._amplifiergain_b_pv_obj
+
+    @property
+    def withrf_push_dfgain_pv_obj(self) -> PV:
+        if not self._withrf_push_dfgain_pv_obj:
+            self._withrf_push_dfgain_pv_obj = PV(self.withrf_push_dfgain_pv)
+        return self._withrf_push_dfgain_pv_obj
+
+    @property
+    def withrf_save_dfgain_pv_obj(self) -> PV:
+        if not self._withrf_save_dfgain_pv_obj:
+            self._withrf_save_dfgain_pv_obj = PV(self.withrf_save_dfgain_pv)
+        return self._withrf_save_dfgain_pv_obj
+
+    @property
+    def detunegain_new_pv_obj(self) -> PV:
+        if not self._detunegain_new_pv_obj:
+            self._detunegain_new_pv_obj = PV(self.detunegain_new_pv)
+        return self._detunegain_new_pv_obj

--- a/src/sc_linac_physics/applications/rf_commissioning/models/cryomodule_models.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/models/cryomodule_models.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import Optional
+
 
 from sc_linac_physics.applications.rf_commissioning.models.registry import (
     PhaseRegistration,
@@ -70,7 +70,7 @@ class CryomoduleCheckoutRecord:
     cryomodule: str
     start_time: datetime = field(default_factory=datetime.now)
 
-    magnet_checkout: Optional[MagnetCheckoutData] = None
+    magnet_checkout: MagnetCheckoutData | None = None
 
     phase_status: dict[CryomodulePhase, CryomodulePhaseStatus] = field(
         default_factory=dict

--- a/src/sc_linac_physics/applications/rf_commissioning/models/data_models.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/models/data_models.py
@@ -696,38 +696,6 @@ class CommissioningRecord:
 
         return True, f"Prerequisites met for {phase.value} (reruns allowed)"
 
-    def advance_to_next_phase(self) -> tuple[bool, str]:
-        """Advance to the next phase in the sequence.
-
-        Returns:
-            Tuple of (success, message)
-            - success: True if phase was advanced
-            - message: Explanation of outcome
-        """
-        # Check if current phase is complete
-        current_status = self.get_phase_status(self.current_phase)
-        if current_status != PhaseStatus.COMPLETE:
-            return (
-                False,
-                f"Cannot advance: {self.current_phase.value} is not complete (status: {current_status.value})",
-            )
-
-        # Get next phase
-        next_phase = self.current_phase.get_next_phase()
-        if next_phase is None:
-            return False, f"{self.current_phase.value} is the final phase"
-
-        # Validate can start next phase
-        can_start, reason = self.can_start_phase(next_phase)
-        if not can_start:
-            return False, f"Cannot start {next_phase.value}: {reason}"
-
-        # Update current phase
-        self.current_phase = next_phase
-        self.phase_status[next_phase] = PhaseStatus.IN_PROGRESS
-
-        return True, f"Advanced to {next_phase.value}"
-
     def add_checkpoint(self, checkpoint: PhaseCheckpoint) -> None:
         """Add a checkpoint to the history.
 

--- a/src/sc_linac_physics/applications/rf_commissioning/models/persistence/database.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/models/persistence/database.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from collections.abc import Generator
 from contextlib import contextmanager
@@ -24,6 +25,9 @@ from sc_linac_physics.applications.rf_commissioning.models.persistence.database_
 from sc_linac_physics.applications.rf_commissioning.models.persistence.database_schema import (
     initialize_database_schema,
 )
+from sc_linac_physics.applications.rf_commissioning.models.serialization import (
+    deserialize_model,
+)
 from sc_linac_physics.applications.rf_commissioning.models.persistence.repositories import (
     CryomoduleRepository,
     MeasurementRepository,
@@ -31,6 +35,9 @@ from sc_linac_physics.applications.rf_commissioning.models.persistence.repositor
     OperatorRepository,
     QueryRepository,
     RecordRepository,
+)
+from sc_linac_physics.applications.rf_commissioning.models.persistence.repositories.base import (
+    BaseRepository,
 )
 
 __all__ = [
@@ -121,6 +128,58 @@ class CommissioningDatabase:
         return self._records.load_workflow_state(
             cursor=cursor,
             record_id=record_id,
+        )
+
+    @staticmethod
+    def _serialize_phase_data(phase_data) -> str | None:
+        if phase_data is None:
+            return None
+        return json.dumps(phase_data.to_dict())
+
+    @staticmethod
+    def _deserialize_phase_data(payload: str | None, model_cls):
+        if not payload:
+            return None
+        return deserialize_model(model_cls, json.loads(payload))
+
+    @staticmethod
+    def _raise_conflict_error(
+        *,
+        cursor: sqlite3.Cursor,
+        table_name: str,
+        row_id: int,
+        expected_version: int,
+        missing_message: str,
+    ) -> None:
+        return BaseRepository.raise_conflict_error(
+            cursor=cursor,
+            table_name=table_name,
+            row_id=row_id,
+            expected_version=expected_version,
+            missing_message=missing_message,
+        )
+
+    def _update_versioned_json_list(
+        self,
+        *,
+        cursor: sqlite3.Cursor,
+        table_name: str,
+        row_id: int,
+        column_name: str,
+        payload: list[dict],
+        updated_at: str,
+        expected_version: int | None,
+        missing_message: str,
+    ) -> bool:
+        return self._notes.update_versioned_json_list(
+            cursor=cursor,
+            table_name=table_name,
+            row_id=row_id,
+            column_name=column_name,
+            payload=payload,
+            updated_at=updated_at,
+            expected_version=expected_version,
+            missing_message=missing_message,
         )
 
     def get_record_by_cavity(

--- a/src/sc_linac_physics/applications/rf_commissioning/models/persistence/database_helpers.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/models/persistence/database_helpers.py
@@ -39,7 +39,7 @@ def serialize_measurement_data(measurement_data: Any) -> str:
 
 
 def parse_json_list(payload: str | None) -> list[dict]:
-    """Return a JSON list payload, tolerating missing or legacy values."""
+    """Return a JSON list payload, tolerating missing or invalid values."""
     if not payload:
         return []
 

--- a/src/sc_linac_physics/applications/rf_commissioning/phases/__init__.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/phases/__init__.py
@@ -1,0 +1,22 @@
+"""RF Commissioning Phases Package.
+
+This package contains the phase execution framework and phase implementations.
+"""
+
+from .phase_base import (
+    PhaseBase,
+    PhaseContext,
+    PhaseResult,
+    PhaseStepResult,
+    PhaseExecutionError,
+)
+from .piezo_pre_rf import PiezoPreRFPhase
+
+__all__ = [
+    "PhaseBase",
+    "PhaseContext",
+    "PhaseResult",
+    "PhaseStepResult",
+    "PhaseExecutionError",
+    "PiezoPreRFPhase",
+]

--- a/src/sc_linac_physics/applications/rf_commissioning/phases/piezo_pre_rf.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/phases/piezo_pre_rf.py
@@ -1,0 +1,416 @@
+"""
+Piezo Pre-RF Test Phase
+
+Validates piezo functionality before applying RF power by testing capacitance
+and frequency response of both piezo channels.
+"""
+
+import time
+from dataclasses import dataclass
+
+from sc_linac_physics.applications.rf_commissioning.models.commissioning_piezo import (
+    CommissioningPiezo,
+)
+from sc_linac_physics.applications.rf_commissioning.models.data_models import (
+    CommissioningPhase,
+    PiezoPreRFCheck,
+)
+from sc_linac_physics.applications.rf_commissioning.phases.phase_base import (
+    PhaseBase,
+    PhaseContext,
+    PhaseResult,
+    PhaseStepResult,
+    PhaseExecutionError,
+)
+from sc_linac_physics.utils.sc_linac.linac_utils import (
+    PIEZO_PRE_RF_CHECKOUT_PASS_VALUE,
+    PIEZO_SCRIPT_RUNNING_VALUE,
+)
+
+
+@dataclass
+class PiezoTestLimits:
+    """Configurable limits for piezo testing."""
+
+    # Test timeout (seconds)
+    test_timeout: float = 30.0
+
+    # Polling interval (seconds)
+    poll_interval: float = 0.5
+
+
+class PiezoPreRFPhase(PhaseBase):
+    """
+    Piezo Pre-RF Test Phase.
+
+    Tests piezo functionality without RF by:
+    1. Triggering automated capacitance/frequency tests
+    2. Monitoring test completion
+    3. Validating results against specifications
+
+    This phase runs the EPICS-based pre-RF checkout script and validates
+    that both piezo channels pass their tests.
+    """
+
+    def __init__(
+        self, context: PhaseContext, limits: PiezoTestLimits | None = None
+    ):
+        super().__init__(context)
+        self.limits = limits or PiezoTestLimits()
+
+        # Get cavity from context
+        self.cavity = None  # Will be set during prerequisite validation
+
+    @property
+    def phase_type(self) -> CommissioningPhase:
+        """Return the phase type."""
+        return CommissioningPhase.PIEZO_PRE_RF
+
+    def validate_prerequisites(self) -> tuple[bool, str]:
+        """
+        Validate that prerequisites are met before starting phase.
+
+        Returns:
+            Tuple of (is_valid, message)
+        """
+        # Get cavity from context parameters
+        cavity = self.context.parameters.get("cavity")
+
+        if cavity is None:
+            return False, "No cavity specified in context"
+
+        if not isinstance(cavity.piezo, CommissioningPiezo):
+            return False, (
+                f"Cavity must use CommissioningPiezo for pre-RF testing. "
+                f"Current type: {type(cavity.piezo).__name__}"
+            )
+
+        self.cavity = cavity
+        return True, "Prerequisites validated"
+
+    def get_phase_steps(self) -> list[str]:
+        """Return list of step names in execution order."""
+        return [
+            "verify_initial_state",
+            "setup_piezo",
+            "trigger_prerf_test",
+            "wait_for_completion",
+            "validate_results",
+        ]
+
+    def execute_step(self, step_name: str) -> PhaseStepResult:
+        """
+        Execute a single phase step.
+
+        Args:
+            step_name: Name of step to execute
+
+        Returns:
+            Result of step execution
+        """
+        if self.cavity is None:
+            raise PhaseExecutionError(
+                "Cavity not set - validate_prerequisites must be called first"
+            )
+
+        piezo = self.cavity.piezo
+
+        step_methods = {
+            "setup_piezo": lambda: self._setup_piezo(piezo),
+            "verify_initial_state": lambda: self._verify_initial_state(piezo),
+            "trigger_prerf_test": lambda: self._trigger_prerf_test(piezo),
+            "wait_for_completion": lambda: self._wait_for_completion(piezo),
+            "validate_results": lambda: self._validate_results(piezo),
+        }
+
+        if step_name not in step_methods:
+            return PhaseStepResult(
+                result=PhaseResult.FAILED,
+                message=f"Unknown step: {step_name}",
+            )
+
+        return step_methods[step_name]()
+
+    def finalize_phase(self) -> None:
+        """
+        Finalize phase and save results to commissioning record.
+        """
+        # Get the validation checkpoint data
+        validation_checkpoint = next(
+            (
+                cp
+                for cp in reversed(self.context.record.phase_history)
+                if cp.phase == self.phase_type
+                and cp.step_name == "validate_results"
+            ),
+            None,
+        )
+
+        if validation_checkpoint and validation_checkpoint.measurements:
+            data = validation_checkpoint.measurements
+
+            # Create PiezoPreRFCheck result
+            self.context.record.piezo_pre_rf = PiezoPreRFCheck(
+                capacitance_a=data.get("capacitance_a_nf", 0)
+                * 1e-9,  # Convert nF to F
+                capacitance_b=data.get("capacitance_b_nf", 0) * 1e-9,
+                channel_a_passed=data.get("channel_a_status")
+                == PIEZO_PRE_RF_CHECKOUT_PASS_VALUE,
+                channel_b_passed=data.get("channel_b_status")
+                == PIEZO_PRE_RF_CHECKOUT_PASS_VALUE,
+                notes=f"Ch A: {data.get('channel_a_message', '')}, Ch B: {data.get('channel_b_message', '')}",
+            )
+
+    # =========================================================================
+    # Phase Steps
+    # =========================================================================
+
+    def _setup_piezo(self, piezo: CommissioningPiezo) -> PhaseStepResult:
+        """Enable piezo, set to manual mode, and initialize DC voltage to 0."""
+        if self.context.dry_run:
+            return PhaseStepResult(
+                result=PhaseResult.SUCCESS,
+                message="[DRY RUN] Would setup piezo (enable, manual mode, DC=0V)",
+            )
+
+        try:
+            # Enable the piezo
+            piezo.enable()
+
+            # Set to manual mode
+            piezo.set_to_manual()
+
+            # Set DC voltage to 0
+            piezo.dc_setpoint = 0
+
+            return PhaseStepResult(
+                result=PhaseResult.SUCCESS,
+                message="Piezo setup complete (enabled, manual mode, DC=0V)",
+            )
+
+        except Exception as e:
+            return PhaseStepResult(
+                result=PhaseResult.FAILED,
+                message=f"Failed to setup piezo: {e}",
+            )
+
+    def _verify_initial_state(
+        self, piezo: CommissioningPiezo
+    ) -> PhaseStepResult:
+        """Verify piezo is ready for testing."""
+        if self.context.dry_run:
+            return PhaseStepResult(
+                result=PhaseResult.SUCCESS,
+                message="[DRY RUN] Would verify initial state",
+                data={
+                    "test_status": 1,  # Complete
+                    "channel_a_status": 0,  # Pass
+                    "channel_b_status": 0,  # Pass
+                },
+            )
+
+        try:
+            # Check if test is already running
+            test_status = piezo.prerf_test_status_pv_obj.get()
+
+            # Handle both int and string enum values
+            if isinstance(test_status, str):
+                is_running = test_status == "Running"
+            else:
+                is_running = test_status == PIEZO_SCRIPT_RUNNING_VALUE
+
+            if is_running:
+                return PhaseStepResult(
+                    result=PhaseResult.FAILED,
+                    message="Piezo test already in progress",
+                    data={"test_status": test_status},
+                )
+
+            # Status is Idle or Complete - both are valid starting states
+            # Check both channels are accessible
+            cha_status = piezo.prerf_cha_status_pv_obj.get()
+            chb_status = piezo.prerf_chb_status_pv_obj.get()
+
+            return PhaseStepResult(
+                result=PhaseResult.SUCCESS,
+                message="Piezo ready for testing",
+                data={
+                    "test_status": test_status,
+                    "channel_a_status": cha_status,
+                    "channel_b_status": chb_status,
+                },
+            )
+
+        except Exception as e:
+            return PhaseStepResult(
+                result=PhaseResult.FAILED,
+                message=f"Failed to verify initial state: {e}",
+            )
+
+    def _trigger_prerf_test(self, piezo: CommissioningPiezo) -> PhaseStepResult:
+        """Trigger the automated pre-RF test."""
+        try:
+            if self.context.dry_run:
+                return PhaseStepResult(
+                    result=PhaseResult.SUCCESS,
+                    message="[DRY RUN] Would trigger pre-RF test",
+                )
+
+            # Trigger the test
+            piezo.prerf_test_start_pv_obj.put(1)
+
+            # Wait briefly for trigger to process
+            time.sleep(0.5)
+
+            # Read the initial status - should be Running or might already be Complete
+            test_status = piezo.prerf_test_status_pv_obj.get(use_monitor=False)
+
+            # Handle both int and string
+            if isinstance(test_status, str):
+                is_crash = test_status == "Crash"
+            else:
+                is_crash = test_status == 0  # Crash
+
+            # Accept Running or Complete as valid (test triggered successfully)
+            # Only fail if it's in Crash state
+            if is_crash:
+                return PhaseStepResult(
+                    result=PhaseResult.FAILED,
+                    message=f"Failed to start test (status={test_status})",
+                    data={"test_status": test_status},
+                )
+
+            # Test triggered successfully (either Running or already Complete)
+            return PhaseStepResult(
+                result=PhaseResult.SUCCESS,
+                message="Test started successfully",
+                data={"test_status": test_status},
+            )
+
+        except Exception as e:
+            return PhaseStepResult(
+                result=PhaseResult.FAILED,
+                message=f"Failed to trigger test: {e}",
+            )
+
+    def _wait_for_completion(
+        self, piezo: CommissioningPiezo
+    ) -> PhaseStepResult:
+        """Wait for pre-RF test to complete."""
+        start_time = time.time()
+        timeout = self.limits.test_timeout
+        poll_interval = self.limits.poll_interval
+
+        try:
+            while True:
+                elapsed = time.time() - start_time
+
+                # Check for abort
+                if self.context.is_abort_requested():
+                    return PhaseStepResult(
+                        result=PhaseResult.FAILED,
+                        message="Test aborted by user",
+                        data={"elapsed_time": elapsed},
+                    )
+
+                if elapsed > timeout:
+                    return PhaseStepResult(
+                        result=PhaseResult.FAILED,
+                        message=f"Test timeout after {timeout}s",
+                        data={"elapsed_time": elapsed},
+                    )
+
+                # Check test status
+                test_status = piezo.prerf_test_status_pv_obj.get()
+
+                # Handle both int and string
+                if isinstance(test_status, str):
+                    is_running = test_status == "Running"
+                else:
+                    is_running = test_status == PIEZO_SCRIPT_RUNNING_VALUE
+
+                # Wait while running
+                if not is_running:
+                    return PhaseStepResult(
+                        result=PhaseResult.SUCCESS,
+                        message=f"Test completed in {elapsed:.1f}s",
+                        data={
+                            "elapsed_time": elapsed,
+                            "final_status": test_status,
+                        },
+                    )
+
+                # Still running, keep waiting
+                time.sleep(poll_interval)
+
+        except Exception as e:
+            return PhaseStepResult(
+                result=PhaseResult.FAILED,
+                message=f"Error while waiting: {e}",
+            )
+
+    def _validate_results(self, piezo: CommissioningPiezo) -> PhaseStepResult:
+        """
+        Validate the test results.
+
+        Handles both integer and string enum values from real/simulated EPICS.
+        """
+        try:
+            # Get channel statuses
+            cha_status = piezo.prerf_cha_status_pv_obj.get()
+            chb_status = piezo.prerf_chb_status_pv_obj.get()
+
+            # Get messages for diagnostics
+            cha_msg = piezo.prerf_cha_testmsg_pv_obj.get()
+            chb_msg = piezo.prerf_chb_testmsg_pv_obj.get()
+
+            # Get capacitance values
+            cap_a = piezo.capacitance_a_pv_obj.get()
+            cap_b = piezo.capacitance_b_pv_obj.get()
+
+            # Check if both channels passed - handle both int and string
+            def is_pass(status):
+                if isinstance(status, str):
+                    return status == "Pass"
+                else:
+                    return status == PIEZO_PRE_RF_CHECKOUT_PASS_VALUE
+
+            cha_passed = is_pass(cha_status)
+            chb_passed = is_pass(chb_status)
+            both_passed = cha_passed and chb_passed
+
+            # Build detailed message
+            if not both_passed:
+                messages = []
+                if not cha_passed:
+                    messages.append(
+                        f"Channel A failed (status={cha_status}): {cha_msg}"
+                    )
+                if not chb_passed:
+                    messages.append(
+                        f"Channel B failed (status={chb_status}): {chb_msg}"
+                    )
+                message = "; ".join(messages)
+                result = PhaseResult.FAILED
+            else:
+                message = f"All tests passed (Cap A={cap_a:.1f}nF, Cap B={cap_b:.1f}nF)"
+                result = PhaseResult.SUCCESS
+
+            return PhaseStepResult(
+                result=result,
+                message=message,
+                data={
+                    "channel_a_status": cha_status,
+                    "channel_b_status": chb_status,
+                    "channel_a_message": cha_msg,
+                    "channel_b_message": chb_msg,
+                    "capacitance_a_nf": cap_a,
+                    "capacitance_b_nf": cap_b,
+                },
+            )
+
+        except Exception as e:
+            return PhaseStepResult(
+                result=PhaseResult.FAILED,
+                message=f"Failed to validate results: {e}",
+            )

--- a/src/sc_linac_physics/applications/rf_commissioning/services/workflow_service.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/services/workflow_service.py
@@ -1,8 +1,8 @@
 """Normalized workflow orchestration service.
 
-This service introduces a phase-instance model independent from the legacy
-wide commissioning record schema. It is intentionally write-focused so the UI
-can adopt it incrementally while prototype workflows evolve rapidly.
+This service orchestrates a phase-instance model that is independent from the
+wide commissioning record shape. It is intentionally write-focused so the UI
+can adopt workflow features incrementally.
 """
 
 from __future__ import annotations

--- a/src/sc_linac_physics/applications/rf_commissioning/session_manager.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/session_manager.py
@@ -119,7 +119,7 @@ class CommissioningSession:
         artifact_payload: dict | None = None,
         artifact_type: str = "phase_result",
     ) -> bool:
-        """Complete a normalized phase instance (pure v2 lifecycle)."""
+        """Complete a normalized phase instance."""
         if self._active_record_id is None:
             return False
 
@@ -145,7 +145,7 @@ class CommissioningSession:
         artifact_payload: dict | None = None,
         artifact_type: str = "phase_failure_snapshot",
     ) -> bool:
-        """Fail a normalized phase instance (pure v2 lifecycle)."""
+        """Fail a normalized phase instance."""
         if self._active_record_id is None:
             return False
 
@@ -178,7 +178,7 @@ class CommissioningSession:
     def get_active_phase_projection(self) -> dict | None:
         """Return phase projection used by UI state components.
 
-        Uses normalized v2 data exclusively.
+        Uses normalized workflow data exclusively.
         """
         run = self.get_active_workflow_run()
         instances = self.get_active_phase_instances()

--- a/src/sc_linac_physics/cli/launchers.py
+++ b/src/sc_linac_physics/cli/launchers.py
@@ -153,6 +153,18 @@ def launch_tuning(standalone=True):
 
 
 @application
+def launch_rf_commissioning(standalone=True):
+    """Launch the RF commissioning multi-phase GUI."""
+    from sc_linac_physics.applications.rf_commissioning.ui.multi_phase_screen import (
+        MultiPhaseCommissioningDisplay,
+    )
+
+    return launch_python_display(
+        MultiPhaseCommissioningDisplay, *sys.argv[1:], standalone=standalone
+    )
+
+
+@application
 def launch_microphonics(standalone=True):
     """Launch the microphonics GUI."""
     from sc_linac_physics.applications.microphonics.gui.main_window import (

--- a/src/sc_linac_physics/utils/sc_linac/piezo.py
+++ b/src/sc_linac_physics/utils/sc_linac/piezo.py
@@ -1,7 +1,7 @@
 import time
 from typing import Optional, TYPE_CHECKING
 
-from sc_linac_physics.utils.epics import PV
+from sc_linac_physics.utils.epics import PV, PVGetError
 from sc_linac_physics.utils.sc_linac import linac_utils
 
 if TYPE_CHECKING:
@@ -14,6 +14,9 @@ class Piezo(linac_utils.SCLinacObject):
     functions for toggling feedback mode and changing bias voltage and DC offset
 
     """
+
+    ENABLE_MAX_ATTEMPTS = 10
+    FEEDBACK_MAX_ATTEMPTS = 10
 
     def __init__(self, cavity: "Cavity"):
         """
@@ -142,7 +145,29 @@ class Piezo(linac_utils.SCLinacObject):
     def is_enabled(self) -> bool:
         if not self._enable_stat_pv_obj:
             self._enable_stat_pv_obj = PV(self.enable_stat_pv)
-        return self._enable_stat_pv_obj.get() == linac_utils.PIEZO_ENABLE_VALUE
+
+        try:
+            return (
+                self._enable_stat_pv_obj.get(use_monitor=False)
+                == linac_utils.PIEZO_ENABLE_VALUE
+            )
+        except PVGetError as exc:
+            self.cavity.logger.warning(
+                "Failed to read ENABLESTAT, falling back to ENABLE command PV",
+                extra={
+                    "extra_data": {
+                        "error": str(exc),
+                        "piezo": str(self),
+                    }
+                },
+            )
+            try:
+                return (
+                    self.enable_pv_obj.get(use_monitor=False)
+                    == linac_utils.PIEZO_ENABLE_VALUE
+                )
+            except Exception:
+                return False
 
     @property
     def feedback_control_pv_obj(self) -> PV:
@@ -154,7 +179,20 @@ class Piezo(linac_utils.SCLinacObject):
     def feedback_stat(self):
         if not self._feedback_stat_pv_obj:
             self._feedback_stat_pv_obj = PV(self.feedback_stat_pv)
-        return self._feedback_stat_pv_obj.get()
+
+        try:
+            return self._feedback_stat_pv_obj.get(use_monitor=False)
+        except PVGetError as exc:
+            self.cavity.logger.warning(
+                "Failed to read MODESTAT, falling back to MODECTRL command PV",
+                extra={
+                    "extra_data": {
+                        "error": str(exc),
+                        "piezo": str(self),
+                    }
+                },
+            )
+            return self.feedback_control_pv_obj.get(use_monitor=False)
 
     @property
     def in_manual(self) -> bool:
@@ -179,6 +217,26 @@ class Piezo(linac_utils.SCLinacObject):
         while not self.is_enabled:
             self.cavity.check_abort()
             attempt += 1
+            if attempt > self.ENABLE_MAX_ATTEMPTS:
+                message = (
+                    f"Piezo failed to enable after {self.ENABLE_MAX_ATTEMPTS} "
+                    "attempts"
+                )
+                self.cavity.logger.error(
+                    message,
+                    extra={
+                        "extra_data": {
+                            "attempt": attempt - 1,
+                            "enable_status": (
+                                self._enable_stat_pv_obj.value_or_none
+                                if self._enable_stat_pv_obj
+                                else None
+                            ),
+                            "piezo": str(self),
+                        }
+                    },
+                )
+                raise RuntimeError(message)
             self.cavity.logger.debug(
                 "Piezo not enabled, attempting to enable (attempt %d)",
                 attempt,
@@ -186,7 +244,7 @@ class Piezo(linac_utils.SCLinacObject):
                     "extra_data": {
                         "attempt": attempt,
                         "enable_status": (
-                            self._enable_stat_pv_obj.get()
+                            self._enable_stat_pv_obj.value_or_none
                             if self._enable_stat_pv_obj
                             else None
                         ),
@@ -214,6 +272,22 @@ class Piezo(linac_utils.SCLinacObject):
         while self.in_manual:
             self.cavity.check_abort()
             attempt += 1
+            if attempt > self.FEEDBACK_MAX_ATTEMPTS:
+                message = (
+                    "Piezo feedback failed to enable after "
+                    f"{self.FEEDBACK_MAX_ATTEMPTS} attempts"
+                )
+                self.cavity.logger.error(
+                    message,
+                    extra={
+                        "extra_data": {
+                            "attempt": attempt - 1,
+                            "feedback_stat": self.feedback_stat,
+                            "piezo": str(self),
+                        }
+                    },
+                )
+                raise RuntimeError(message)
             self.cavity.logger.debug(
                 "Piezo feedback not enabled, attempting to enable (attempt %d)",
                 attempt,
@@ -249,6 +323,22 @@ class Piezo(linac_utils.SCLinacObject):
         while not self.in_manual:
             self.cavity.check_abort()
             attempt += 1
+            if attempt > self.FEEDBACK_MAX_ATTEMPTS:
+                message = (
+                    "Piezo feedback failed to disable after "
+                    f"{self.FEEDBACK_MAX_ATTEMPTS} attempts"
+                )
+                self.cavity.logger.error(
+                    message,
+                    extra={
+                        "extra_data": {
+                            "attempt": attempt - 1,
+                            "feedback_stat": self.feedback_stat,
+                            "piezo": str(self),
+                        }
+                    },
+                )
+                raise RuntimeError(message)
             self.cavity.logger.debug(
                 "Piezo feedback still enabled, attempting to disable (attempt %d)",
                 attempt,

--- a/src/sc_linac_physics/utils/simulation/tuner_service.py
+++ b/src/sc_linac_physics/utils/simulation/tuner_service.py
@@ -151,11 +151,29 @@ class StepperPVGroup(PVGroup):
 
 
 class PiezoPVGroup(PVGroup):
-    enable: PvpropertyEnum = pvproperty(name="ENABLE")
+    simulate_failure = pvproperty(
+        name="SIM_FAIL",
+        value=0,
+        dtype=ChannelType.ENUM,
+        enum_strings=(
+            "No Failure",
+            "Channel A Fail (Low Cap)",
+            "Channel B Fail (Low Cap)",
+            "Both Fail (No Connection)",
+            "Channel A Fail (High Cap)",
+            "Timeout",
+        ),
+    )
+    enable: PvpropertyEnum = pvproperty(
+        name="ENABLE",
+        value=0,
+        dtype=ChannelType.ENUM,
+        enum_strings=("Disable", "Enable"),
+    )
     enable_stat = pvproperty(
         name="ENABLESTAT",
         dtype=ChannelType.ENUM,
-        value=1,
+        value=0,
         enum_strings=("Disabled", "Enabled"),
     )
     feedback_mode = pvproperty(
@@ -170,46 +188,89 @@ class PiezoPVGroup(PVGroup):
         dtype=ChannelType.ENUM,
         enum_strings=("Manual", "Feedback"),
     )
-    dc_setpoint = pvproperty(name="DAC_SP")
-    bias_voltage = pvproperty(name="BIAS")
-    prerf_test_start = pvproperty(name="TESTSTRT")
-    prerf_cha_status = pvproperty(name="CHA_TESTSTAT")
-    prerf_chb_status = pvproperty(name="CHB_TESTSTAT")
-    prerf_cha_testmsg = pvproperty(name="CHA_TESTMSG1")
-    prerf_chb_testmsg = pvproperty(name="CHA_TESTMSG2")
-    capacitance_a = pvproperty(name="CHA_C")
-    capacitance_b = pvproperty(name="CHB_C")
+    dc_setpoint = pvproperty(name="DAC_SP", value=0.0, dtype=ChannelType.FLOAT)
+    bias_voltage = pvproperty(name="BIAS", value=0.0, dtype=ChannelType.FLOAT)
+
+    # Pre-RF Test PVs
+    prerf_test_start = pvproperty(name="TESTSTRT", value=0)
+    prerf_cha_status = pvproperty(
+        name="CHA_TESTSTAT",
+        dtype=ChannelType.ENUM,
+        value=0,
+        enum_strings=(
+            "Pass",
+            "Fail",
+            "Not Tested",
+        ),
+    )
+
+    prerf_chb_status = pvproperty(
+        name="CHB_TESTSTAT",
+        dtype=ChannelType.ENUM,
+        value=0,
+        enum_strings=("Pass", "Fail", "Not Tested"),
+    )
+    prerf_cha_testmsg = pvproperty(
+        name="CHA_TESTMSG1", value="", dtype=ChannelType.STRING
+    )
+    prerf_chb_testmsg = pvproperty(
+        name="CHA_TESTMSG2",
+        value="",
+        dtype=ChannelType.STRING,
+    )
+    capacitance_a: PvpropertyFloat = pvproperty(
+        name="CHA_C", value=0.0, dtype=ChannelType.FLOAT
+    )
+    capacitance_b: PvpropertyFloat = pvproperty(
+        name="CHB_C", value=0.0, dtype=ChannelType.FLOAT
+    )
     prerf_test_status: PvpropertyEnum = pvproperty(
         name="TESTSTS",
         dtype=ChannelType.ENUM,
-        value=0,
-        enum_strings=("", "Complete", "Running"),
+        value=1,
+        enum_strings=("Crash", "Complete", "Running"),
     )
-    withrf_run_check = pvproperty(name="RFTESTSTRT")
+
+    # With-RF Test PVs
+    withrf_run_check = pvproperty(name="RFTESTSTRT", value=0)
     withrf_check_status: PvpropertyEnum = pvproperty(
         name="RFTESTSTS",
         dtype=ChannelType.ENUM,
-        value=1,
-        enum_strings=("", "Complete", "Running"),
+        value=0,
+        enum_strings=("Idle", "Complete", "Running"),
     )
-    withrf_status = pvproperty(name="RFSTESTSTAT")
-    amplifiergain_a = pvproperty(name="CHA_AMPGAIN")
-    amplifiergain_b = pvproperty(name="CHB_AMPGAIN")
-    withrf_push_dfgain = pvproperty(name="PUSH_DFGAIN.PROC")
-    withrf_save_dfgain = pvproperty(name="SAVE_DFGAIN.PROC")
-    detunegain_new = pvproperty(name="DFGAIN_NEW")
+    withrf_status = pvproperty(
+        name="RFSTESTSTAT",
+        dtype=ChannelType.ENUM,
+        value=0,
+        enum_strings=("Not Tested", "Pass", "Fail"),
+    )
+    amplifiergain_a = pvproperty(
+        name="CHA_AMPGAIN", value=0.0, dtype=ChannelType.FLOAT
+    )
+    amplifiergain_b = pvproperty(
+        name="CHB_AMPGAIN", value=0.0, dtype=ChannelType.FLOAT
+    )
+    withrf_push_dfgain = pvproperty(name="PUSH_DFGAIN.PROC", value=0)
+    withrf_save_dfgain = pvproperty(name="SAVE_DFGAIN.PROC", value=0)
+    detunegain_new = pvproperty(
+        name="DFGAIN_NEW", value=0.0, dtype=ChannelType.FLOAT
+    )
+
+    # Status PVs
     hardware_sum = pvproperty(
         value=0,
         name="HWSTATSUM",
         dtype=ChannelType.ENUM,
-        enum_strings=("", "Minor Fault", "Fault"),
+        enum_strings=("OK", "Minor Fault", "Fault"),
     )
     feedback_sum = pvproperty(
         value=0,
         name="FBSTATSUM",
         dtype=ChannelType.ENUM,
-        enum_strings=("", "Minor Fault", "Fault"),
+        enum_strings=("OK", "Minor Fault", "Fault"),
     )
+
     integrator_sp: PvpropertyFloat = pvproperty(
         name="INTEG_SP", value=0, dtype=ChannelType.FLOAT
     )
@@ -226,12 +287,140 @@ class PiezoPVGroup(PVGroup):
         super().__init__(prefix)
         self.cavity_group: CavityPVGroup = cavity_group
 
+    @enable.putter
+    async def enable(self, instance, value):
+        """Update enable status when enable command is issued."""
+        if isinstance(value, str):
+            is_enabled = value in ("Enable", "Enabled")
+        else:
+            is_enabled = int(value) == 1
+
+        await self.enable_stat.write(1 if is_enabled else 0)
+        if not is_enabled:  # Disabled
+            # Optionally reset feedback mode to manual
+            await self.feedback_mode_stat.write(0)
+        return value
+
     @prerf_test_start.putter
     async def prerf_test_start(self, instance, value):
-        await self.prerf_test_status.write("Running")
-        await sleep(5)
-        await self.prerf_test_status.write("Complete")
+        """Simulate pre-RF test execution."""
+        if value == 0:
+            return value
+
+        print("Starting Pre-RF test simulation...")
+
+        # Set test status to Running (index 2)
+        await self.prerf_test_status.write(2)  # Running
+
+        # Reset previous test results to "Not Tested" (index 2)
+        await self.prerf_cha_status.write(2)  # Not Tested
+        await self.prerf_chb_status.write(2)  # Not Tested
+        await self.capacitance_a.write(0.0)
+        await self.capacitance_b.write(0.0)
+        await self.prerf_cha_testmsg.write("Testing...")
+        await self.prerf_chb_testmsg.write("Testing...")
+
+        await sleep(1)
+
+        # Get failure mode - it's already an integer!
+        fail_mode = self.simulate_failure.value  # Already 0, 1, 2, 3, 4, or 5
+
+        if fail_mode == 0:  # No failure
+            await self.prerf_cha_status.write(0)  # Pass
+            await self.prerf_chb_status.write(0)  # Pass
+            await self.capacitance_a.write(25.3)
+            await self.capacitance_b.write(24.8)
+            await self.prerf_cha_testmsg.write("Test passed")
+            await self.prerf_chb_testmsg.write("Test passed")
+
+        elif fail_mode == 1:  # Channel A fails
+            await self.prerf_cha_status.write(1)  # Fail
+            await self.prerf_chb_status.write(0)  # Pass
+            await self.capacitance_a.write(10.5)
+            await self.capacitance_b.write(24.8)
+            await self.prerf_cha_testmsg.write("Low capacitance detected")
+            await self.prerf_chb_testmsg.write("Test passed")
+
+        elif fail_mode == 2:  # Channel B fails
+            await self.prerf_cha_status.write(0)
+            await self.prerf_chb_status.write(1)
+            await self.capacitance_a.write(25.3)
+            await self.capacitance_b.write(5.2)
+            await self.prerf_cha_testmsg.write("Test passed")
+            await self.prerf_chb_testmsg.write("Low capacitance detected")
+
+        elif fail_mode == 3:  # Both channels fail
+            await self.prerf_cha_status.write(1)
+            await self.prerf_chb_status.write(1)
+            await self.capacitance_a.write(0.1)
+            await self.capacitance_b.write(0.2)
+            await self.prerf_cha_testmsg.write("No connection detected")
+            await self.prerf_chb_testmsg.write("No connection detected")
+
+        elif fail_mode == 4:  # High capacitance
+            await self.prerf_cha_status.write(1)
+            await self.prerf_chb_status.write(0)
+            await self.capacitance_a.write(45.7)
+            await self.capacitance_b.write(24.8)
+            await self.prerf_cha_testmsg.write("High capacitance detected")
+            await self.prerf_chb_testmsg.write("Test passed")
+
+        elif fail_mode == 5:  # Timeout
+            await self.prerf_cha_status.write(1)
+            await self.prerf_chb_status.write(1)
+            await self.capacitance_a.write(0.0)
+            await self.capacitance_b.write(0.0)
+            await self.prerf_cha_testmsg.write("Test timeout")
+            await self.prerf_chb_testmsg.write("Test timeout")
+
+        else:  # Unknown
+            await self.prerf_cha_status.write(1)
+            await self.prerf_chb_status.write(1)
+            await self.prerf_cha_testmsg.write("Unknown failure mode")
+            await self.prerf_chb_testmsg.write("Unknown failure mode")
+
+        # Set test status to Complete
+        await self.prerf_test_status.write(1)  # Complete
+
+        # Determine overall result - compare to strings!
+        overall_pass = (
+            self.prerf_cha_status.value == "Pass"
+            and self.prerf_chb_status.value == "Pass"
+        )
+
+        if overall_pass:
+            print("Pre-RF test complete: PASS")
+        else:
+            print("Pre-RF test complete: FAIL")
+
+        return value
 
     @feedback_mode.putter
     async def feedback_mode(self, instance, value):
+        """Update feedback mode status."""
+        if self.enable_stat.value == 0:
+            print("Warning: Cannot change feedback mode while disabled")
+            return instance.value  # Don't change if disabled
         await self.feedback_mode_stat.write(value)
+        return value
+
+    @withrf_run_check.putter
+    async def withrf_run_check(self, instance, value):
+        """Simulate with-RF test execution."""
+        if value == 0:
+            return value
+
+        print("Starting With-RF test simulation...")
+        await self.withrf_check_status.write(2)  # Running
+        await self.withrf_status.write(0)  # Reset status
+
+        await sleep(3)
+
+        # Simulate successful with-RF test
+        await self.withrf_status.write(1)  # Pass
+        await self.amplifiergain_a.write(1.05)
+        await self.amplifiergain_b.write(0.98)
+
+        await self.withrf_check_status.write(1)  # Complete
+        print("With-RF test complete: PASS")
+        return value

--- a/tests/applications/rf_commissioning/models/test_data_models.py
+++ b/tests/applications/rf_commissioning/models/test_data_models.py
@@ -221,25 +221,6 @@ class TestCommissioningRecord:
         )
         assert record.is_complete is True
 
-    def test_advance_to_next_phase_requires_current_complete(self):
-        record = CommissioningRecord(
-            linac=1,
-            cryomodule="02",
-            cavity_number=3,
-        )
-
-        success, message = record.advance_to_next_phase()
-        assert success is False
-        assert "is not complete" in message
-
-        record.set_phase_status(
-            CommissioningPhase.PIEZO_PRE_RF, PhaseStatus.COMPLETE
-        )
-        success, message = record.advance_to_next_phase()
-        assert success is True
-        assert record.current_phase == CommissioningPhase.SSA_CHAR
-        assert "Advanced to ssa_char" == message
-
     def test_checkpoint_helpers(self):
         record = CommissioningRecord(
             linac=1,

--- a/tests/applications/rf_commissioning/phases/test_phase_base.py
+++ b/tests/applications/rf_commissioning/phases/test_phase_base.py
@@ -1,0 +1,78 @@
+"""Tests for shared PhaseBase retry behavior."""
+
+from sc_linac_physics.applications.rf_commissioning.models.data_models import (
+    CommissioningPhase,
+    CommissioningRecord,
+)
+from sc_linac_physics.applications.rf_commissioning.phases.phase_base import (
+    PhaseBase,
+    PhaseContext,
+    PhaseResult,
+    PhaseStepResult,
+)
+
+
+class _RetryBehaviorPhase(PhaseBase):
+    def __init__(self, context: PhaseContext, outcomes, sleep_calls):
+        super().__init__(context=context, sleep_fn=sleep_calls.append)
+        self._outcomes = list(outcomes)
+
+    @property
+    def phase_type(self) -> CommissioningPhase:
+        return CommissioningPhase.PIEZO_PRE_RF
+
+    def validate_prerequisites(self) -> tuple[bool, str]:
+        return True, "ok"
+
+    def get_phase_steps(self) -> list[str]:
+        return ["single_step"]
+
+    def execute_step(self, step_name: str) -> PhaseStepResult:
+        outcome = self._outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    def finalize_phase(self) -> None:
+        return None
+
+
+def _new_context() -> PhaseContext:
+    return PhaseContext(
+        record=CommissioningRecord(linac=1, cryomodule="02", cavity_number=1),
+        operator="tester",
+    )
+
+
+def test_retry_result_honors_retry_delay_seconds():
+    sleep_calls = []
+    phase = _RetryBehaviorPhase(
+        context=_new_context(),
+        outcomes=[
+            PhaseStepResult(
+                result=PhaseResult.RETRY,
+                message="temporary issue",
+                retry_delay_seconds=1.25,
+            ),
+            PhaseStepResult(result=PhaseResult.SUCCESS, message="done"),
+        ],
+        sleep_calls=sleep_calls,
+    )
+
+    assert phase.run() is True
+    assert sleep_calls == [1.25]
+
+
+def test_exception_retry_uses_default_backoff_delay():
+    sleep_calls = []
+    phase = _RetryBehaviorPhase(
+        context=_new_context(),
+        outcomes=[
+            RuntimeError("transient failure"),
+            PhaseStepResult(result=PhaseResult.SUCCESS, message="done"),
+        ],
+        sleep_calls=sleep_calls,
+    )
+
+    assert phase.run() is True
+    assert sleep_calls == [5.0]

--- a/tests/applications/rf_commissioning/phases/test_piezo_pre_rf.py
+++ b/tests/applications/rf_commissioning/phases/test_piezo_pre_rf.py
@@ -1,0 +1,723 @@
+"""
+Tests for Piezo Pre-RF Phase
+"""
+
+from datetime import datetime
+from unittest.mock import Mock
+
+import pytest
+
+from sc_linac_physics.applications.rf_commissioning.models.commissioning_piezo import (
+    CommissioningPiezo,
+)
+from sc_linac_physics.applications.rf_commissioning.models.data_models import (
+    CommissioningRecord,
+    CommissioningPhase,
+    PhaseStatus,
+)
+from sc_linac_physics.applications.rf_commissioning.phases.phase_base import (
+    PhaseContext,
+    PhaseResult,
+)
+from sc_linac_physics.applications.rf_commissioning.phases.piezo_pre_rf import (
+    PiezoPreRFPhase,
+    PiezoTestLimits,
+)
+from sc_linac_physics.utils.sc_linac.linac_utils import (
+    PIEZO_PRE_RF_CHECKOUT_PASS_VALUE,
+    PIEZO_SCRIPT_RUNNING_VALUE,
+)
+
+
+@pytest.fixture
+def mock_cavity():
+    """Create a mock cavity with CommissioningPiezo."""
+    cavity = Mock()
+    cavity.piezo = Mock(spec=CommissioningPiezo)
+    cavity.__str__ = Mock(return_value="CM02_CAV1")
+    return cavity
+
+
+@pytest.fixture
+def mock_piezo_pvs(mock_cavity):
+    """Setup mock PV objects for piezo testing."""
+    piezo = mock_cavity.piezo
+
+    # Setup methods
+    piezo.enable = Mock()
+    piezo.set_to_manual = Mock()
+    piezo.dc_setpoint_pv_obj = Mock()
+
+    # Create a mock property for dc_setpoint setter
+    type(piezo).dc_setpoint = Mock(
+        **{
+            "__set__": Mock(return_value=None),
+            "__get__": Mock(return_value=0),
+        }
+    )
+
+    # Initial state PVs
+    piezo.prerf_test_status_pv_obj = Mock()
+    piezo.prerf_cha_status_pv_obj = Mock()
+    piezo.prerf_chb_status_pv_obj = Mock()
+
+    # Test control PVs
+    piezo.prerf_test_start_pv_obj = Mock()
+
+    # Result PVs
+    piezo.prerf_cha_testmsg_pv_obj = Mock()
+    piezo.prerf_chb_testmsg_pv_obj = Mock()
+    piezo.capacitance_a_pv_obj = Mock()
+    piezo.capacitance_b_pv_obj = Mock()
+
+    return piezo
+
+
+@pytest.fixture
+def commissioning_record(mock_cavity):
+    """Create a commissioning record."""
+    return CommissioningRecord(
+        linac=1,
+        cryomodule="02",
+        cavity_number=1,
+    )
+
+
+@pytest.fixture
+def context(mock_cavity, commissioning_record):
+    """Create phase context."""
+    return PhaseContext(
+        record=commissioning_record,
+        operator="test_operator",
+        dry_run=False,
+        parameters={"cavity": mock_cavity},
+    )
+
+
+@pytest.fixture
+def phase(context):
+    """Create phase with short timeout for testing."""
+    return PiezoPreRFPhase(
+        context=context,
+        limits=PiezoTestLimits(
+            test_timeout=5.0,
+            poll_interval=0.1,
+        ),
+    )
+
+
+class TestPiezoPreRFPhase:
+    """Test suite for PiezoPreRFPhase."""
+
+    def test_phase_type(self, phase):
+        """Test that phase type is correct."""
+        assert phase.phase_type == CommissioningPhase.PIEZO_PRE_RF
+
+    def test_prerequisite_validation_success(self, phase, mock_cavity):
+        """Test successful prerequisite validation."""
+        is_valid, message = phase.validate_prerequisites()
+
+        assert is_valid
+        assert "validated" in message.lower()
+        assert phase.cavity is mock_cavity
+
+    def test_prerequisite_validation_no_cavity(self, context):
+        """Test prerequisite validation fails when no cavity."""
+        context.parameters.pop("cavity")
+        phase = PiezoPreRFPhase(context)
+
+        is_valid, message = phase.validate_prerequisites()
+
+        assert not is_valid
+        assert "no cavity" in message.lower()
+
+    def test_prerequisite_validation_wrong_piezo_type(self, context):
+        """Test prerequisite validation fails with wrong piezo type."""
+        # Replace with non-CommissioningPiezo
+        context.parameters["cavity"].piezo = Mock()
+        phase = PiezoPreRFPhase(context)
+
+        is_valid, message = phase.validate_prerequisites()
+
+        assert not is_valid
+        assert "CommissioningPiezo" in message
+
+    def test_get_phase_steps(self, phase):
+        """Test that phase steps are returned in correct order."""
+        steps = phase.get_phase_steps()
+
+        assert len(steps) == 5
+        assert steps[0] == "verify_initial_state"
+        assert steps[1] == "setup_piezo"
+        assert steps[2] == "trigger_prerf_test"
+        assert steps[3] == "wait_for_completion"
+        assert steps[4] == "validate_results"
+
+    def test_successful_run(self, phase, mock_piezo_pvs):
+        """Test successful complete phase run."""
+        # Setup successful test scenario
+        mock_piezo_pvs.prerf_test_status_pv_obj.get.side_effect = [
+            0,  # Initial: not running
+            PIEZO_SCRIPT_RUNNING_VALUE,  # After start: running
+            PIEZO_SCRIPT_RUNNING_VALUE,  # Still running
+            0,  # Completed
+        ]
+
+        # Both channels pass
+        mock_piezo_pvs.prerf_cha_status_pv_obj.get.return_value = (
+            PIEZO_PRE_RF_CHECKOUT_PASS_VALUE
+        )
+        mock_piezo_pvs.prerf_chb_status_pv_obj.get.return_value = (
+            PIEZO_PRE_RF_CHECKOUT_PASS_VALUE
+        )
+
+        # Messages
+        mock_piezo_pvs.prerf_cha_testmsg_pv_obj.get.return_value = "OK"
+        mock_piezo_pvs.prerf_chb_testmsg_pv_obj.get.return_value = "OK"
+
+        # Capacitance values
+        mock_piezo_pvs.capacitance_a_pv_obj.get.return_value = 25.3
+        mock_piezo_pvs.capacitance_b_pv_obj.get.return_value = 24.8
+
+        # Run phase
+        success = phase.run()
+
+        # Verify results
+        assert success
+        assert (
+            phase.context.record.phase_status[CommissioningPhase.PIEZO_PRE_RF]
+            == PhaseStatus.COMPLETE
+        )
+
+        # Verify test was triggered
+        mock_piezo_pvs.prerf_test_start_pv_obj.put.assert_called_once_with(1)
+
+        # Verify data was saved
+        assert phase.context.record.piezo_pre_rf is not None
+        assert phase.context.record.piezo_pre_rf.channel_a_passed
+        assert phase.context.record.piezo_pre_rf.channel_b_passed
+
+    def test_setup_piezo_success(self, phase, mock_piezo_pvs):
+        """Test setup_piezo step success."""
+        phase.validate_prerequisites()
+
+        result = phase.execute_step("setup_piezo")
+
+        assert result.result == PhaseResult.SUCCESS
+        assert "setup complete" in result.message.lower()
+
+        # Verify enable, set_to_manual, and dc_setpoint were called
+        mock_piezo_pvs.enable.assert_called_once()
+        mock_piezo_pvs.set_to_manual.assert_called_once()
+        # Check that dc_setpoint was set to 0
+        # Since dc_setpoint is a property with a setter, we check if it was called
+
+    def test_setup_piezo_dry_run(self, phase, mock_piezo_pvs):
+        """Test setup_piezo in dry run mode."""
+        phase.context.dry_run = True
+        phase.validate_prerequisites()
+
+        result = phase.execute_step("setup_piezo")
+
+        assert result.result == PhaseResult.SUCCESS
+        assert "dry run" in result.message.lower()
+
+        # Verify enable and set_to_manual were NOT called in dry run
+        mock_piezo_pvs.enable.assert_not_called()
+        mock_piezo_pvs.set_to_manual.assert_not_called()
+
+    def test_verify_initial_state_success(self, phase, mock_piezo_pvs):
+        """Test verify_initial_state step success."""
+        phase.validate_prerequisites()
+
+        mock_piezo_pvs.prerf_test_status_pv_obj.get.return_value = 0
+        mock_piezo_pvs.prerf_cha_status_pv_obj.get.return_value = 0
+        mock_piezo_pvs.prerf_chb_status_pv_obj.get.return_value = 0
+
+        result = phase.execute_step("verify_initial_state")
+
+        assert result.result == PhaseResult.SUCCESS
+        assert "ready" in result.message.lower()
+
+    def test_verify_initial_state_already_running(self, phase, mock_piezo_pvs):
+        """Test verify_initial_state fails when test already running."""
+        phase.validate_prerequisites()
+
+        mock_piezo_pvs.prerf_test_status_pv_obj.get.return_value = (
+            PIEZO_SCRIPT_RUNNING_VALUE
+        )
+
+        result = phase.execute_step("verify_initial_state")
+
+        assert result.result == PhaseResult.FAILED
+        assert "already in progress" in result.message.lower()
+
+    def test_trigger_prerf_test_success(self, phase, mock_piezo_pvs):
+        """Test trigger_prerf_test step success."""
+        phase.validate_prerequisites()
+
+        mock_piezo_pvs.prerf_test_status_pv_obj.get.return_value = (
+            PIEZO_SCRIPT_RUNNING_VALUE
+        )
+
+        result = phase.execute_step("trigger_prerf_test")
+
+        assert result.result == PhaseResult.SUCCESS
+        assert "started successfully" in result.message.lower()
+        mock_piezo_pvs.prerf_test_start_pv_obj.put.assert_called_once_with(1)
+
+    def test_trigger_prerf_test_dry_run(self, phase, mock_piezo_pvs):
+        """Test trigger_prerf_test in dry run mode."""
+        phase.context.dry_run = True
+        phase.validate_prerequisites()
+
+        result = phase.execute_step("trigger_prerf_test")
+
+        assert result.result == PhaseResult.SUCCESS
+        assert "DRY RUN" in result.message
+        mock_piezo_pvs.prerf_test_start_pv_obj.put.assert_not_called()
+
+    def test_trigger_prerf_test_fails_to_start(self, phase, mock_piezo_pvs):
+        """Test trigger_prerf_test fails when test doesn't start."""
+        phase.validate_prerequisites()
+
+        mock_piezo_pvs.prerf_test_status_pv_obj.get.return_value = (
+            0  # Still not running
+        )
+
+        result = phase.execute_step("trigger_prerf_test")
+
+        assert result.result == PhaseResult.FAILED
+        assert "failed to start" in result.message.lower()
+
+    def test_wait_for_completion_success(self, phase, mock_piezo_pvs):
+        """Test wait_for_completion step success."""
+        phase.validate_prerequisites()
+
+        # Simulate test running then completing
+        mock_piezo_pvs.prerf_test_status_pv_obj.get.side_effect = [
+            PIEZO_SCRIPT_RUNNING_VALUE,
+            PIEZO_SCRIPT_RUNNING_VALUE,
+            0,  # Completed
+        ]
+
+        result = phase.execute_step("wait_for_completion")
+
+        assert result.result == PhaseResult.SUCCESS
+        assert "completed" in result.message.lower()
+        assert "elapsed_time" in result.data
+
+    def test_wait_for_completion_timeout(self, phase, mock_piezo_pvs):
+        """Test wait_for_completion timeout."""
+        phase.validate_prerequisites()
+
+        # Keep this timeout-path test fast while preserving behavior.
+        phase.limits.test_timeout = 0.02
+        phase.limits.poll_interval = 0.001
+
+        # Test never completes
+        mock_piezo_pvs.prerf_test_status_pv_obj.get.return_value = (
+            PIEZO_SCRIPT_RUNNING_VALUE
+        )
+
+        result = phase.execute_step("wait_for_completion")
+
+        assert result.result == PhaseResult.FAILED
+        assert "timeout" in result.message.lower()
+
+    def test_wait_for_completion_abort(self, phase, mock_piezo_pvs):
+        """Test wait_for_completion handles abort request."""
+        phase.validate_prerequisites()
+
+        # Request abort
+        phase.context.request_abort()
+
+        mock_piezo_pvs.prerf_test_status_pv_obj.get.return_value = (
+            PIEZO_SCRIPT_RUNNING_VALUE
+        )
+
+        result = phase.execute_step("wait_for_completion")
+
+        assert result.result == PhaseResult.FAILED
+        assert "aborted" in result.message.lower()
+
+    def test_validate_results_success(self, phase, mock_piezo_pvs):
+        """Test validate_results step with passing results."""
+        phase.validate_prerequisites()
+
+        mock_piezo_pvs.prerf_cha_status_pv_obj.get.return_value = (
+            PIEZO_PRE_RF_CHECKOUT_PASS_VALUE
+        )
+        mock_piezo_pvs.prerf_chb_status_pv_obj.get.return_value = (
+            PIEZO_PRE_RF_CHECKOUT_PASS_VALUE
+        )
+        mock_piezo_pvs.prerf_cha_testmsg_pv_obj.get.return_value = "OK"
+        mock_piezo_pvs.prerf_chb_testmsg_pv_obj.get.return_value = "OK"
+        mock_piezo_pvs.capacitance_a_pv_obj.get.return_value = 25.3
+        mock_piezo_pvs.capacitance_b_pv_obj.get.return_value = 24.8
+
+        result = phase.execute_step("validate_results")
+
+        assert result.result == PhaseResult.SUCCESS
+        assert "passed" in result.message.lower()
+        assert (
+            result.data["channel_a_status"] == PIEZO_PRE_RF_CHECKOUT_PASS_VALUE
+        )
+        assert (
+            result.data["channel_b_status"] == PIEZO_PRE_RF_CHECKOUT_PASS_VALUE
+        )
+        assert result.data["capacitance_a_nf"] == 25.3
+        assert result.data["capacitance_b_nf"] == 24.8
+
+    def test_validate_results_channel_a_fails(self, phase, mock_piezo_pvs):
+        """Test validate_results with Channel A failure."""
+        phase.validate_prerequisites()
+
+        mock_piezo_pvs.prerf_cha_status_pv_obj.get.return_value = 1  # Not pass
+        mock_piezo_pvs.prerf_chb_status_pv_obj.get.return_value = (
+            PIEZO_PRE_RF_CHECKOUT_PASS_VALUE
+        )
+        mock_piezo_pvs.prerf_cha_testmsg_pv_obj.get.return_value = (
+            "Low capacitance"
+        )
+        mock_piezo_pvs.prerf_chb_testmsg_pv_obj.get.return_value = "OK"
+        mock_piezo_pvs.capacitance_a_pv_obj.get.return_value = 5.2
+        mock_piezo_pvs.capacitance_b_pv_obj.get.return_value = 24.8
+
+        result = phase.execute_step("validate_results")
+
+        assert result.result == PhaseResult.FAILED
+        assert "Channel A failed" in result.message
+        assert "Low capacitance" in result.message
+
+    def test_validate_results_channel_b_fails(self, phase, mock_piezo_pvs):
+        """Test validate_results with Channel B failure."""
+        phase.validate_prerequisites()
+
+        mock_piezo_pvs.prerf_cha_status_pv_obj.get.return_value = (
+            PIEZO_PRE_RF_CHECKOUT_PASS_VALUE
+        )
+        mock_piezo_pvs.prerf_chb_status_pv_obj.get.return_value = 2  # Not pass
+        mock_piezo_pvs.prerf_cha_testmsg_pv_obj.get.return_value = "OK"
+        mock_piezo_pvs.prerf_chb_testmsg_pv_obj.get.return_value = (
+            "Connection error"
+        )
+        mock_piezo_pvs.capacitance_a_pv_obj.get.return_value = 25.3
+        mock_piezo_pvs.capacitance_b_pv_obj.get.return_value = 0.0
+
+        result = phase.execute_step("validate_results")
+
+        assert result.result == PhaseResult.FAILED
+        assert "Channel B failed" in result.message
+        assert "Connection error" in result.message
+
+    def test_validate_results_both_channels_fail(self, phase, mock_piezo_pvs):
+        """Test validate_results with both channels failing."""
+        phase.validate_prerequisites()
+
+        mock_piezo_pvs.prerf_cha_status_pv_obj.get.return_value = 1
+        mock_piezo_pvs.prerf_chb_status_pv_obj.get.return_value = 2
+        mock_piezo_pvs.prerf_cha_testmsg_pv_obj.get.return_value = "Error A"
+        mock_piezo_pvs.prerf_chb_testmsg_pv_obj.get.return_value = "Error B"
+        mock_piezo_pvs.capacitance_a_pv_obj.get.return_value = 0.0
+        mock_piezo_pvs.capacitance_b_pv_obj.get.return_value = 0.0
+
+        result = phase.execute_step("validate_results")
+
+        assert result.result == PhaseResult.FAILED
+        assert "Channel A failed" in result.message
+        assert "Channel B failed" in result.message
+
+    def test_execute_step_unknown_step(self, phase):
+        """Test execute_step with unknown step name."""
+        phase.validate_prerequisites()
+
+        result = phase.execute_step("unknown_step")
+
+        assert result.result == PhaseResult.FAILED
+        assert "Unknown step" in result.message
+
+    def test_execute_step_without_prerequisite_validation(self, context):
+        """Test execute_step fails without prerequisite validation."""
+        phase = PiezoPreRFPhase(context)
+
+        with pytest.raises(Exception):  # PhaseExecutionError
+            phase.execute_step("verify_initial_state")
+
+    def test_finalize_phase(self, phase, mock_piezo_pvs):
+        """Test finalize_phase saves data correctly."""
+        phase.validate_prerequisites()
+
+        # Setup validation data
+        mock_piezo_pvs.prerf_cha_status_pv_obj.get.return_value = (
+            PIEZO_PRE_RF_CHECKOUT_PASS_VALUE
+        )
+        mock_piezo_pvs.prerf_chb_status_pv_obj.get.return_value = (
+            PIEZO_PRE_RF_CHECKOUT_PASS_VALUE
+        )
+        mock_piezo_pvs.prerf_cha_testmsg_pv_obj.get.return_value = "OK"
+        mock_piezo_pvs.prerf_chb_testmsg_pv_obj.get.return_value = "OK"
+        mock_piezo_pvs.capacitance_a_pv_obj.get.return_value = 25.3
+        mock_piezo_pvs.capacitance_b_pv_obj.get.return_value = 24.8
+
+        # Execute validation step to create checkpoint
+        result = phase.execute_step("validate_results")
+
+        # Create checkpoint manually (normally done by run())
+        from sc_linac_physics.applications.rf_commissioning.models.data_models import (
+            PhaseCheckpoint,
+        )
+
+        checkpoint = PhaseCheckpoint(
+            phase=CommissioningPhase.PIEZO_PRE_RF,
+            timestamp=datetime.now(),
+            operator="test_operator",
+            step_name="validate_results",
+            success=True,
+            measurements=result.data,
+        )
+        phase.context.record.phase_history.append(checkpoint)
+
+        # Finalize phase
+        phase.finalize_phase()
+
+        # Verify data was saved
+        assert phase.context.record.piezo_pre_rf is not None
+        piezo_result = phase.context.record.piezo_pre_rf
+
+        assert piezo_result.channel_a_passed
+        assert piezo_result.channel_b_passed
+        assert (
+            abs(piezo_result.capacitance_a - 25.3e-9) < 1e-12
+        )  # Check nF to F conversion
+        assert abs(piezo_result.capacitance_b - 24.8e-9) < 1e-12
+
+    def test_custom_limits(self, context):
+        """Test phase with custom test limits."""
+        custom_limits = PiezoTestLimits(
+            test_timeout=60.0,
+            poll_interval=1.0,
+        )
+        phase = PiezoPreRFPhase(context=context, limits=custom_limits)
+
+        assert phase.limits.test_timeout == 60.0
+        assert phase.limits.poll_interval == 1.0
+
+    def test_default_limits(self, context):
+        """Test phase with default limits."""
+        phase = PiezoPreRFPhase(context=context)
+
+        assert phase.limits.test_timeout == 30.0
+        assert phase.limits.poll_interval == 0.5
+
+    def test_phase_name(self, phase):
+        """Test human-readable phase name."""
+        assert phase.phase_name == "Piezo Pre Rf"
+
+    def test_full_run_creates_checkpoints(self, phase, mock_piezo_pvs):
+        """Test that full run creates appropriate checkpoints."""
+        # Setup successful test scenario
+        mock_piezo_pvs.prerf_test_status_pv_obj.get.side_effect = [
+            0,  # Initial: not running
+            PIEZO_SCRIPT_RUNNING_VALUE,  # After start: running
+            PIEZO_SCRIPT_RUNNING_VALUE,  # Still running
+            0,  # Completed
+        ]
+
+        mock_piezo_pvs.prerf_cha_status_pv_obj.get.return_value = (
+            PIEZO_PRE_RF_CHECKOUT_PASS_VALUE
+        )
+        mock_piezo_pvs.prerf_chb_status_pv_obj.get.return_value = (
+            PIEZO_PRE_RF_CHECKOUT_PASS_VALUE
+        )
+        mock_piezo_pvs.prerf_cha_testmsg_pv_obj.get.return_value = "OK"
+        mock_piezo_pvs.prerf_chb_testmsg_pv_obj.get.return_value = "OK"
+        mock_piezo_pvs.capacitance_a_pv_obj.get.return_value = 25.3
+        mock_piezo_pvs.capacitance_b_pv_obj.get.return_value = 24.8
+
+        # Run phase
+        success = phase.run()
+
+        assert success
+
+        # Check checkpoints were created
+        checkpoints = phase.context.record.phase_history
+        assert len(checkpoints) > 0
+
+        # Find specific checkpoints
+        checkpoint_names = [cp.step_name for cp in checkpoints]
+        assert "phase_start" in checkpoint_names
+        assert "verify_initial_state" in checkpoint_names
+        assert "trigger_prerf_test" in checkpoint_names
+        assert "wait_for_completion" in checkpoint_names
+        assert "validate_results" in checkpoint_names
+        assert "phase_complete" in checkpoint_names
+
+        completion_checkpoint = next(
+            cp for cp in checkpoints if cp.step_name == "phase_complete"
+        )
+        assert "phase_data" in completion_checkpoint.measurements
+        phase_data = completion_checkpoint.measurements["phase_data"]
+        assert phase_data["channel_a_passed"] is True
+        assert phase_data["channel_b_passed"] is True
+        assert phase_data["passed"] is True
+
+        # Verify all successful
+        for cp in checkpoints:
+            assert cp.success
+
+    def test_failed_run_marks_phase_failed(self, phase, mock_piezo_pvs):
+        """Test that failed run marks phase as failed."""
+        # Setup failure scenario - channel A fails
+        mock_piezo_pvs.prerf_test_status_pv_obj.get.side_effect = [
+            0,  # Initial
+            PIEZO_SCRIPT_RUNNING_VALUE,  # Running
+            0,  # Completed
+        ]
+
+        mock_piezo_pvs.prerf_cha_status_pv_obj.get.return_value = 1  # Failed
+        mock_piezo_pvs.prerf_chb_status_pv_obj.get.return_value = (
+            PIEZO_PRE_RF_CHECKOUT_PASS_VALUE
+        )
+        mock_piezo_pvs.prerf_cha_testmsg_pv_obj.get.return_value = "Error"
+        mock_piezo_pvs.prerf_chb_testmsg_pv_obj.get.return_value = "OK"
+        mock_piezo_pvs.capacitance_a_pv_obj.get.return_value = 0.0
+        mock_piezo_pvs.capacitance_b_pv_obj.get.return_value = 24.8
+
+        # Run phase
+        success = phase.run()
+
+        assert not success
+        assert (
+            phase.context.record.phase_status[CommissioningPhase.PIEZO_PRE_RF]
+            == PhaseStatus.FAILED
+        )
+
+    def test_pv_read_error_handling(self, phase, mock_piezo_pvs):
+        """Test handling of PV read errors."""
+        phase.validate_prerequisites()
+
+        # Simulate PV error
+        mock_piezo_pvs.prerf_test_status_pv_obj.get.side_effect = Exception(
+            "PV timeout"
+        )
+
+        result = phase.execute_step("verify_initial_state")
+
+        assert result.result == PhaseResult.FAILED
+        assert "Failed to verify" in result.message
+
+    def test_multiple_runs_with_fresh_context(
+        self, mock_cavity, mock_piezo_pvs
+    ):
+        """Test that phase can be run multiple times with fresh contexts."""
+
+        # Setup successful scenario
+        def setup_success():
+            mock_piezo_pvs.prerf_test_status_pv_obj.get.side_effect = [
+                0,  # Initial
+                PIEZO_SCRIPT_RUNNING_VALUE,  # Running
+                PIEZO_SCRIPT_RUNNING_VALUE,
+                0,  # Complete
+            ]
+            mock_piezo_pvs.prerf_cha_status_pv_obj.get.return_value = (
+                PIEZO_PRE_RF_CHECKOUT_PASS_VALUE
+            )
+            mock_piezo_pvs.prerf_chb_status_pv_obj.get.return_value = (
+                PIEZO_PRE_RF_CHECKOUT_PASS_VALUE
+            )
+            mock_piezo_pvs.prerf_cha_testmsg_pv_obj.get.return_value = "OK"
+            mock_piezo_pvs.prerf_chb_testmsg_pv_obj.get.return_value = "OK"
+            mock_piezo_pvs.capacitance_a_pv_obj.get.return_value = 25.3
+            mock_piezo_pvs.capacitance_b_pv_obj.get.return_value = 24.8
+
+        # First run with first record
+        setup_success()
+        record1 = CommissioningRecord(linac=1, cryomodule="02", cavity_number=1)
+        context1 = PhaseContext(
+            record=record1,
+            operator="test_operator",
+            dry_run=False,
+            parameters={"cavity": mock_cavity},
+        )
+        phase1 = PiezoPreRFPhase(
+            context=context1,
+            limits=PiezoTestLimits(test_timeout=5.0, poll_interval=0.1),
+        )
+        success1 = phase1.run()
+        assert success1
+        assert record1.piezo_pre_rf is not None
+
+        # Second run with second record (simulating different cavity)
+        setup_success()
+        record2 = CommissioningRecord(linac=1, cryomodule="02", cavity_number=2)
+        context2 = PhaseContext(
+            record=record2,
+            operator="test_operator",
+            dry_run=False,
+            parameters={"cavity": mock_cavity},
+        )
+        phase2 = PiezoPreRFPhase(
+            context=context2,
+            limits=PiezoTestLimits(test_timeout=5.0, poll_interval=0.1),
+        )
+        success2 = phase2.run()
+        assert success2
+        assert record2.piezo_pre_rf is not None
+
+        # Both should have triggered the test
+        assert mock_piezo_pvs.prerf_test_start_pv_obj.put.call_count == 2
+
+    def test_integration_with_commissioning_record(self, phase, mock_piezo_pvs):
+        """Test full integration with commissioning record tracking."""
+        # Setup successful scenario
+        mock_piezo_pvs.prerf_test_status_pv_obj.get.side_effect = [
+            0,
+            PIEZO_SCRIPT_RUNNING_VALUE,
+            PIEZO_SCRIPT_RUNNING_VALUE,
+            0,
+        ]
+        mock_piezo_pvs.prerf_cha_status_pv_obj.get.return_value = (
+            PIEZO_PRE_RF_CHECKOUT_PASS_VALUE
+        )
+        mock_piezo_pvs.prerf_chb_status_pv_obj.get.return_value = (
+            PIEZO_PRE_RF_CHECKOUT_PASS_VALUE
+        )
+        mock_piezo_pvs.prerf_cha_testmsg_pv_obj.get.return_value = "OK"
+        mock_piezo_pvs.prerf_chb_testmsg_pv_obj.get.return_value = "OK"
+        mock_piezo_pvs.capacitance_a_pv_obj.get.return_value = 25.3
+        mock_piezo_pvs.capacitance_b_pv_obj.get.return_value = 24.8
+
+        # Verify initial state
+        record = phase.context.record
+        assert record.piezo_pre_rf is None
+        assert (
+            record.phase_status[CommissioningPhase.PIEZO_PRE_RF]
+            == PhaseStatus.IN_PROGRESS
+        )
+
+        # Run phase
+        success = phase.run()
+        assert success
+
+        # Verify final state
+        assert record.piezo_pre_rf is not None
+        assert record.piezo_pre_rf.passed
+        assert (
+            record.phase_status[CommissioningPhase.PIEZO_PRE_RF]
+            == PhaseStatus.COMPLETE
+        )
+        assert record.current_phase == CommissioningPhase.PIEZO_PRE_RF
+
+        # Verify checkpoint history
+        piezo_checkpoints = [
+            cp
+            for cp in record.phase_history
+            if cp.phase == CommissioningPhase.PIEZO_PRE_RF
+        ]
+        assert len(piezo_checkpoints) > 0
+
+        # Verify can serialize record
+        record_dict = record.to_dict()
+        assert "piezo_pre_rf" in record_dict
+        assert record_dict["piezo_pre_rf"]["passed"]

--- a/tests/applications/rf_commissioning/test_batch_piezo_pre_rf_controller.py
+++ b/tests/applications/rf_commissioning/test_batch_piezo_pre_rf_controller.py
@@ -1,0 +1,1040 @@
+"""Tests for BatchPiezoPreRFController."""
+
+import sys
+from threading import Event
+from types import SimpleNamespace
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+import sc_linac_physics.applications.rf_commissioning.ui.controllers.batch_piezo_pre_rf_controller as ctrl_module
+from sc_linac_physics.applications.rf_commissioning.ui.controllers.batch_piezo_pre_rf_controller import (
+    BatchPiezoPreRFController,
+    CavityRunState,
+    CavitySpec,
+    TRIGGER_STEPS,
+    COLLECT_STEPS,
+)
+from sc_linac_physics.applications.rf_commissioning.models.commissioning_piezo import (
+    CommissioningPiezo,
+)
+from sc_linac_physics.applications.rf_commissioning.models.data_models import (
+    CommissioningRecord,
+    PiezoPreRFCheck,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_session(*, existing_record_id=None, existing_record=None):
+    session = Mock()
+    session.db.get_record_id_for_cavity.return_value = existing_record_id
+    if existing_record_id is not None:
+        record = existing_record or CommissioningRecord(
+            linac=0, cryomodule="01", cavity_number=1
+        )
+        session.db.get_record_with_version.return_value = (record, 1)
+    else:
+        session.db.save_record.return_value = 99
+    session.workflow.start_phase_for_record.return_value = SimpleNamespace(
+        phase_instance_id=42, run_id=7, attempt_number=1
+    )
+    return session
+
+
+def _make_controller(session=None):
+    return BatchPiezoPreRFController(session or _mock_session())
+
+
+def _make_state(cm="01", cav=1, session=None):
+    spec = CavitySpec(cryomodule=cm, cavity_number=cav)
+    state = CavityRunState(spec=spec)
+    ctrl = _make_controller(session)
+    ctrl._init_record_and_context(state, "operator")
+    return ctrl, state
+
+
+def _passing_phase():
+    phase = Mock()
+    phase._execute_step_with_retry.return_value = True
+    phase._retry_count = 0
+    result = PiezoPreRFCheck(
+        capacitance_a=25e-9,
+        capacitance_b=24e-9,
+        channel_a_passed=True,
+        channel_b_passed=True,
+    )
+    phase.finalize_phase.side_effect = lambda: None
+    return phase, result
+
+
+# ---------------------------------------------------------------------------
+# CavitySpec
+# ---------------------------------------------------------------------------
+
+
+class TestCavitySpec:
+    def test_key_format(self):
+        spec = CavitySpec(cryomodule="02", cavity_number=3)
+        assert spec.key == "02_CAV3"
+
+    def test_linac_name_l0b(self):
+        assert CavitySpec(cryomodule="01", cavity_number=1).linac_name == "L0B"
+
+    def test_linac_name_l1b(self):
+        assert CavitySpec(cryomodule="02", cavity_number=1).linac_name == "L1B"
+
+    def test_linac_name_hl(self):
+        assert CavitySpec(cryomodule="H1", cavity_number=1).linac_name == "L1B"
+
+    def test_linac_name_unknown(self):
+        assert CavitySpec(cryomodule="ZZ", cavity_number=1).linac_name is None
+
+    def test_linac_idx_l0b(self):
+        assert CavitySpec(cryomodule="01", cavity_number=1).linac_idx == 0
+
+    def test_linac_idx_l1b(self):
+        assert CavitySpec(cryomodule="02", cavity_number=1).linac_idx == 1
+
+    def test_linac_idx_unknown(self):
+        assert CavitySpec(cryomodule="ZZ", cavity_number=1).linac_idx is None
+
+
+# ---------------------------------------------------------------------------
+# Controller init
+# ---------------------------------------------------------------------------
+
+
+class TestControllerInit:
+    def test_pool_not_started_on_init(self):
+        ctrl = _make_controller()
+        assert not ctrl._pool_ready
+
+    def test_abort_event_clear_on_init(self):
+        ctrl = _make_controller()
+        assert not ctrl._abort_event.is_set()
+
+    def test_is_running_false_initially(self):
+        ctrl = _make_controller()
+        assert not ctrl.is_running()
+
+
+# ---------------------------------------------------------------------------
+# _init_record_and_context
+# ---------------------------------------------------------------------------
+
+
+class TestInitRecordAndContext:
+    def test_creates_new_record_when_none_exists(self):
+        session = _mock_session(existing_record_id=None)
+        ctrl = _make_controller(session)
+        state = CavityRunState(
+            spec=CavitySpec(cryomodule="01", cavity_number=1)
+        )
+
+        ctrl._init_record_and_context(state, "op")
+
+        session.db.save_record.assert_called_once()
+        assert state.record is not None
+        assert state.record_id == 99
+        assert state.record_version == 1
+
+    def test_loads_existing_record(self):
+        existing = CommissioningRecord(
+            linac=0, cryomodule="01", cavity_number=1
+        )
+        session = _mock_session(existing_record_id=5, existing_record=existing)
+        ctrl = _make_controller(session)
+        state = CavityRunState(
+            spec=CavitySpec(cryomodule="01", cavity_number=1)
+        )
+
+        ctrl._init_record_and_context(state, "op")
+
+        session.db.save_record.assert_not_called()
+        assert state.record is existing
+        assert state.record_id == 5
+        assert state.record_version == 1
+
+    def test_raises_for_unknown_cryomodule(self):
+        ctrl = _make_controller()
+        state = CavityRunState(
+            spec=CavitySpec(cryomodule="ZZ", cavity_number=1)
+        )
+
+        with pytest.raises(ValueError, match="Cannot determine linac"):
+            ctrl._init_record_and_context(state, "op")
+
+    def test_raises_when_record_missing_after_id_lookup(self):
+        session = _mock_session(existing_record_id=5)
+        session.db.get_record_with_version.return_value = None
+        ctrl = _make_controller(session)
+        state = CavityRunState(
+            spec=CavitySpec(cryomodule="01", cavity_number=1)
+        )
+
+        with pytest.raises(ValueError, match="not found"):
+            ctrl._init_record_and_context(state, "op")
+
+    def test_phase_instance_id_set_from_workflow(self):
+        ctrl, state = _make_state()
+        assert state.phase_instance_id == 42
+
+    def test_phase_instance_id_none_when_workflow_returns_none(self):
+        session = _mock_session()
+        session.workflow.start_phase_for_record.return_value = None
+        ctrl = _make_controller(session)
+        state = CavityRunState(
+            spec=CavitySpec(cryomodule="01", cavity_number=1)
+        )
+
+        ctrl._init_record_and_context(state, "op")
+
+        assert state.phase_instance_id is None
+
+    def test_context_contains_correct_operator(self):
+        ctrl, state = _make_state()
+        assert state.context.operator == "operator"
+
+    def test_validates_prerequisites_on_phase(self):
+        ctrl, state = _make_state()
+        # validate_prerequisites is called inside _init_record_and_context
+        # The phase mock returns (False, ...) when prerequisites aren't met.
+        # We just verify phase was created and is a PiezoPreRFPhase mock.
+        assert state.phase is not None
+
+
+# ---------------------------------------------------------------------------
+# _trigger_cavity
+# ---------------------------------------------------------------------------
+
+
+class TestTriggerCavity:
+    def _state_with_mock_phase(self, step_results=None):
+        ctrl, state = _make_state()
+        phase = Mock()
+        phase._retry_count = 0
+        # Default: all trigger steps succeed
+        results = step_results or {s: True for s in TRIGGER_STEPS}
+        phase._execute_step_with_retry.side_effect = lambda s: results.get(
+            s, True
+        )
+        # validate_prerequisites must pass
+        phase.validate_prerequisites.return_value = (True, "ok")
+        state.phase = phase
+        return ctrl, state
+
+    def test_success_sets_triggered_true(self):
+        ctrl, state = self._state_with_mock_phase()
+        ctrl._trigger_cavity(state)
+        assert state.triggered is True
+
+    def test_success_emits_triggered_status(self):
+        ctrl, state = self._state_with_mock_phase()
+        emitted = []
+        ctrl.cavity_status_changed.connect(lambda k, s: emitted.append((k, s)))
+        ctrl._trigger_cavity(state)
+        statuses = [s for _, s in emitted]
+        assert BatchPiezoPreRFController.STATUS_TRIGGERED in statuses
+
+    def test_step_failure_sets_error_and_not_triggered(self):
+        ctrl, state = self._state_with_mock_phase(
+            {TRIGGER_STEPS[0]: False, TRIGGER_STEPS[1]: True}
+        )
+        ctrl._trigger_cavity(state)
+        assert state.triggered is False
+        assert state.error is not None
+
+    def test_step_failure_emits_error_status(self):
+        ctrl, state = self._state_with_mock_phase(
+            {TRIGGER_STEPS[0]: False, TRIGGER_STEPS[1]: True}
+        )
+        emitted = []
+        ctrl.cavity_status_changed.connect(lambda k, s: emitted.append((k, s)))
+        ctrl._trigger_cavity(state)
+        assert BatchPiezoPreRFController.STATUS_ERROR in [s for _, s in emitted]
+
+    def test_abort_before_step_skips_trigger(self):
+        ctrl, state = self._state_with_mock_phase()
+        ctrl._abort_event.set()
+        ctrl._trigger_cavity(state)
+        assert state.triggered is False
+
+    def test_skips_when_state_already_has_error(self):
+        ctrl, state = self._state_with_mock_phase()
+        state.error = "pre-existing error"
+        ctrl._trigger_cavity(state)
+        state.phase._execute_step_with_retry.assert_not_called()
+
+    def test_retry_count_reset_before_each_step(self):
+        ctrl, state = self._state_with_mock_phase()
+        state.phase._retry_count = 99
+        ctrl._trigger_cavity(state)
+        # After each successful step, _retry_count was reset to 0 before call
+        # Last reset will have left it at 0
+        assert state.phase._retry_count == 0
+
+    def test_noop_when_phase_is_none(self):
+        ctrl, state = _make_state()
+        state.phase = None
+
+        emitted = []
+        ctrl.cavity_status_changed.connect(lambda k, s: emitted.append((k, s)))
+        ctrl._trigger_cavity(state)
+
+        assert emitted == []
+
+
+# ---------------------------------------------------------------------------
+# _collect_cavity
+# ---------------------------------------------------------------------------
+
+
+class TestCollectCavity:
+    def _state_with_mock_phase(self, step_results=None):
+        ctrl, state = _make_state()
+        state.triggered = True
+
+        phase = Mock()
+        phase._retry_count = 0
+        results = step_results or {s: True for s in COLLECT_STEPS}
+        phase._execute_step_with_retry.side_effect = lambda s: results.get(
+            s, True
+        )
+
+        record = state.record
+        record.piezo_pre_rf = PiezoPreRFCheck(
+            capacitance_a=25e-9,
+            capacitance_b=24e-9,
+            channel_a_passed=True,
+            channel_b_passed=True,
+        )
+        state.phase = phase
+        return ctrl, state
+
+    def test_success_emits_passed_status(self):
+        ctrl, state = self._state_with_mock_phase()
+        emitted = []
+        ctrl.cavity_status_changed.connect(lambda k, s: emitted.append((k, s)))
+        ctrl._collect_cavity(state)
+        assert BatchPiezoPreRFController.STATUS_PASSED in [
+            s for _, s in emitted
+        ]
+
+    def test_success_emits_result_ready(self):
+        ctrl, state = self._state_with_mock_phase()
+        emitted = []
+        ctrl.cavity_result_ready.connect(lambda k, r: emitted.append((k, r)))
+        ctrl._collect_cavity(state)
+        assert len(emitted) == 1
+        assert emitted[0][1] is state.record.piezo_pre_rf
+
+    def test_failed_step_emits_failed_status(self):
+        ctrl, state = self._state_with_mock_phase(
+            {COLLECT_STEPS[0]: False, COLLECT_STEPS[1]: True}
+        )
+        emitted = []
+        ctrl.cavity_status_changed.connect(lambda k, s: emitted.append((k, s)))
+        ctrl._collect_cavity(state)
+        assert BatchPiezoPreRFController.STATUS_FAILED in [
+            s for _, s in emitted
+        ]
+
+    def test_failed_step_calls_fail_phase_instance(self):
+        ctrl, state = self._state_with_mock_phase(
+            {COLLECT_STEPS[0]: False, COLLECT_STEPS[1]: True}
+        )
+        ctrl._collect_cavity(state)
+        ctrl.session.workflow.fail_phase_instance.assert_called_once()
+
+    def test_abort_emits_error_status(self):
+        ctrl, state = self._state_with_mock_phase()
+        ctrl._abort_event.set()
+        emitted = []
+        ctrl.cavity_status_changed.connect(lambda k, s: emitted.append((k, s)))
+        ctrl._collect_cavity(state)
+        assert BatchPiezoPreRFController.STATUS_ERROR in [s for _, s in emitted]
+
+    def test_failed_piezo_check_emits_failed_status(self):
+        ctrl, state = self._state_with_mock_phase()
+        state.record.piezo_pre_rf = PiezoPreRFCheck(
+            capacitance_a=25e-9,
+            capacitance_b=24e-9,
+            channel_a_passed=False,
+            channel_b_passed=True,
+        )
+        emitted = []
+        ctrl.cavity_status_changed.connect(lambda k, s: emitted.append((k, s)))
+        ctrl._collect_cavity(state)
+        assert BatchPiezoPreRFController.STATUS_FAILED in [
+            s for _, s in emitted
+        ]
+
+    def test_calls_complete_phase_instance_on_success(self):
+        ctrl, state = self._state_with_mock_phase()
+        ctrl._collect_cavity(state)
+        ctrl.session.workflow.complete_phase_instance.assert_called_once()
+
+    def test_calls_save_record_on_success(self):
+        ctrl, state = self._state_with_mock_phase()
+        ctrl._collect_cavity(state)
+        ctrl.session.db.save_record.assert_called()
+
+    def test_missing_result_data_emits_failed_and_none_payload(self):
+        ctrl, state = self._state_with_mock_phase()
+        state.record.piezo_pre_rf = None
+
+        statuses = []
+        results = []
+        ctrl.cavity_status_changed.connect(lambda k, s: statuses.append(s))
+        ctrl.cavity_result_ready.connect(lambda k, r: results.append(r))
+
+        ctrl._collect_cavity(state)
+
+        assert BatchPiezoPreRFController.STATUS_FAILED in statuses
+        assert results == [None]
+        call_kwargs = ctrl.session.workflow.complete_phase_instance.call_args[1]
+        assert call_kwargs["artifact_payload"] is None
+
+
+# ---------------------------------------------------------------------------
+# _run_batch (integration-style, parallel trigger mocked out)
+# ---------------------------------------------------------------------------
+
+
+class TestRunBatch:
+    def _make_passing_run(self):
+        session = _mock_session()
+        ctrl = _make_controller(session)
+
+        phase = Mock()
+        phase._retry_count = 0
+        phase._execute_step_with_retry.return_value = True
+
+        def _fake_init(state, operator):
+            record = CommissioningRecord(
+                linac=0, cryomodule="01", cavity_number=state.spec.cavity_number
+            )
+            record.piezo_pre_rf = PiezoPreRFCheck(
+                capacitance_a=25e-9,
+                capacitance_b=24e-9,
+                channel_a_passed=True,
+                channel_b_passed=True,
+            )
+            state.record = record
+            state.record_id = 1
+            state.record_version = 1
+            state.phase_instance_id = 42
+            state.phase = phase
+            state.context = Mock()
+            state.context.abort_requested = False
+
+        ctrl._init_record_and_context = _fake_init
+        # Run triggers synchronously (bypass parallel pool)
+        ctrl._trigger_cavities_parallel = lambda states: [
+            ctrl._trigger_cavity(s) for s in states
+        ]
+        return ctrl
+
+    def test_batch_finished_signal_emitted(self):
+        ctrl = self._make_passing_run()
+        finished = []
+        ctrl.batch_finished.connect(lambda: finished.append(True))
+
+        cavities = [CavitySpec("01", 1), CavitySpec("01", 2)]
+        ctrl._run_batch(cavities, "op")
+
+        assert finished == [True]
+
+    def test_progress_signal_emitted_per_cavity(self):
+        ctrl = self._make_passing_run()
+        progress = []
+        ctrl.batch_progress.connect(lambda c, t: progress.append((c, t)))
+
+        cavities = [CavitySpec("01", 1), CavitySpec("01", 2)]
+        ctrl._run_batch(cavities, "op")
+
+        assert len(progress) == 2
+        assert progress[-1] == (2, 2)
+
+    def test_cavities_with_init_error_not_triggered(self):
+        session = _mock_session()
+        ctrl = _make_controller(session)
+
+        def _bad_init(state, operator):
+            raise ValueError("boom")
+
+        ctrl._init_record_and_context = _bad_init
+        ctrl._trigger_cavities_parallel = lambda states: [
+            ctrl._trigger_cavity(s) for s in states
+        ]
+
+        statuses = []
+        ctrl.cavity_status_changed.connect(lambda k, s: statuses.append(s))
+
+        ctrl._run_batch([CavitySpec("01", 1)], "op")
+
+        assert BatchPiezoPreRFController.STATUS_ERROR in statuses
+
+    def test_logs_singular_cavity_message(self):
+        ctrl = self._make_passing_run()
+        logs = []
+        ctrl.log_message.connect(lambda m: logs.append(m))
+
+        ctrl._run_batch([CavitySpec("01", 1)], "op")
+
+        assert any("1 cavity" in msg for msg in logs)
+
+
+# ---------------------------------------------------------------------------
+# abort and is_running
+# ---------------------------------------------------------------------------
+
+
+class TestAbort:
+    def test_abort_sets_event(self):
+        ctrl = _make_controller()
+        ctrl.abort()
+        assert ctrl._abort_event.is_set()
+
+    def test_abort_clears_on_new_run_batch_call(self):
+        ctrl = _make_controller()
+        ctrl.abort()
+
+        # run_batch clears the event before starting
+        ctrl._abort_event.clear()
+        assert not ctrl._abort_event.is_set()
+
+
+# ---------------------------------------------------------------------------
+# _get_machine_cavity
+# ---------------------------------------------------------------------------
+
+
+class TestGetMachineCavity:
+    def test_builds_machine_with_commissioning_piezo(self, monkeypatch):
+        class _MachineStub:
+            def __init__(self, *, piezo_class):
+                self.piezo_class = piezo_class
+                self.cryomodules = {
+                    "01": SimpleNamespace(cavities={1: "cav-obj"})
+                }
+
+        monkeypatch.setattr(ctrl_module, "Machine", _MachineStub)
+        ctrl = _make_controller()
+        result = ctrl._get_machine_cavity(CavitySpec("01", 1))
+
+        assert result == "cav-obj"
+        assert ctrl._machine.piezo_class is CommissioningPiezo
+
+    def test_reuses_existing_machine(self, monkeypatch):
+        call_count = 0
+
+        class _MachineStub:
+            def __init__(self, *, piezo_class):
+                nonlocal call_count
+                call_count += 1
+                self.cryomodules = {
+                    "01": SimpleNamespace(cavities={1: "cav-obj"})
+                }
+
+        monkeypatch.setattr(ctrl_module, "Machine", _MachineStub)
+        ctrl = _make_controller()
+        ctrl._get_machine_cavity(CavitySpec("01", 1))
+        ctrl._get_machine_cavity(CavitySpec("01", 1))
+
+        assert call_count == 1
+
+    def test_numeric_cryomodule_zero_padded(self, monkeypatch):
+        accessed_keys = []
+
+        class _CMStub:
+            def __getitem__(self, key):
+                accessed_keys.append(key)
+                return SimpleNamespace(cavities={1: "cav"})
+
+        class _MachineStub:
+            def __init__(self, *, piezo_class):
+                self.cryomodules = _CMStub()
+
+        monkeypatch.setattr(ctrl_module, "Machine", _MachineStub)
+        ctrl = _make_controller()
+        ctrl._get_machine_cavity(CavitySpec("1", 1))
+
+        assert "01" in accessed_keys
+
+
+# ---------------------------------------------------------------------------
+# _persist_record
+# ---------------------------------------------------------------------------
+
+
+class TestPersistRecord:
+    def test_increments_version_on_success(self):
+        ctrl, state = _make_state()
+        state.record_version = 3
+        ctrl._persist_record(state)
+        assert state.record_version == 4
+
+    def test_no_op_when_no_record(self):
+        ctrl = _make_controller()
+        state = CavityRunState(spec=CavitySpec("01", 1))
+        ctrl._persist_record(state)  # should not raise
+
+    def test_calls_save_record_with_version(self):
+        ctrl, state = _make_state()
+        state.record_version = 2
+        ctrl._persist_record(state)
+        ctrl.session.db.save_record.assert_called_with(
+            state.record, state.record_id, expected_version=2
+        )
+
+    def test_save_record_exception_does_not_propagate(self):
+        ctrl, state = _make_state()
+        ctrl.session.db.save_record.side_effect = RuntimeError("db down")
+        ctrl._persist_record(state)  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# run_batch public API
+# ---------------------------------------------------------------------------
+
+
+class TestRunBatchPublicAPI:
+    def test_already_running_logs_message(self):
+        ctrl = _make_controller()
+        logs = []
+        ctrl.log_message.connect(lambda m: logs.append(m))
+
+        mock_thread = MagicMock()
+        mock_thread.is_alive.return_value = True
+        ctrl._worker_thread = mock_thread
+
+        ctrl.run_batch([CavitySpec("01", 1)], "op")
+        assert any("already running" in m.lower() for m in logs)
+
+    def test_run_batch_clears_abort_event(self):
+        ctrl = _make_controller()
+        ctrl._abort_event.set()
+        ctrl._run_batch = lambda cavities, op: None  # no-op
+        ctrl.run_batch([CavitySpec("01", 1)], "op")
+        # The event is cleared before the thread starts
+        # Give thread a moment to clear
+        import time
+
+        time.sleep(0.05)
+        assert not ctrl._abort_event.is_set()
+
+    def test_run_batch_starts_background_thread(self):
+        ctrl = _make_controller()
+
+        started = []
+
+        def _fake_run_batch(cavities, operator):
+            started.append(True)
+
+        ctrl._run_batch = _fake_run_batch
+        ctrl.run_batch([CavitySpec("01", 1)], "op")
+
+        import time
+
+        time.sleep(0.1)
+        assert started == [True]
+        assert ctrl._worker_thread is not None
+
+
+# ---------------------------------------------------------------------------
+# Workflow exception in _init_record_and_context
+# ---------------------------------------------------------------------------
+
+
+class TestInitRecordWorkflowException:
+    def test_workflow_exception_sets_phase_instance_id_none(self):
+        session = _mock_session()
+        session.workflow.start_phase_for_record.side_effect = RuntimeError(
+            "rpc fail"
+        )
+        ctrl = _make_controller(session)
+        state = CavityRunState(spec=CavitySpec("01", 1))
+        ctrl._init_record_and_context(state, "op")
+        assert state.phase_instance_id is None
+
+    def test_workflow_exception_does_not_propagate(self):
+        session = _mock_session()
+        session.workflow.start_phase_for_record.side_effect = RuntimeError(
+            "rpc fail"
+        )
+        ctrl = _make_controller(session)
+        state = CavityRunState(spec=CavitySpec("01", 1))
+        ctrl._init_record_and_context(state, "op")  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Prerequisites not met
+# ---------------------------------------------------------------------------
+
+
+class TestPrerequisitesNotMet:
+    def test_raises_when_prerequisites_fail(self, monkeypatch):
+        class _BadPhase:
+            def __init__(self, ctx):
+                pass
+
+            def validate_prerequisites(self):
+                return (False, "bad state")
+
+        monkeypatch.setattr(ctrl_module, "PiezoPreRFPhase", _BadPhase)
+
+        ctrl = _make_controller()
+        state = CavityRunState(spec=CavitySpec("01", 1))
+        with pytest.raises(ValueError, match="Prerequisites not met"):
+            ctrl._init_record_and_context(state, "op")
+
+
+# ---------------------------------------------------------------------------
+# Exception paths in _complete_phase_instance / _fail_phase_instance
+# ---------------------------------------------------------------------------
+
+
+class TestCompletePhaseInstanceException:
+    def test_exception_does_not_propagate(self):
+        ctrl, state = _make_state()
+        ctrl.session.workflow.complete_phase_instance.side_effect = (
+            RuntimeError("network")
+        )
+        result = PiezoPreRFCheck(
+            capacitance_a=25e-9,
+            capacitance_b=24e-9,
+            channel_a_passed=True,
+            channel_b_passed=True,
+        )
+        ctrl._complete_phase_instance(state, result)  # no raise
+
+    def test_no_op_when_phase_instance_id_is_none(self):
+        ctrl = _make_controller()
+        state = CavityRunState(spec=CavitySpec("01", 1))
+        state.record_id = 99
+        state.phase_instance_id = None
+        ctrl._complete_phase_instance(state, None)  # should not call workflow
+
+
+class TestFailPhaseInstanceException:
+    def test_exception_does_not_propagate(self):
+        ctrl, state = _make_state()
+        ctrl.session.workflow.fail_phase_instance.side_effect = RuntimeError(
+            "down"
+        )
+        ctrl._fail_phase_instance(state, "step failed")  # no raise
+
+    def test_payload_includes_piezo_pre_rf_data(self):
+        ctrl, state = _make_state()
+        state.record.piezo_pre_rf = PiezoPreRFCheck(
+            capacitance_a=25e-9,
+            capacitance_b=24e-9,
+            channel_a_passed=True,
+            channel_b_passed=True,
+        )
+        ctrl._fail_phase_instance(state, "step failed")
+        call_kwargs = ctrl.session.workflow.fail_phase_instance.call_args[1]
+        assert call_kwargs["artifact_payload"] is not None
+
+    def test_no_op_when_phase_instance_id_none(self):
+        ctrl = _make_controller()
+        state = CavityRunState(spec=CavitySpec("01", 1))
+        state.record_id = 99
+        state.phase_instance_id = None
+        ctrl._fail_phase_instance(state, "boom")  # should not call workflow
+
+    def test_payload_is_none_when_no_piezo_data(self):
+        ctrl, state = _make_state()
+        state.record.piezo_pre_rf = None
+
+        ctrl._fail_phase_instance(state, "step failed")
+
+        call_kwargs = ctrl.session.workflow.fail_phase_instance.call_args[1]
+        assert call_kwargs["artifact_payload"] is None
+
+
+# ---------------------------------------------------------------------------
+# _ensure_pool and _trigger_cavities_parallel
+# ---------------------------------------------------------------------------
+
+
+class TestEnsurePool:
+    def test_sets_pool_ready(self):
+        ctrl = _make_controller()
+        assert not ctrl._pool_ready
+        ctrl._ensure_pool()
+        assert ctrl._pool_ready
+
+    def test_idempotent_second_call_safe(self):
+        ctrl = _make_controller()
+        ctrl._ensure_pool()
+        ctrl._ensure_pool()  # should not raise or start more threads
+
+
+class TestTriggerCavitiesParallel:
+    def test_empty_states_no_error(self):
+        ctrl = _make_controller()
+        ctrl._trigger_cavities_parallel([])  # should not raise
+
+    def test_abort_before_dispatch_returns_without_pool(self):
+        ctrl = _make_controller()
+        ctrl._abort_event.set()
+
+        state = CavityRunState(spec=CavitySpec("01", 1))
+        state.triggered = False
+        state.error = None
+
+        ctrl._trigger_cavities_parallel([state])
+        # Pool should not have been started since abort happened first
+        assert not ctrl._pool_ready
+
+    def test_abort_before_dispatch_marks_triggered_as_skipped(self):
+        ctrl = _make_controller()
+        ctrl._abort_event.set()
+
+        state = CavityRunState(spec=CavitySpec("01", 1))
+        state.triggered = True
+        state.error = None
+
+        statuses = []
+        ctrl.cavity_status_changed.connect(lambda k, s: statuses.append(s))
+        ctrl._trigger_cavities_parallel([state])
+
+        assert BatchPiezoPreRFController.STATUS_SKIPPED in statuses
+
+    def test_dispatches_to_pool_and_waits(self):
+        ctrl = _make_controller()
+        triggered = []
+
+        def _fake_trigger(state):
+            state.triggered = True
+            triggered.append(state.spec.key)
+
+        ctrl._trigger_cavity = _fake_trigger
+
+        state = CavityRunState(spec=CavitySpec("01", 1))
+        state.error = None
+        state.phase = Mock()
+        ctrl._trigger_cavities_parallel([state])
+
+        assert "01_CAV1" in triggered
+
+
+# ---------------------------------------------------------------------------
+# finalize_phase exception path in _collect_cavity
+# ---------------------------------------------------------------------------
+
+
+class TestFinalizePhaseFails:
+    def test_finalize_exception_does_not_propagate(self):
+        ctrl, state = _make_state()
+        state.triggered = True
+
+        phase = Mock()
+        phase._retry_count = 0
+        phase._execute_step_with_retry.return_value = True
+        phase.finalize_phase.side_effect = RuntimeError("phase broken")
+        state.phase = phase
+
+        state.record.piezo_pre_rf = PiezoPreRFCheck(
+            capacitance_a=25e-9,
+            capacitance_b=24e-9,
+            channel_a_passed=True,
+            channel_b_passed=True,
+        )
+
+        ctrl._collect_cavity(state)  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# abort during collect sweep in _run_batch
+# ---------------------------------------------------------------------------
+
+
+class TestAbortDuringCollect:
+    def _make_ctrl_with_triggered_states(self):
+        session = _mock_session()
+        ctrl = _make_controller(session)
+
+        def _fake_init(state, operator):
+            from sc_linac_physics.applications.rf_commissioning.models.data_models import (
+                CommissioningRecord,
+            )
+
+            record = CommissioningRecord(
+                linac=0, cryomodule="01", cavity_number=state.spec.cavity_number
+            )
+            record.piezo_pre_rf = PiezoPreRFCheck(
+                capacitance_a=25e-9,
+                capacitance_b=24e-9,
+                channel_a_passed=True,
+                channel_b_passed=True,
+            )
+            state.record = record
+            state.record_id = 1
+            state.record_version = 1
+            state.phase_instance_id = 42
+            state.phase = Mock()
+            state.phase._retry_count = 0
+            state.phase._execute_step_with_retry.return_value = True
+            state.context = Mock()
+            state.context.abort_requested = False
+
+        ctrl._init_record_and_context = _fake_init
+        ctrl._trigger_cavities_parallel = lambda states: [
+            setattr(s, "triggered", True) for s in states
+        ]
+        return ctrl
+
+    def test_abort_before_collect_marks_untriggered_as_skipped(self):
+        ctrl = self._make_ctrl_with_triggered_states()
+
+        # Override parallel trigger: only trigger first cavity, leave others untriggered
+        def _partial_trigger(states):
+            if states:
+                states[0].triggered = True
+
+        ctrl._trigger_cavities_parallel = _partial_trigger
+
+        statuses = {}
+        ctrl.cavity_status_changed.connect(
+            lambda k, s: statuses.__setitem__(k, s)
+        )
+
+        # Make collect abort after first cavity
+        def _abort_on_first_collect(state):
+            ctrl._abort_event.set()
+
+        ctrl._collect_cavity = _abort_on_first_collect
+
+        cavities = [
+            CavitySpec("01", 1),
+            CavitySpec("01", 2),
+            CavitySpec("01", 3),
+        ]
+        ctrl._run_batch(cavities, "op")
+
+        # Untriggered cavities (cav 2, cav 3) should be marked SKIPPED
+        assert (
+            statuses.get("01_CAV2") == BatchPiezoPreRFController.STATUS_SKIPPED
+        )
+        assert (
+            statuses.get("01_CAV3") == BatchPiezoPreRFController.STATUS_SKIPPED
+        )
+
+
+# ---------------------------------------------------------------------------
+# _mark_remaining_skipped
+# ---------------------------------------------------------------------------
+
+
+class TestMarkRemainingSkipped:
+    # Logic: emit SKIPPED when `not state.error AND state.triggered != only_triggered`
+    # Default only_triggered=False: emit SKIPPED for triggered=True states
+    # only_triggered=True: emit SKIPPED for triggered=False states
+
+    def test_emits_skipped_for_triggered_by_default(self):
+        ctrl = _make_controller()
+        state = CavityRunState(spec=CavitySpec("01", 1))
+        state.triggered = True
+        state.error = None
+
+        statuses = []
+        ctrl.cavity_status_changed.connect(lambda k, s: statuses.append(s))
+        ctrl._mark_remaining_skipped([state])
+        assert BatchPiezoPreRFController.STATUS_SKIPPED in statuses
+
+    def test_does_not_emit_skipped_for_untriggered_by_default(self):
+        ctrl = _make_controller()
+        state = CavityRunState(spec=CavitySpec("01", 1))
+        state.triggered = False
+        state.error = None
+
+        statuses = []
+        ctrl.cavity_status_changed.connect(lambda k, s: statuses.append(s))
+        ctrl._mark_remaining_skipped([state])
+        assert BatchPiezoPreRFController.STATUS_SKIPPED not in statuses
+
+    def test_emits_skipped_for_untriggered_when_only_triggered_true(self):
+        ctrl = _make_controller()
+        state = CavityRunState(spec=CavitySpec("01", 1))
+        state.triggered = False
+        state.error = None
+
+        statuses = []
+        ctrl.cavity_status_changed.connect(lambda k, s: statuses.append(s))
+        ctrl._mark_remaining_skipped([state], only_triggered=True)
+        assert BatchPiezoPreRFController.STATUS_SKIPPED in statuses
+
+    def test_does_not_emit_skipped_for_error_states(self):
+        ctrl = _make_controller()
+        state = CavityRunState(spec=CavitySpec("01", 1))
+        state.triggered = True  # would match default, but error blocks it
+        state.error = "already failed"
+
+        statuses = []
+        ctrl.cavity_status_changed.connect(lambda k, s: statuses.append(s))
+        ctrl._mark_remaining_skipped([state])
+        assert BatchPiezoPreRFController.STATUS_SKIPPED not in statuses
+
+
+# ---------------------------------------------------------------------------
+# _pool_worker
+# ---------------------------------------------------------------------------
+
+
+class TestPoolWorker:
+    class _QueueOnce:
+        def __init__(self, item):
+            self._item = item
+            self.task_done_calls = 0
+            self._calls = 0
+
+        def get(self):
+            self._calls += 1
+            if self._calls == 1:
+                return self._item
+            raise SystemExit()
+
+        def task_done(self):
+            self.task_done_calls += 1
+
+    def test_trigger_exception_sets_error_and_signals_done(self):
+        ctrl = _make_controller()
+        state = CavityRunState(spec=CavitySpec("01", 1))
+        done = Event()
+
+        queue_stub = self._QueueOnce((state, done))
+        ctrl._trigger_queue = queue_stub
+        ctrl._trigger_cavity = Mock(side_effect=RuntimeError("boom"))
+
+        with pytest.raises(SystemExit):
+            ctrl._pool_worker()
+
+        assert state.error == "boom"
+        assert done.is_set()
+        assert queue_stub.task_done_calls == 1
+
+    def test_uses_initial_epics_context_when_available(self, monkeypatch):
+        ctrl = _make_controller()
+        state = CavityRunState(spec=CavitySpec("01", 1))
+        done = Event()
+
+        queue_stub = self._QueueOnce((state, done))
+        ctrl._trigger_queue = queue_stub
+        ctrl._trigger_cavity = Mock()
+
+        use_initial_context = Mock()
+        fake_epics = SimpleNamespace(
+            ca=SimpleNamespace(use_initial_context=use_initial_context)
+        )
+        monkeypatch.setitem(sys.modules, "epics", fake_epics)
+
+        with pytest.raises(SystemExit):
+            ctrl._pool_worker()
+
+        use_initial_context.assert_called_once()

--- a/tests/applications/rf_commissioning/test_batch_piezo_pre_rf_ui.py
+++ b/tests/applications/rf_commissioning/test_batch_piezo_pre_rf_ui.py
@@ -1,0 +1,550 @@
+"""Tests for BatchPiezoPreRFWindow."""
+
+from unittest.mock import Mock
+
+import pytest
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QComboBox, QWidget
+
+from sc_linac_physics.applications.rf_commissioning.ui.controllers.batch_piezo_pre_rf_controller import (
+    BatchPiezoPreRFController,
+    CavitySpec,
+)
+from sc_linac_physics.applications.rf_commissioning.models.data_models import (
+    PiezoPreRFCheck,
+)
+from sc_linac_physics.applications.rf_commissioning.ui.displays.batch_piezo_pre_rf import (
+    BatchPiezoPreRFWindow,
+    _COL_CAV,
+    _COL_CHA,
+    _COL_CHB,
+    _COL_CM,
+    _COL_LINAC,
+    _COL_OVERALL,
+    _COL_STATUS,
+    _STATUS_COLORS,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_window():
+    session = Mock()
+    return BatchPiezoPreRFWindow(session=session)
+
+
+@pytest.fixture
+def win():
+    w = _make_window()
+    yield w
+    w.deleteLater()
+
+
+def _cell_text(win, row, col):
+    item = win._table.item(row, col)
+    return item.text() if item else None
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_window_title(self, win):
+        assert win.windowTitle() == "Batch Piezo Pre-RF"
+
+    def test_minimum_size(self, win):
+        assert win.minimumWidth() >= 1000
+        assert win.minimumHeight() >= 700
+
+    def test_controller_created(self, win):
+        assert isinstance(win._controller, BatchPiezoPreRFController)
+
+    def test_row_by_key_empty_initially(self, win):
+        assert win._row_by_key == {}
+
+    def test_run_btn_enabled_initially(self, win):
+        assert win._run_btn.isEnabled()
+
+    def test_abort_btn_disabled_initially(self, win):
+        assert not win._abort_btn.isEnabled()
+
+    def test_progress_bar_zero(self, win):
+        assert win._progress_bar.value() == 0
+
+    def test_selection_count_label_shows_zero(self, win):
+        assert "0" in win._selection_count_label.text()
+
+    def test_log_starts_empty(self, win):
+        assert win._log.toPlainText() == ""
+
+
+# ---------------------------------------------------------------------------
+# Tree population
+# ---------------------------------------------------------------------------
+
+
+class TestTreePopulation:
+    def test_linac_nodes_at_top_level(self, win):
+        root = win._tree.invisibleRootItem()
+        assert root.childCount() == 5  # L0B through L4B
+
+    def test_l0b_has_one_cm(self, win):
+        root = win._tree.invisibleRootItem()
+        l0 = root.child(0)
+        assert l0.childCount() == 1  # CM01 only
+
+    def test_l1b_has_four_cms(self, win):
+        root = win._tree.invisibleRootItem()
+        l1 = root.child(1)
+        assert l1.childCount() == 4  # 02, 03, H1, H2
+
+    def test_each_cm_has_eight_cavities(self, win):
+        root = win._tree.invisibleRootItem()
+        l0 = root.child(0)
+        cm = l0.child(0)
+        assert cm.childCount() == 8
+
+    def test_cavity_items_initially_unchecked(self, win):
+        root = win._tree.invisibleRootItem()
+        l0 = root.child(0)
+        cm = l0.child(0)
+        for i in range(cm.childCount()):
+            assert cm.child(i).checkState(0) == Qt.Unchecked
+
+    def test_cavity_user_data_has_cm_and_num(self, win):
+        root = win._tree.invisibleRootItem()
+        l0 = root.child(0)
+        cm = l0.child(0)
+        cav_item = cm.child(0)
+        data = cav_item.data(0, Qt.UserRole)
+        assert data is not None
+        assert data[0] == "cav"
+
+    def test_cm_item_has_user_data(self, win):
+        root = win._tree.invisibleRootItem()
+        l0 = root.child(0)
+        cm = l0.child(0)
+        data = cm.data(0, Qt.UserRole)
+        assert data is not None
+        assert data[0] == "cm"
+
+
+# ---------------------------------------------------------------------------
+# Select / deselect all
+# ---------------------------------------------------------------------------
+
+
+class TestSelectAll:
+    def test_select_all_checks_all_cavities(self, win):
+        win._select_all()
+        root = win._tree.invisibleRootItem()
+        for i in range(root.childCount()):
+            linac = root.child(i)
+            for j in range(linac.childCount()):
+                cm = linac.child(j)
+                for k in range(cm.childCount()):
+                    assert cm.child(k).checkState(0) == Qt.Checked
+
+    def test_deselect_all_unchecks_all_cavities(self, win):
+        win._select_all()
+        win._deselect_all()
+        root = win._tree.invisibleRootItem()
+        for i in range(root.childCount()):
+            linac = root.child(i)
+            for j in range(linac.childCount()):
+                cm = linac.child(j)
+                for k in range(cm.childCount()):
+                    assert cm.child(k).checkState(0) == Qt.Unchecked
+
+    def test_select_all_updates_count_label(self, win):
+        win._select_all()
+        label = win._selection_count_label.text()
+        assert "0" not in label or "cavities" in label  # non-zero count
+
+    def test_deselect_all_resets_count_label(self, win):
+        win._select_all()
+        win._deselect_all()
+        assert "0" in win._selection_count_label.text()
+
+
+# ---------------------------------------------------------------------------
+# Get selected cavities
+# ---------------------------------------------------------------------------
+
+
+class TestGetSelectedCavities:
+    def test_no_selection_returns_empty(self, win):
+        assert win._get_selected_cavities() == []
+
+    def test_select_all_returns_all_cavities(self, win):
+        win._select_all()
+        selected = win._get_selected_cavities()
+        assert len(selected) > 0
+
+    def test_single_check_returns_one_spec(self, win):
+        root = win._tree.invisibleRootItem()
+        l0 = root.child(0)
+        cm = l0.child(0)
+        cm.child(0).setCheckState(0, Qt.Checked)
+        selected = win._get_selected_cavities()
+        assert len(selected) == 1
+        assert isinstance(selected[0], CavitySpec)
+
+    def test_selected_spec_has_correct_cavity_number(self, win):
+        root = win._tree.invisibleRootItem()
+        l0 = root.child(0)
+        cm = l0.child(0)
+        cm.child(2).setCheckState(0, Qt.Checked)  # Cav 3
+        selected = win._get_selected_cavities()
+        assert len(selected) == 1
+        assert selected[0].cavity_number == 3
+
+
+# ---------------------------------------------------------------------------
+# Update selection count
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateSelectionCount:
+    def test_singular_cavity_label(self, win):
+        root = win._tree.invisibleRootItem()
+        l0 = root.child(0)
+        cm = l0.child(0)
+        cm.child(0).setCheckState(0, Qt.Checked)
+        win._update_selection_count()
+        assert "1 cavity" in win._selection_count_label.text()
+        assert "cavities" not in win._selection_count_label.text()
+
+    def test_plural_cavities_label(self, win):
+        root = win._tree.invisibleRootItem()
+        l0 = root.child(0)
+        cm = l0.child(0)
+        cm.child(0).setCheckState(0, Qt.Checked)
+        cm.child(1).setCheckState(0, Qt.Checked)
+        win._update_selection_count()
+        assert "2 cavities" in win._selection_count_label.text()
+
+
+# ---------------------------------------------------------------------------
+# Setup results table
+# ---------------------------------------------------------------------------
+
+
+class TestSetupResultsTable:
+    def test_table_has_correct_row_count(self, win):
+        cavities = [CavitySpec("01", 1), CavitySpec("01", 2)]
+        win._setup_results_table(cavities)
+        assert win._table.rowCount() == 2
+
+    def test_row_key_mapping_populated(self, win):
+        cavities = [CavitySpec("01", 1), CavitySpec("02", 3)]
+        win._setup_results_table(cavities)
+        assert "01_CAV1" in win._row_by_key
+        assert "02_CAV3" in win._row_by_key
+
+    def test_status_column_set_to_pending(self, win):
+        cavities = [CavitySpec("01", 1)]
+        win._setup_results_table(cavities)
+        assert _cell_text(win, 0, _COL_STATUS) == "PENDING"
+
+    def test_cm_column_set(self, win):
+        cavities = [CavitySpec("01", 5)]
+        win._setup_results_table(cavities)
+        assert _cell_text(win, 0, _COL_CM) == "01"
+
+    def test_cav_column_set(self, win):
+        cavities = [CavitySpec("01", 7)]
+        win._setup_results_table(cavities)
+        assert _cell_text(win, 0, _COL_CAV) == "7"
+
+    def test_clears_previous_rows(self, win):
+        win._setup_results_table([CavitySpec("01", 1), CavitySpec("01", 2)])
+        win._setup_results_table([CavitySpec("01", 3)])
+        assert win._table.rowCount() == 1
+
+    def test_linac_name_shown_in_linac_column(self, win):
+        cavities = [CavitySpec("01", 1)]
+        win._setup_results_table(cavities)
+        assert _cell_text(win, 0, _COL_LINAC) == "L0B"
+
+    def test_unknown_linac_shown_as_question_mark(self, win):
+        cavities = [CavitySpec("ZZ", 1)]
+        win._setup_results_table(cavities)
+        assert _cell_text(win, 0, _COL_LINAC) == "?"
+
+
+# ---------------------------------------------------------------------------
+# Signal handlers
+# ---------------------------------------------------------------------------
+
+
+class TestOnCavityStatus:
+    def test_updates_status_cell(self, win):
+        cavities = [CavitySpec("01", 1)]
+        win._setup_results_table(cavities)
+        win._on_cavity_status("01_CAV1", "TRIGGERING")
+        assert _cell_text(win, 0, _COL_STATUS) == "TRIGGERING"
+
+    def test_unknown_key_is_no_op(self, win):
+        win._on_cavity_status("MISSING_KEY", "PASSED")  # should not raise
+
+    def test_status_color_applied(self, win):
+        cavities = [CavitySpec("01", 1)]
+        win._setup_results_table(cavities)
+        win._on_cavity_status("01_CAV1", "PASSED")
+        item = win._table.item(0, _COL_STATUS)
+        assert item.foreground().color().name().lower() in (
+            _STATUS_COLORS["PASSED"].lower(),
+            "#66bb6a",
+        )
+
+    def test_unknown_status_uses_white(self, win):
+        cavities = [CavitySpec("01", 1)]
+        win._setup_results_table(cavities)
+        win._on_cavity_status("01_CAV1", "UNKNOWN_STATUS")
+        item = win._table.item(0, _COL_STATUS)
+        # white = #ffffff
+        assert item.foreground().color().name().lower() == "#ffffff"
+
+
+class TestOnCavityResult:
+    def _passing_result(self):
+        return PiezoPreRFCheck(
+            capacitance_a=25e-9,
+            capacitance_b=24e-9,
+            channel_a_passed=True,
+            channel_b_passed=True,
+        )
+
+    def _failing_result(self):
+        return PiezoPreRFCheck(
+            capacitance_a=5e-9,
+            capacitance_b=24e-9,
+            channel_a_passed=False,
+            channel_b_passed=True,
+        )
+
+    def test_cha_pass_shown(self, win):
+        cavities = [CavitySpec("01", 1)]
+        win._setup_results_table(cavities)
+        win._on_cavity_result("01_CAV1", self._passing_result())
+        assert _cell_text(win, 0, _COL_CHA) == "PASS"
+
+    def test_chb_pass_shown(self, win):
+        cavities = [CavitySpec("01", 1)]
+        win._setup_results_table(cavities)
+        win._on_cavity_result("01_CAV1", self._passing_result())
+        assert _cell_text(win, 0, _COL_CHB) == "PASS"
+
+    def test_cha_fail_shown(self, win):
+        cavities = [CavitySpec("01", 1)]
+        win._setup_results_table(cavities)
+        win._on_cavity_result("01_CAV1", self._failing_result())
+        assert _cell_text(win, 0, _COL_CHA) == "FAIL"
+
+    def test_overall_pass_shown(self, win):
+        cavities = [CavitySpec("01", 1)]
+        win._setup_results_table(cavities)
+        win._on_cavity_result("01_CAV1", self._passing_result())
+        assert _cell_text(win, 0, _COL_OVERALL) == "PASS"
+
+    def test_overall_fail_when_channel_fails(self, win):
+        cavities = [CavitySpec("01", 1)]
+        win._setup_results_table(cavities)
+        win._on_cavity_result("01_CAV1", self._failing_result())
+        assert _cell_text(win, 0, _COL_OVERALL) == "FAIL"
+
+    def test_capacitance_a_formatted(self, win):
+        cavities = [CavitySpec("01", 1)]
+        win._setup_results_table(cavities)
+        win._on_cavity_result("01_CAV1", self._passing_result())
+        # 25e-9 * 1e9 = 25.00
+        assert _cell_text(win, 0, _COL_CHA + 2) == "25.00"  # _COL_CAPA
+
+    def test_unknown_key_is_no_op(self, win):
+        win._on_cavity_result("MISSING", self._passing_result())  # no raise
+
+    def test_none_result_is_no_op(self, win):
+        cavities = [CavitySpec("01", 1)]
+        win._setup_results_table(cavities)
+        win._on_cavity_result("01_CAV1", None)  # should not update table
+
+
+class TestOnBatchProgress:
+    def test_progress_bar_updated(self, win):
+        win._progress_bar.setMaximum(5)
+        win._on_batch_progress(3, 5)
+        assert win._progress_bar.value() == 3
+
+    def test_progress_label_updated(self, win):
+        win._on_batch_progress(2, 7)
+        assert "2 / 7" in win._progress_label.text()
+
+
+class TestOnBatchFinished:
+    def test_run_btn_reenabled(self, win):
+        win._run_btn.setEnabled(False)
+        win._on_batch_finished()
+        assert win._run_btn.isEnabled()
+
+    def test_abort_btn_disabled(self, win):
+        win._abort_btn.setEnabled(True)
+        win._on_batch_finished()
+        assert not win._abort_btn.isEnabled()
+
+    def test_log_shows_complete_message(self, win):
+        win._on_batch_finished()
+        assert "complete" in win._log.toPlainText().lower()
+
+
+# ---------------------------------------------------------------------------
+# Log
+# ---------------------------------------------------------------------------
+
+
+class TestAppendLog:
+    def test_message_appears_in_log(self, win):
+        win._append_log("hello log")
+        assert "hello log" in win._log.toPlainText()
+
+    def test_multiple_messages_accumulated(self, win):
+        win._append_log("first message")
+        win._append_log("second message")
+        text = win._log.toPlainText()
+        assert "first message" in text
+        assert "second message" in text
+
+
+# ---------------------------------------------------------------------------
+# Operator resolution
+# ---------------------------------------------------------------------------
+
+
+class TestGetOperator:
+    def test_returns_empty_when_no_parent(self, win):
+        assert win._get_operator() == ""
+
+    def test_returns_operator_from_parent_combo(self, win):
+        parent = QWidget()
+        parent.operator_combo = QComboBox()
+        parent.operator_combo.addItem("Alice", "Alice")
+        parent.operator_combo.setCurrentIndex(0)
+
+        child = BatchPiezoPreRFWindow(parent=parent, session=Mock())
+        try:
+            result = child._get_operator()
+            assert result == "Alice"
+        finally:
+            child.deleteLater()
+            parent.deleteLater()
+
+    def test_skips_select_placeholder(self, win):
+        parent = QWidget()
+        parent.operator_combo = QComboBox()
+        parent.operator_combo.addItem("👤 Select operator...", "")
+        parent.operator_combo.setCurrentIndex(0)
+
+        child = BatchPiezoPreRFWindow(parent=parent, session=Mock())
+        try:
+            result = child._get_operator()
+            assert result == ""
+        finally:
+            child.deleteLater()
+            parent.deleteLater()
+
+    def test_strips_person_emoji_from_operator_text(self, win):
+        parent = QWidget()
+        parent.operator_combo = QComboBox()
+        parent.operator_combo.addItem("👤 Bob", None)  # data is None, text used
+        parent.operator_combo.setCurrentIndex(0)
+
+        child = BatchPiezoPreRFWindow(parent=parent, session=Mock())
+        try:
+            result = child._get_operator()
+            assert result == "Bob"
+        finally:
+            child.deleteLater()
+            parent.deleteLater()
+
+
+# ---------------------------------------------------------------------------
+# Run / Abort buttons
+# ---------------------------------------------------------------------------
+
+
+class TestOnRunClicked:
+    def test_no_operator_logs_error(self, win):
+        logs = []
+        win._log.append = lambda m: logs.append(m)
+        win._get_operator = lambda: ""
+        win._on_run_clicked()
+        assert any("operator" in (m or "").lower() for m in logs)
+
+    def test_no_cavities_selected_logs_message(self, win):
+        logs = []
+        win._log.append = lambda m: logs.append(m)
+        win._get_operator = lambda: "operator"
+        win._on_run_clicked()
+        # selection count is 0, should log about no cavities
+        assert any("No cavities" in (m or "") for m in logs)
+
+    def test_run_disables_run_btn(self, win):
+        win._get_operator = lambda: "operator"
+        # select one cavity
+        root = win._tree.invisibleRootItem()
+        root.child(0).child(0).child(0).setCheckState(0, Qt.Checked)
+        win._controller.run_batch = Mock()
+        win._on_run_clicked()
+        assert not win._run_btn.isEnabled()
+
+    def test_run_enables_abort_btn(self, win):
+        win._get_operator = lambda: "operator"
+        root = win._tree.invisibleRootItem()
+        root.child(0).child(0).child(0).setCheckState(0, Qt.Checked)
+        win._controller.run_batch = Mock()
+        win._on_run_clicked()
+        assert win._abort_btn.isEnabled()
+
+    def test_run_calls_controller_run_batch(self, win):
+        win._get_operator = lambda: "operator"
+        root = win._tree.invisibleRootItem()
+        root.child(0).child(0).child(0).setCheckState(0, Qt.Checked)
+        win._controller.run_batch = Mock()
+        win._on_run_clicked()
+        win._controller.run_batch.assert_called_once()
+
+
+class TestOnAbortClicked:
+    def test_abort_calls_controller_abort(self, win):
+        win._controller.abort = Mock()
+        win._abort_btn.setEnabled(True)
+        win._on_abort_clicked()
+        win._controller.abort.assert_called_once()
+
+    def test_abort_disables_abort_btn(self, win):
+        win._controller.abort = Mock()
+        win._abort_btn.setEnabled(True)
+        win._on_abort_clicked()
+        assert not win._abort_btn.isEnabled()
+
+
+# ---------------------------------------------------------------------------
+# Tree item changed
+# ---------------------------------------------------------------------------
+
+
+class TestOnTreeItemChanged:
+    def test_updates_selection_count_label(self, win):
+        root = win._tree.invisibleRootItem()
+        cav_item = root.child(0).child(0).child(0)
+        initial = win._selection_count_label.text()
+        cav_item.setCheckState(0, Qt.Checked)
+        # After check state change the label should reflect the new count
+        assert (
+            win._selection_count_label.text() != initial
+            or "1" in win._selection_count_label.text()
+        )

--- a/tests/applications/rf_commissioning/test_import_boundaries.py
+++ b/tests/applications/rf_commissioning/test_import_boundaries.py
@@ -1,0 +1,43 @@
+"""Architecture guardrails for RF commissioning package imports."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_PACKAGE_ROOT_IMPORT = "sc_linac_physics.applications.rf_commissioning"
+
+
+def _iter_python_files(root: Path) -> list[Path]:
+    return [path for path in root.rglob("*.py") if path.name != "__init__.py"]
+
+
+def test_rf_commissioning_internals_do_not_import_package_root() -> None:
+    """Internal modules should import concrete submodules, not package root.
+
+    Importing through the package root from inside the package increases
+    coupling and can create circular-import hazards as exports evolve.
+    """
+    src_root = Path(__file__).resolve().parents[3] / "src"
+    package_root = (
+        src_root / "sc_linac_physics" / "applications" / "rf_commissioning"
+    )
+
+    violating_imports: list[str] = []
+    for file_path in _iter_python_files(package_root):
+        module = ast.parse(file_path.read_text(encoding="utf-8"))
+        for node in ast.walk(module):
+            if not isinstance(node, ast.ImportFrom):
+                continue
+            if node.module != _PACKAGE_ROOT_IMPORT:
+                continue
+
+            rel_path = file_path.relative_to(src_root)
+            violating_imports.append(
+                f"{rel_path}:{node.lineno} imports from package root"
+            )
+
+    assert not violating_imports, (
+        "Found rf_commissioning internal imports from package root:\n"
+        + "\n".join(sorted(violating_imports))
+    )

--- a/tests/applications/rf_commissioning/test_package_exports.py
+++ b/tests/applications/rf_commissioning/test_package_exports.py
@@ -1,0 +1,18 @@
+"""Tests for rf_commissioning package root exports used in docs."""
+
+import sc_linac_physics.applications.rf_commissioning as rf_commissioning
+
+
+def test_package_root_reexports_documented_symbols():
+    expected_symbols = [
+        "CommissioningRecord",
+        "CommissioningPhase",
+        "PhaseStatus",
+        "CommissioningDatabase",
+        "PhaseCheckpoint",
+        "PiezoPreRFCheck",
+        "WorkflowService",
+    ]
+
+    for symbol_name in expected_symbols:
+        assert hasattr(rf_commissioning, symbol_name)

--- a/tests/applications/rf_commissioning/test_phase_specs.py
+++ b/tests/applications/rf_commissioning/test_phase_specs.py
@@ -1,0 +1,44 @@
+"""Tests for RF commissioning phase tab selection."""
+
+from sc_linac_physics.applications.rf_commissioning.models.data_models import (
+    CommissioningPhase,
+)
+from sc_linac_physics.applications.rf_commissioning.ui.container.phase_specs import (
+    build_default_phase_specs,
+)
+
+
+def test_default_phase_specs_hide_placeholder_tabs_for_beta() -> None:
+    specs = build_default_phase_specs()
+
+    assert [spec.phase for spec in specs] == [CommissioningPhase.PIEZO_PRE_RF]
+    assert [spec.title for spec in specs] == ["Piezo Pre-RF"]
+
+
+def test_default_phase_specs_can_include_all_placeholder_tabs() -> None:
+    specs = build_default_phase_specs(include_placeholder_phases=True)
+
+    assert [spec.phase for spec in specs] == [
+        CommissioningPhase.PIEZO_PRE_RF,
+        CommissioningPhase.SSA_CHAR,
+        CommissioningPhase.FREQUENCY_TUNING,
+        CommissioningPhase.CAVITY_CHAR,
+        CommissioningPhase.PIEZO_WITH_RF,
+        CommissioningPhase.HIGH_POWER_RAMP,
+        CommissioningPhase.MP_PROCESSING,
+        CommissioningPhase.ONE_HOUR_RUN,
+    ]
+
+
+def test_default_phase_specs_accept_custom_visible_phase_subset() -> None:
+    specs = build_default_phase_specs(
+        visible_phases=(
+            CommissioningPhase.FREQUENCY_TUNING,
+            CommissioningPhase.PIEZO_PRE_RF,
+        )
+    )
+
+    assert [spec.phase for spec in specs] == [
+        CommissioningPhase.PIEZO_PRE_RF,
+        CommissioningPhase.FREQUENCY_TUNING,
+    ]

--- a/tests/applications/rf_commissioning/test_piezo_pre_rf_controller.py
+++ b/tests/applications/rf_commissioning/test_piezo_pre_rf_controller.py
@@ -1,0 +1,1250 @@
+"""Targeted tests for Piezo Pre-RF controller helpers."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+import sc_linac_physics.applications.rf_commissioning.ui.controllers.piezo_pre_rf_controller as controller_module
+from sc_linac_physics.applications.rf_commissioning.ui.controllers.piezo_pre_rf_controller import (
+    PiezoPreRFController,
+)
+from sc_linac_physics.applications.rf_commissioning.models.commissioning_piezo import (
+    CommissioningPiezo,
+)
+from sc_linac_physics.applications.rf_commissioning.models.data_models import (
+    CommissioningRecord,
+    PiezoPreRFCheck,
+)
+from sc_linac_physics.applications.rf_commissioning.phases.phase_base import (
+    PhaseContext,
+    PhaseResult,
+    PhaseStepResult,
+)
+
+
+class _ButtonStub:
+    def __init__(self):
+        self.enabled = True
+        self.text = ""
+
+    def setEnabled(self, enabled: bool) -> None:
+        self.enabled = enabled
+
+    def setText(self, text: str) -> None:
+        self.text = text
+
+
+class _ViewStub:
+    def __init__(
+        self,
+        *,
+        current_operator: str = "Test Operator",
+        selected_operator: str = "",
+        cavity: tuple[str, str] | None = ("L1B_CM02_CAV1", "02"),
+    ):
+        self._current_operator = current_operator
+        self._selected_operator = selected_operator
+        self._cavity = cavity
+        self.logs: list[str] = []
+        self.errors: list[str] = []
+
+        self.run_button = _ButtonStub()
+        self.pause_button = _ButtonStub()
+        self.abort_button = _ButtonStub()
+        self.next_step_btn = _ButtonStub()
+        self.local_phase_status = Mock()
+        self.local_progress_bar = Mock()
+        self.ui = SimpleNamespace(update_toolbar_state=Mock())
+        self.step_progress_signal = SimpleNamespace(emit=Mock())
+        self.update_piezo_readbacks = Mock()
+        self._update_local_results = Mock()
+        self._update_stored_readout = Mock()
+
+    def get_current_operator(self) -> str:
+        return self._current_operator
+
+    def get_selected_operator(self) -> str:
+        return self._selected_operator
+
+    def get_current_cavity(self):
+        return self._cavity
+
+    def log_message(self, message: str) -> None:
+        self.logs.append(message)
+
+    def show_error(self, message: str) -> None:
+        self.errors.append(message)
+
+    def clear_results(self) -> None:
+        return None
+
+    def parent(self):
+        return None
+
+    def _notify_parent_of_record_update(self, record, message: str) -> None:
+        return None
+
+
+def _make_controller(view=None, session=None):
+    return PiezoPreRFController(view or _ViewStub(), session or Mock())
+
+
+def _record_with_result() -> CommissioningRecord:
+    record = CommissioningRecord(linac=1, cryomodule="02", cavity_number=1)
+    record.piezo_pre_rf = PiezoPreRFCheck(
+        capacitance_a=25.3e-9,
+        capacitance_b=24.8e-9,
+        channel_a_passed=True,
+        channel_b_passed=True,
+    )
+    return record
+
+
+def test_append_measurement_history_uses_active_phase_instance_id() -> None:
+    session = Mock()
+    controller = _make_controller(session=session)
+    record = _record_with_result()
+    controller.context = PhaseContext(record=record, operator="Test Operator")
+    controller._active_phase_instance_id = 42
+
+    controller._append_measurement_history()
+
+    session.add_measurement_to_history.assert_called_once()
+    args, kwargs = session.add_measurement_to_history.call_args
+    assert kwargs["phase_instance_id"] == 42
+    assert kwargs["operator"] == "Test Operator"
+    assert args[1] is record.piezo_pre_rf
+
+
+def test_append_measurement_history_adds_error_note() -> None:
+    session = Mock()
+    controller = _make_controller(session=session)
+    controller.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+
+    controller._append_measurement_history(error_msg="boom")
+
+    kwargs = session.add_measurement_to_history.call_args[1]
+    assert kwargs["notes"] == "Phase failed: boom"
+
+
+def test_append_measurement_history_no_context_is_noop() -> None:
+    session = Mock()
+    controller = _make_controller(session=session)
+    controller.context = None
+
+    controller._append_measurement_history()
+
+    session.add_measurement_to_history.assert_not_called()
+
+
+def test_get_machine_cavity_builds_machine_with_commissioning_piezo(
+    monkeypatch,
+) -> None:
+    class _MachineStub:
+        def __init__(self, *, piezo_class):
+            self.piezo_class = piezo_class
+            self.cryomodules = {
+                "02": SimpleNamespace(cavities={1: "cavity-object"})
+            }
+
+    monkeypatch.setattr(controller_module, "Machine", _MachineStub)
+    controller = _make_controller()
+
+    cavity = controller._get_machine_cavity(2, 1)
+
+    assert cavity == "cavity-object"
+    assert isinstance(controller.machine, _MachineStub)
+    assert controller.machine.piezo_class is CommissioningPiezo
+
+
+def test_get_operator_does_not_use_legacy_selector() -> None:
+    view = _ViewStub(current_operator="", selected_operator="Legacy Operator")
+    controller = _make_controller(view=view)
+
+    assert controller._get_operator() == ""
+
+
+def test_update_pv_addresses_no_selection_logs_message() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller._resolve_cavity_selection = Mock(return_value=(None, None))
+
+    controller.update_pv_addresses()
+
+    assert "No cavity selected" in view.logs
+
+
+def test_update_pv_addresses_parse_error_logs_message() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller._resolve_cavity_selection = Mock(return_value=("02", "bad"))
+    controller._get_piezo_from_selection = Mock(side_effect=ValueError("bad"))
+
+    controller.update_pv_addresses()
+
+    assert any("Error parsing cavity info" in msg for msg in view.logs)
+
+
+def test_update_pv_addresses_success_runs_mapping_and_sync() -> None:
+    controller = _make_controller()
+    controller._resolve_cavity_selection = Mock(return_value=("02", "1"))
+    controller._get_piezo_from_selection = Mock(return_value=(Mock(), 2, 1))
+    controller._build_pv_mapping = Mock(return_value={"k": Mock()})
+    controller._apply_pv_mapping = Mock()
+    controller._log_pv_update = Mock()
+    controller._sync_piezo_readbacks = Mock()
+
+    controller.update_pv_addresses()
+
+    controller._apply_pv_mapping.assert_called_once()
+    controller._log_pv_update.assert_called_once_with("02", "1", 2, 1)
+    controller._sync_piezo_readbacks.assert_called_once()
+
+
+def test_get_selected_cavity_info_handles_missing_cavity() -> None:
+    view = _ViewStub(cavity=None)
+    controller = _make_controller(view=view)
+
+    assert controller._get_selected_cavity_info() is None
+    assert "Unable to determine cavity information" in view.errors[0]
+
+
+def test_get_selected_cavity_info_handles_parse_error() -> None:
+    view = _ViewStub(cavity=("bad-format", "02"))
+    controller = _make_controller(view=view)
+    controller._parse_cavity_from_record = Mock(side_effect=ValueError())
+
+    assert controller._get_selected_cavity_info() is None
+    assert "Invalid cavity name format" in view.errors[0]
+
+
+def test_get_selected_cavity_info_returns_parsed_values() -> None:
+    controller = _make_controller()
+    controller._parse_cavity_from_record = Mock(return_value=(2, 1))
+
+    result = controller._get_selected_cavity_info()
+
+    assert result == ("L1B_CM02_CAV1", 2, 1)
+
+
+def test_execute_step_with_retries_success_calls_success_handler() -> None:
+    controller = _make_controller()
+    controller.phase = Mock()
+    controller.phase.execute_step.return_value = PhaseStepResult(
+        result=PhaseResult.SUCCESS,
+        message="ok",
+    )
+    controller._create_step_checkpoint = Mock()
+    controller._handle_step_success = Mock(return_value=True)
+
+    result = controller._execute_step_with_retries("setup_piezo", max_retries=3)
+
+    assert result is True
+    controller._create_step_checkpoint.assert_called_once()
+    controller._handle_step_success.assert_called_once()
+
+
+def test_execute_step_with_retries_retry_exhausted_returns_false() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller.phase = Mock()
+    controller.phase.execute_step.return_value = PhaseStepResult(
+        result=PhaseResult.RETRY,
+        message="try again",
+    )
+    controller._create_step_checkpoint = Mock()
+
+    result = controller._execute_step_with_retries("validate", max_retries=2)
+
+    assert result is False
+    assert any("Failed after 2 retries" in msg for msg in view.logs)
+
+
+def test_execute_step_with_retries_failed_result_returns_false() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller.phase = Mock()
+    controller.phase.execute_step.return_value = PhaseStepResult(
+        result=PhaseResult.FAILED,
+        message="bad",
+    )
+    controller._create_step_checkpoint = Mock()
+
+    result = controller._execute_step_with_retries("validate", max_retries=2)
+
+    assert result is False
+    assert any("validate failed" in msg for msg in view.logs)
+
+
+def test_execute_step_with_retries_exception_exhausted_returns_false() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller.phase = Mock()
+    controller.phase.execute_step.side_effect = RuntimeError("rpc down")
+
+    result = controller._execute_step_with_retries("validate", max_retries=2)
+
+    assert result is False
+    assert any("Exception after 2 retries" in msg for msg in view.logs)
+
+
+def test_on_phase_run_finished_routes_to_completed_handler() -> None:
+    controller = _make_controller()
+    controller._sync_piezo_readbacks = Mock()
+    controller.on_phase_completed = Mock()
+    controller.on_phase_failed = Mock()
+
+    controller._on_phase_run_finished(True, "")
+
+    controller._sync_piezo_readbacks.assert_called_once()
+    controller.on_phase_completed.assert_called_once()
+    controller.on_phase_failed.assert_not_called()
+
+
+def test_on_phase_run_finished_uses_default_error_message() -> None:
+    controller = _make_controller()
+    controller._sync_piezo_readbacks = Mock()
+    controller.on_phase_completed = Mock()
+    controller.on_phase_failed = Mock()
+
+    controller._on_phase_run_finished(False, "")
+
+    controller.on_phase_failed.assert_called_once_with("Phase execution failed")
+
+
+def test_on_abort_requests_abort_and_disables_button() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+
+    controller.on_abort()
+
+    assert controller.context.abort_requested is True
+    assert view.abort_button.enabled is False
+    assert "Abort requested..." in view.logs
+
+
+def test_on_pause_test_toggles_pause_state_and_button_text() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+
+    controller.on_pause_test()
+    assert controller._paused is True
+    assert view.pause_button.text == "\u25b6 Resume"
+
+    controller.on_pause_test()
+    assert controller._paused is False
+    assert view.pause_button.text == "\u23f8 Pause"
+
+
+def test_set_next_button_enabled_no_next_step_button_is_safe() -> None:
+    controller = PiezoPreRFController(SimpleNamespace(), Mock())
+    controller._set_next_button_enabled(True)
+
+
+@pytest.mark.parametrize(
+    "view_like",
+    [SimpleNamespace(), SimpleNamespace(ui=SimpleNamespace())],
+)
+def test_update_toolbar_state_without_handler_is_safe(view_like) -> None:
+    controller = PiezoPreRFController(view_like, Mock())
+    controller._update_toolbar_state("running")
+
+
+def test_setup_pv_connections_updates_when_active_record_exists() -> None:
+    session = Mock()
+    session.has_active_record.return_value = True
+    controller = _make_controller(session=session)
+    controller.update_pv_addresses = Mock()
+
+    controller.setup_pv_connections()
+
+    controller.update_pv_addresses.assert_called_once()
+
+
+def test_resolve_and_get_piezo_wrappers(monkeypatch) -> None:
+    controller = _make_controller()
+    piezo = Mock()
+
+    monkeypatch.setattr(
+        controller_module,
+        "resolve_cavity_selection",
+        lambda view, cm, cav: ("02", "1"),
+    )
+    monkeypatch.setattr(
+        controller_module,
+        "get_piezo_from_selection",
+        lambda machine, cm, cav: (piezo, 2, 1, "machine-obj"),
+    )
+
+    assert controller._resolve_cavity_selection(None, None) == ("02", "1")
+    result = controller._get_piezo_from_selection("02", "1")
+    assert result == (piezo, 2, 1)
+    assert controller.machine == "machine-obj"
+
+
+def test_update_pv_addresses_generic_error_logs_message() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller._resolve_cavity_selection = Mock(return_value=("02", "1"))
+    controller._get_piezo_from_selection = Mock(
+        side_effect=RuntimeError("oops")
+    )
+
+    controller.update_pv_addresses()
+
+    assert any("Error setting PVs" in msg for msg in view.logs)
+
+
+def test_update_pv_addresses_mapping_error_logs_message() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller._resolve_cavity_selection = Mock(return_value=("02", "1"))
+    controller._get_piezo_from_selection = Mock(return_value=(Mock(), 2, 1))
+    controller._build_pv_mapping = Mock(side_effect=RuntimeError("map fail"))
+
+    controller.update_pv_addresses()
+
+    assert any("Error setting PVs" in msg for msg in view.logs)
+
+
+def test_build_apply_log_wrappers_delegate(monkeypatch) -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    piezo = Mock()
+    called = {"apply": False}
+
+    monkeypatch.setattr(
+        controller_module,
+        "build_pv_mapping",
+        lambda in_view, in_piezo: {"ok": (in_view, in_piezo)},
+    )
+    monkeypatch.setattr(
+        controller_module,
+        "apply_pv_mapping",
+        lambda mapping: called.__setitem__("apply", bool(mapping)),
+    )
+    monkeypatch.setattr(
+        controller_module,
+        "format_pv_update_message",
+        lambda cm, cav, cm_i, cav_i: f"{cm}-{cav}-{cm_i}-{cav_i}",
+    )
+
+    mapping = controller._build_pv_mapping(piezo)
+    controller._apply_pv_mapping(mapping)
+    controller._log_pv_update("02", "1", 2, 1)
+
+    assert called["apply"] is True
+    assert view.logs[-1] == "02-1-2-1"
+
+
+def test_sync_piezo_readbacks_branches() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    piezo = Mock()
+
+    controller._sync_piezo_readbacks(piezo)
+    view.update_piezo_readbacks.assert_called_once_with(piezo)
+
+    controller._resolve_cavity_selection = Mock(return_value=("02", "1"))
+    controller._get_piezo_from_selection = Mock(return_value=(piezo, 2, 1))
+    controller._sync_piezo_readbacks(None)
+    assert controller._get_piezo_from_selection.called
+
+
+def test_sync_piezo_readbacks_error_and_no_handler_paths() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller._resolve_cavity_selection = Mock(return_value=("02", "1"))
+    controller._get_piezo_from_selection = Mock(
+        side_effect=RuntimeError("rb fail")
+    )
+
+    controller._sync_piezo_readbacks(None)
+    assert any("Readback sync failed" in msg for msg in view.logs)
+
+    controller_no_hook = PiezoPreRFController(SimpleNamespace(), Mock())
+    controller_no_hook._sync_piezo_readbacks(Mock())
+
+
+def test_parse_cavity_from_record() -> None:
+    controller = _make_controller()
+    assert controller._parse_cavity_from_record("L1B_CM02_CAV8", "02") == (2, 8)
+    assert controller._parse_cavity_from_record("SHORT", "02") == (2, 1)
+
+
+def test_prepare_phase_context_can_run_false() -> None:
+    view = _ViewStub()
+    session = Mock()
+    session.get_active_record.return_value = _record_with_result()
+    session.get_active_record_id.return_value = 7
+    session.can_run_phase.return_value = (False, "blocked")
+    controller = _make_controller(view=view, session=session)
+
+    ok = controller._prepare_phase_context(Mock(), "op")
+
+    assert ok is False
+    assert any("ERROR: blocked" in msg for msg in view.logs)
+
+
+def test_prepare_phase_context_prerequisites_fail(monkeypatch) -> None:
+    view = _ViewStub()
+    session = Mock()
+    session.get_active_record.return_value = _record_with_result()
+    session.get_active_record_id.return_value = 7
+    session.can_run_phase.return_value = (True, "")
+    session.start_active_phase_instance.return_value = SimpleNamespace(
+        phase_instance_id=99
+    )
+
+    class _PhaseStub:
+        def __init__(self, context):
+            self.context = context
+
+        def validate_prerequisites(self):
+            return (False, "bad state")
+
+    monkeypatch.setattr(controller_module, "PiezoPreRFPhase", _PhaseStub)
+    controller = _make_controller(view=view, session=session)
+
+    ok = controller._prepare_phase_context(Mock(), "op")
+
+    assert ok is False
+    assert any("ERROR: bad state" in msg for msg in view.logs)
+
+
+def test_prepare_phase_context_success_without_record_id(monkeypatch) -> None:
+    session = Mock()
+    session.get_active_record.return_value = _record_with_result()
+    session.get_active_record_id.return_value = None
+    session.can_run_phase.return_value = (True, "")
+
+    class _PhaseStub:
+        def __init__(self, context):
+            self.context = context
+
+        def validate_prerequisites(self):
+            return (True, "ok")
+
+    monkeypatch.setattr(controller_module, "PiezoPreRFPhase", _PhaseStub)
+    controller = _make_controller(session=session)
+
+    ok = controller._prepare_phase_context(Mock(), "op")
+
+    assert ok is True
+    assert controller._active_phase_instance_id is None
+
+
+def test_set_running_ui_state_sets_expected_controls() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+
+    controller._set_running_ui_state()
+
+    assert view.run_button.enabled is False
+    assert view.pause_button.enabled is True
+    assert view.abort_button.enabled is True
+    view.local_phase_status.setText.assert_called_once_with("RUNNING")
+
+
+def test_on_run_automated_test_no_operator_focuses_parent() -> None:
+    view = _ViewStub(current_operator="")
+    controller = _make_controller(view=view)
+    controller._focus_parent_widget = Mock()
+
+    controller.on_run_automated_test()
+
+    controller._focus_parent_widget.assert_called_once_with("operator_combo")
+
+
+def test_on_run_automated_test_stops_when_auto_create_fails() -> None:
+    session = Mock()
+    session.has_active_record.return_value = False
+    controller = _make_controller(session=session)
+    controller._auto_create_record = Mock(return_value=False)
+
+    controller.on_run_automated_test()
+
+    controller._auto_create_record.assert_called_once()
+
+
+def test_on_run_automated_test_stops_when_no_cavity() -> None:
+    session = Mock()
+    session.has_active_record.return_value = True
+    controller = _make_controller(session=session)
+    controller._get_selected_cavity_info = Mock(return_value=None)
+
+    controller.on_run_automated_test()
+
+    controller._get_selected_cavity_info.assert_called_once()
+
+
+def test_on_run_automated_test_success_path() -> None:
+    view = _ViewStub()
+    session = Mock()
+    session.has_active_record.return_value = True
+    controller = _make_controller(view=view, session=session)
+    controller._get_selected_cavity_info = Mock(
+        return_value=("L1B_CM02_CAV1", 2, 1)
+    )
+    controller.update_pv_addresses = Mock()
+    controller._get_machine_cavity = Mock(return_value=Mock())
+    controller._prepare_phase_context = Mock(return_value=True)
+    controller._set_running_ui_state = Mock()
+    controller.execute_phase_steps = Mock()
+
+    controller.on_run_automated_test()
+
+    controller.update_pv_addresses.assert_called_once_with("02", "1")
+    controller._set_running_ui_state.assert_called_once()
+    controller.execute_phase_steps.assert_called_once()
+
+
+def test_on_run_automated_test_exception_is_logged() -> None:
+    view = _ViewStub()
+    session = Mock()
+    session.has_active_record.return_value = True
+    controller = _make_controller(view=view, session=session)
+    controller._get_selected_cavity_info = Mock(
+        return_value=("L1B_CM02_CAV1", 2, 1)
+    )
+    controller.update_pv_addresses = Mock(side_effect=RuntimeError("kaboom"))
+
+    controller.on_run_automated_test()
+
+    assert any("Failed to start test" in msg for msg in view.errors)
+
+
+def test_auto_create_record_paths(monkeypatch) -> None:
+    view = _ViewStub()
+    session = Mock()
+    controller = _make_controller(view=view, session=session)
+
+    controller._get_cavity_from_parent = Mock(return_value=(None, None))
+    controller._focus_parent_widget = Mock()
+    assert controller._auto_create_record() is False
+
+    controller._get_cavity_from_parent = Mock(return_value=("02", "1"))
+    session.start_new_record.return_value = (_record_with_result(), 10, True)
+    controller._notify_parent_record_created = Mock()
+    controller.update_pv_addresses = Mock()
+    assert controller._auto_create_record() is True
+
+    session.start_new_record.return_value = (_record_with_result(), 10, False)
+    assert controller._auto_create_record() is True
+
+    controller._get_cavity_from_parent = Mock(return_value=("02", "1"))
+    session.start_new_record.side_effect = RuntimeError("db down")
+    assert controller._auto_create_record() is False
+
+
+class _Combo:
+    def __init__(self, text):
+        self._text = text
+
+    def currentText(self):
+        return self._text
+
+
+class _ParentWithCavitySelection:
+    def __init__(self, cm="02", cav="1"):
+        self.cryomodule_combo = _Combo(cm)
+        self.cavity_combo = _Combo(cav)
+
+    def parent(self):
+        return None
+
+
+class _BrokenCombo:
+    def currentText(self):
+        raise RuntimeError("bad parent")
+
+
+class _BadParentWithBrokenCombos:
+    def __init__(self):
+        self.cryomodule_combo = _BrokenCombo()
+        self.cavity_combo = _BrokenCombo()
+
+    def parent(self):
+        return None
+
+
+class _FocusableParent:
+    def __init__(self):
+        self.operator_combo = SimpleNamespace(setFocus=Mock())
+
+    def parent(self):
+        return None
+
+
+class _ChainParent:
+    def __init__(self, parent_obj):
+        self._parent_obj = parent_obj
+
+    def parent(self):
+        return self._parent_obj
+
+
+def test_get_cavity_from_parent_returns_selected_cm_and_cavity() -> None:
+    controller = _make_controller()
+    view = _ViewStub()
+    view.parent = lambda: _ParentWithCavitySelection(cm="02", cav="1")
+    controller.view = view
+
+    assert controller._get_cavity_from_parent() == ("02", "1")
+
+
+def test_get_cavity_from_parent_returns_none_when_selection_empty() -> None:
+    controller = _make_controller()
+    view = _ViewStub()
+    view.parent = lambda: _ParentWithCavitySelection(cm="", cav="")
+    controller.view = view
+
+    assert controller._get_cavity_from_parent() == (None, None)
+
+
+def test_get_cavity_from_parent_returns_none_when_parent_combo_fails() -> None:
+    controller = _make_controller()
+    view = _ViewStub()
+    view.parent = lambda: _BadParentWithBrokenCombos()
+    controller.view = view
+
+    assert controller._get_cavity_from_parent() == (None, None)
+
+
+def test_focus_parent_widget_focuses_direct_parent_attribute() -> None:
+    controller = _make_controller()
+    view = _ViewStub()
+    focus_parent = _FocusableParent()
+    view.parent = lambda: focus_parent
+    controller.view = view
+
+    controller._focus_parent_widget("operator_combo")
+
+    focus_parent.operator_combo.setFocus.assert_called_once()
+
+
+def test_focus_parent_widget_traverses_parent_chain() -> None:
+    controller = _make_controller()
+    view = _ViewStub()
+    focus_parent = _FocusableParent()
+    view.parent = lambda: _ChainParent(focus_parent)
+    controller.view = view
+
+    controller._focus_parent_widget("operator_combo")
+
+    focus_parent.operator_combo.setFocus.assert_called_once()
+
+
+def test_on_run_automated_test_stops_when_prepare_context_fails() -> None:
+    session = Mock()
+    session.has_active_record.return_value = True
+    controller = _make_controller(session=session)
+    controller._get_selected_cavity_info = Mock(
+        return_value=("L1B_CM02_CAV1", 2, 1)
+    )
+    controller.update_pv_addresses = Mock()
+    controller._get_machine_cavity = Mock(return_value=Mock())
+    controller._prepare_phase_context = Mock(return_value=False)
+    controller.execute_phase_steps = Mock()
+
+    controller.on_run_automated_test()
+
+    controller.execute_phase_steps.assert_not_called()
+
+
+def test_execute_phase_steps_paths(monkeypatch) -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+
+    controller.context = None
+    controller.phase = None
+    controller.execute_phase_steps()
+    assert "No phase context available" in view.errors[-1]
+
+    controller.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+    controller.phase = Mock()
+    controller.phase.get_phase_steps.return_value = ["a"]
+    controller._step_mode = True
+    controller._set_next_button_enabled = Mock()
+    monkeypatch.setattr(
+        controller_module.QTimer, "singleShot", lambda _ms, fn: fn()
+    )
+
+    controller.execute_phase_steps()
+    controller._set_next_button_enabled.assert_called_once_with(True)
+
+    controller._step_mode = False
+    controller._run_phase_in_background = Mock(
+        side_effect=RuntimeError("run boom")
+    )
+    controller.on_phase_failed = Mock()
+    controller.execute_phase_steps()
+    controller.on_phase_failed.assert_called_once_with("run boom")
+
+
+def test_run_phase_in_background_worker_paths(monkeypatch) -> None:
+    controller = _make_controller()
+    controller.phase = Mock()
+    controller.phase.get_phase_steps.return_value = ["step"]
+    controller._check_pause_and_abort = Mock(return_value=False)
+
+    class _ThreadStub:
+        def __init__(self, target, daemon):
+            self.target = target
+
+        def start(self):
+            self.target()
+
+    monkeypatch.setattr(controller_module, "Thread", _ThreadStub)
+    controller._run_phase_in_background()
+
+    controller = _make_controller()
+    controller.phase = Mock()
+    controller.phase.get_phase_steps.return_value = ["step"]
+    controller.phase._execute_step_with_retry.return_value = False
+    controller._check_pause_and_abort = Mock(return_value=True)
+    monkeypatch.setattr(controller_module, "Thread", _ThreadStub)
+    emitted = []
+    controller.phase_run_finished.connect(
+        lambda ok, msg: emitted.append((ok, msg))
+    )
+    controller._run_phase_in_background()
+    assert emitted[-1] == (False, "Step failed: step")
+
+    controller = _make_controller()
+    controller.phase = Mock()
+    controller.phase.get_phase_steps.side_effect = RuntimeError("worker fail")
+    monkeypatch.setattr(controller_module, "Thread", _ThreadStub)
+    emitted = []
+    controller.phase_run_finished.connect(
+        lambda ok, msg: emitted.append((ok, msg))
+    )
+    controller._run_phase_in_background()
+    assert emitted[-1] == (False, "worker fail")
+
+    controller = _make_controller()
+    controller.phase = Mock()
+    controller.phase.get_phase_steps.return_value = ["step"]
+    controller.phase._execute_step_with_retry.return_value = True
+    controller._check_pause_and_abort = Mock(return_value=True)
+    controller._finalize_background_phase = Mock()
+    monkeypatch.setattr(controller_module, "Thread", _ThreadStub)
+    controller._run_phase_in_background()
+    controller._finalize_background_phase.assert_called_once()
+
+
+def test_check_pause_and_abort_paths(monkeypatch) -> None:
+    controller = _make_controller()
+    controller.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+    controller._paused = True
+
+    def _sleep(_):
+        controller.context.request_abort()
+
+    monkeypatch.setitem(
+        __import__("sys").modules, "time", SimpleNamespace(sleep=_sleep)
+    )
+    emitted = []
+    controller.phase_run_finished.connect(
+        lambda ok, msg: emitted.append((ok, msg))
+    )
+    assert controller._check_pause_and_abort() is False
+    assert emitted[-1] == (False, "Aborted")
+
+    controller = _make_controller()
+    controller.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+    controller.context.request_abort()
+    emitted = []
+    controller.phase_run_finished.connect(
+        lambda ok, msg: emitted.append((ok, msg))
+    )
+    assert controller._check_pause_and_abort() is False
+    assert emitted[-1] == (False, "Aborted")
+
+    controller = _make_controller()
+    assert controller._check_pause_and_abort() is True
+
+
+def test_finalize_background_phase_paths() -> None:
+    controller = _make_controller()
+    controller.phase = Mock()
+    emitted = []
+    controller.phase_run_finished.connect(
+        lambda ok, msg: emitted.append((ok, msg))
+    )
+    controller._finalize_background_phase()
+    assert emitted[-1] == (True, "")
+
+    controller = _make_controller()
+    controller.phase = Mock()
+    controller.phase.finalize_phase.side_effect = RuntimeError("finalize fail")
+    emitted = []
+    controller.phase_run_finished.connect(
+        lambda ok, msg: emitted.append((ok, msg))
+    )
+    controller._finalize_background_phase()
+    assert emitted[-1] == (False, "finalize fail")
+
+
+def test_execute_single_step_and_wait_notify_helpers(monkeypatch) -> None:
+    controller = _make_controller()
+    controller._wait_for_unpause = Mock(return_value=False)
+    assert controller._execute_single_step("step") is False
+
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller._wait_for_unpause = Mock(return_value=True)
+    controller.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+    controller.context.request_abort()
+    assert controller._execute_single_step("step") is False
+    assert any("Abort during step" in msg for msg in view.logs)
+
+    controller = _make_controller()
+    controller._wait_for_unpause = Mock(return_value=True)
+    controller._notify_step_progress = Mock()
+    controller._execute_step_with_retries = Mock(return_value=True)
+    assert controller._execute_single_step("step") is True
+
+    controller = _make_controller()
+    assert controller._wait_for_unpause() is True
+    controller._paused = True
+    calls = {"n": 0}
+    monkeypatch.setattr(
+        controller_module.QTimer, "singleShot", lambda _ms, fn: fn()
+    )
+
+    def _sleep(_):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            controller._paused = False
+
+    monkeypatch.setitem(
+        __import__("sys").modules, "time", SimpleNamespace(sleep=_sleep)
+    )
+    assert controller._wait_for_unpause() is True
+
+    events = []
+    controller.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+    controller.context.progress_callback = lambda step, prog: events.append(
+        (step, prog)
+    )
+    controller._steps = ["a", "b"]
+    controller._notify_step_progress("b")
+    controller._notify_step_progress("x")
+    assert events[0] == ("b", 50)
+    assert events[1] == ("x", 0)
+
+
+def test_execute_step_with_retries_skip_and_retry_then_success() -> None:
+    controller = _make_controller()
+    controller.phase = Mock()
+    controller.phase.execute_step.return_value = PhaseStepResult(
+        result=PhaseResult.SKIP,
+        message="skip",
+    )
+    controller._create_step_checkpoint = Mock()
+    controller._handle_step_success = Mock(return_value=True)
+    assert controller._execute_step_with_retries("step", 2) is True
+
+    controller = _make_controller(view=_ViewStub())
+    controller.phase = Mock()
+    controller.phase.execute_step.side_effect = [
+        PhaseStepResult(result=PhaseResult.RETRY, message="retry"),
+        PhaseStepResult(result=PhaseResult.SUCCESS, message="ok"),
+    ]
+    controller._create_step_checkpoint = Mock()
+    controller._handle_step_success = Mock(return_value=True)
+    assert controller._execute_step_with_retries("step", 3) is True
+
+
+def test_execute_step_with_retries_zero_retries_returns_false() -> None:
+    controller = _make_controller()
+    controller.phase = Mock()
+    assert controller._execute_step_with_retries("step", 0) is False
+
+
+def test_create_checkpoint_and_handle_step_success_paths() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    record = _record_with_result()
+    record.phase_history = []
+    controller.context = PhaseContext(record=record, operator="op")
+    controller.phase = Mock()
+    controller.phase.phase_type = "PHASE"
+
+    result = PhaseStepResult(
+        result=PhaseResult.SUCCESS, message="done", data={"a": 1}
+    )
+    controller._create_step_checkpoint("step", result)
+    assert len(record.phase_history) == 1
+
+    controller._sync_piezo_readbacks = Mock()
+    assert controller._handle_step_success("setup_piezo", result) is True
+    controller._sync_piezo_readbacks.assert_called_once()
+
+    skip = PhaseStepResult(result=PhaseResult.SKIP, message="skip")
+    assert controller._handle_step_success("validate", skip) is True
+
+
+def test_finalize_phase_execution_paths() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller.phase = Mock()
+    controller.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+    controller.on_phase_completed = Mock()
+    controller._finalize_phase_execution()
+    controller.on_phase_completed.assert_called_once()
+
+    controller = _make_controller(view=_ViewStub())
+    controller.phase = Mock()
+    rec = _record_with_result()
+    rec.piezo_pre_rf = None
+    controller.context = PhaseContext(record=rec, operator="op")
+    controller.on_phase_completed = Mock()
+    controller._finalize_phase_execution()
+    assert any("not populated" in msg for msg in controller.view.logs)
+
+    controller = _make_controller(view=_ViewStub())
+    controller.phase = Mock()
+    controller.phase.finalize_phase.side_effect = RuntimeError("boom")
+    controller.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+    controller.on_phase_failed = Mock()
+    controller._finalize_phase_execution()
+    controller.on_phase_failed.assert_called_once_with("boom")
+
+
+def test_on_phase_completed_paths() -> None:
+    view = _ViewStub()
+    session = Mock()
+    session.complete_active_phase_instance.return_value = True
+    session.has_active_record.return_value = True
+    session.get_active_record.return_value = SimpleNamespace(
+        current_phase=SimpleNamespace(value="NEXT")
+    )
+    session.save_active_record.return_value = True
+    session.get_active_record_id.return_value = 77
+    controller = _make_controller(view=view, session=session)
+    controller.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+    controller._active_phase_instance_id = 3
+    captured = []
+    controller.phase_completed.connect(lambda rec: captured.append(rec))
+    controller._append_measurement_history = Mock()
+
+    controller.on_phase_completed()
+
+    assert controller._active_phase_instance_id is None
+    assert view.run_button.enabled is True
+    assert captured
+
+    view2 = _ViewStub()
+    session2 = Mock()
+    session2.complete_active_phase_instance.return_value = False
+    session2.save_active_record.return_value = False
+    controller2 = _make_controller(view=view2, session=session2)
+    controller2.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+    controller2._active_phase_instance_id = 5
+    controller2.on_phase_completed()
+    assert any("Warning: Failed to advance" in msg for msg in view2.logs)
+    assert any("Warning: Failed to save" in msg for msg in view2.logs)
+
+    view3 = _ViewStub()
+    controller3 = _make_controller(view=view3, session=Mock())
+    rec = _record_with_result()
+    rec.piezo_pre_rf = None
+    controller3.context = PhaseContext(record=rec, operator="op")
+    controller3.on_phase_completed()
+    assert any("No piezo_pre_rf" in msg for msg in view3.logs)
+
+
+def test_on_phase_completed_exception_fails_active_phase() -> None:
+    view = _ViewStub()
+    session = Mock()
+    session.complete_active_phase_instance.side_effect = RuntimeError(
+        "svc down"
+    )
+    controller = _make_controller(view=view, session=session)
+    controller.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+    controller._active_phase_instance_id = 11
+
+    controller.on_phase_completed()
+
+    session.fail_active_phase_instance.assert_called_once()
+
+
+def test_on_phase_failed_paths() -> None:
+    view = _ViewStub()
+    session = Mock()
+    session.save_active_record.return_value = True
+    controller = _make_controller(view=view, session=session)
+    controller.phase = Mock()
+    controller.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+    controller._active_phase_instance_id = 9
+    controller._append_measurement_history = Mock()
+
+    controller.on_phase_failed("bad")
+
+    session.fail_active_phase_instance.assert_called_once()
+    assert view.run_button.enabled is True
+    assert view.pause_button.enabled is False
+    assert view.abort_button.enabled is False
+
+    view2 = _ViewStub()
+    session2 = Mock()
+    controller2 = _make_controller(view=view2, session=session2)
+    controller2.phase = Mock()
+    rec = _record_with_result()
+    rec.piezo_pre_rf = None
+    controller2.context = PhaseContext(record=rec, operator="op")
+    controller2._active_phase_instance_id = 4
+    controller2.on_phase_failed("bad2")
+    kwargs = session2.fail_active_phase_instance.call_args[1]
+    assert kwargs["artifact_payload"] is None
+
+
+def test_on_phase_failed_exception_branch() -> None:
+    view = _ViewStub()
+    session = Mock()
+    session.save_active_record.side_effect = RuntimeError("db exploded")
+    controller = _make_controller(view=view, session=session)
+    controller.phase = Mock()
+    controller.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+    controller._active_phase_instance_id = 10
+
+    controller.on_phase_failed("orig")
+
+    session.fail_active_phase_instance.assert_called_once()
+
+
+def test_get_operator_empty_when_no_methods() -> None:
+    controller = PiezoPreRFController(SimpleNamespace(), Mock())
+    assert controller._get_operator() == ""
+
+
+def test_on_abort_without_context_is_noop() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller.context = None
+    controller.on_abort()
+    assert view.abort_button.enabled is True
+
+
+def test_set_next_button_enabled_and_update_toolbar_positive_paths() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller._set_next_button_enabled(True)
+    assert view.next_step_btn.enabled is True
+
+    controller._update_toolbar_state("running")
+    view.ui.update_toolbar_state.assert_called_once_with("running")
+
+
+def test_toggle_step_mode_and_next_step_paths(monkeypatch) -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller._set_next_button_enabled = Mock()
+
+    controller.on_toggle_step_mode()
+    assert controller._step_mode is True
+
+    controller.on_toggle_step_mode()
+    assert controller._step_mode is False
+    controller._set_next_button_enabled.assert_called_with(False)
+
+    controller._step_mode = False
+    controller._step_executing = False
+    controller.on_next_step()
+
+    controller._step_mode = True
+    controller._step_executing = True
+    controller.on_next_step()
+
+    controller._step_executing = False
+    controller._steps = ["a"]
+    controller._current_step_index = 1
+    controller.on_next_step()
+    assert any("All steps completed" in msg for msg in view.logs)
+
+    monkeypatch.setattr(
+        controller_module.QTimer, "singleShot", lambda _ms, fn: fn()
+    )
+    controller._current_step_index = 0
+    controller._steps = ["a", "b"]
+    controller._execute_single_step = Mock(return_value=True)
+    controller._set_next_button_enabled = Mock()
+    controller.on_next_step()
+    assert controller._current_step_index == 1
+
+    controller._steps = ["a"]
+    controller._current_step_index = 0
+    controller._execute_single_step = Mock(return_value=True)
+    controller._finalize_phase_execution = Mock()
+    controller.on_next_step()
+    controller._finalize_phase_execution.assert_called_once()
+
+    controller._steps = ["a"]
+    controller._current_step_index = 0
+    controller._execute_single_step = Mock(return_value=False)
+    controller.on_phase_failed = Mock()
+    controller.on_next_step()
+    controller.on_phase_failed.assert_called_once_with("Step execution failed")
+
+    controller._steps = ["a"]
+    controller._current_step_index = 0
+    controller._execute_single_step = Mock(
+        side_effect=RuntimeError("step kaboom")
+    )
+    controller.on_phase_failed = Mock()
+    controller.on_next_step()
+    controller.on_phase_failed.assert_called_once_with("step kaboom")
+
+
+def test_notify_parent_record_created_logs_message() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    record = _record_with_result()
+
+    controller._notify_parent_record_created(record, 1)
+
+    assert any("Notified parent container" in msg for msg in view.logs)
+
+
+def test_get_cavity_from_parent_returns_none_when_no_matching_parent() -> None:
+    controller = _make_controller()
+
+    class _NoCombos:
+        def parent(self):
+            return None
+
+    controller.view.parent = lambda: _NoCombos()
+
+    assert controller._get_cavity_from_parent() == (None, None)

--- a/tests/utils/sc_linac/test_piezo.py
+++ b/tests/utils/sc_linac/test_piezo.py
@@ -111,11 +111,12 @@ def test_enable(piezo):
     piezo._bias_voltage_pv_obj = make_mock_pv()
     piezo._enable_stat_pv_obj = make_mock_pv()
 
-    # For 1 loop iteration: 2 calls (condition + logging) + 1 final check = 3 total
+    # With robust status logging, only condition checks consume get side effects.
+    # This sequence yields 2 loop iterations then exit.
     piezo._enable_stat_pv_obj.get = Mock(
         side_effect=[
             PIEZO_DISABLE_VALUE,  # while loop check
-            PIEZO_DISABLE_VALUE,  # logging in loop body
+            PIEZO_DISABLE_VALUE,  # second while loop check
             PIEZO_ENABLE_VALUE,  # final while loop check - exits
         ]
     )
@@ -126,8 +127,8 @@ def test_enable(piezo):
     piezo.enable()
 
     piezo._bias_voltage_pv_obj.put.assert_called_with(25)
-    assert piezo.cavity.check_abort.call_count == 1
-    assert piezo._enable_pv_obj.put.call_count == 2  # 1 disable + 1 enable
+    assert piezo.cavity.check_abort.call_count == 2
+    assert piezo._enable_pv_obj.put.call_count == 4  # 2x (disable + enable)
 
 
 def test_enable_feedback(piezo):


### PR DESCRIPTION

Introduces the core backend for the RF commissioning application:
- Data models and enums (CommissioningRecord, phase/status enums)
- SQLite persistence layer with optimistic locking (CommissioningDatabase)
- Phase execution framework (PhaseBase, PiezoPreRFPhase)
- CommissioningSession facade and WorkflowService orchestration
- Piezo hardware model updates and simulation tuner service
- CLI launcher registration

Generated with AI

Co-Authored-By: SLAC AI