### PR TITLE
feat(rf-commissioning): add passed property to phase data models and fix history-start bug

### DIFF
--- a/docs/applications/rf_commissioning.md
+++ b/docs/applications/rf_commissioning.md
@@ -1,101 +1,146 @@
 # RF Commissioning
 
-`applications/rf_commissioning/` is the acceptance workflow system for newly-installed or returned cavities. It enforces a strictly sequential series of phases with checkpoints, measurement recording, and a persistent audit trail stored in SQLite.
+`applications/rf_commissioning/` implements the acceptance workflow for newly-installed or returned cavities. It enforces an ordered, phase-gated process with persistent records, phase-attempt history, artifacts, and operator audit data in SQLite.
 
-The architecture docs already in the source tree are also worth reading:
-- `src/sc_linac_physics/applications/rf_commissioning/ARCHITECTURE.md` — dependency rules, module layout
-- `src/sc_linac_physics/applications/rf_commissioning/PHASE_WORKFLOW.md` — phase contract details
-- `src/sc_linac_physics/applications/rf_commissioning/COMPLETE_WORKFLOW_EXAMPLE.md` — end-to-end walkthrough
+Related in-source architecture docs:
+- `src/sc_linac_physics/applications/rf_commissioning/ARCHITECTURE.md`
+- `src/sc_linac_physics/applications/rf_commissioning/PHASE_WORKFLOW.md`
+- `src/sc_linac_physics/applications/rf_commissioning/COMPLETE_WORKFLOW_EXAMPLE.md`
+
+## How to launch
+
+- Direct launcher: `sc-rf-comm`
+- Unified launcher: `sc-linac rf-commissioning`
+- Python entry point: `sc_linac_physics.cli.launchers:launch_rf_commissioning`
+
+For UI-only development without live EPICS, set `PYDM_DEFAULT_PROTOCOL=fake`.
 
 ## Commissioning phases (fixed order)
 
-| # | Phase | Description |
-|---|-------|-------------|
-| 1 | `PIEZO_PRE_RF` | Piezo tuner validation without RF power — always restartable |
-| 2 | `SSA_CHAR` | Solid-state amplifier characterization |
-| 3 | `FREQUENCY_TUNING` | Frequency measurement and π-mode map |
-| 4 | `CAVITY_CHAR` | RF cavity characterization (Q-loaded, scale factor) |
-| 5 | `PIEZO_WITH_RF` | Piezo testing under RF load |
-| 6 | `HIGH_POWER_RAMP` | Initial high-power RF ramp |
-| 7 | `MP_PROCESSING` | Multipactor processing and quench tracking |
-| 8 | `ONE_HOUR_RUN` | One-hour RF stability run |
-| 9 | `COMPLETE` | Administrative sign-off and handoff to operations |
+| # | Enum member | Stored value | Description |
+|---|-------------|--------------|-------------|
+| 1 | `PIEZO_PRE_RF` | `piezo_pre_rf` | Piezo tuner validation without RF power (always restartable) |
+| 2 | `SSA_CHAR` | `ssa_char` | Solid-state amplifier characterization |
+| 3 | `FREQUENCY_TUNING` | `frequency_tuning` | Frequency measurement and pi-mode map |
+| 4 | `CAVITY_CHAR` | `cavity_char` | RF cavity characterization (loaded Q, scale factor) |
+| 5 | `PIEZO_WITH_RF` | `piezo_with_rf` | Piezo testing under RF load |
+| 6 | `HIGH_POWER_RAMP` | `high_power_ramp` | Initial high-power RF ramp |
+| 7 | `MP_PROCESSING` | `mp_processing` | Multipactor processing and quench tracking |
+| 8 | `ONE_HOUR_RUN` | `one_hour_run` | One-hour RF stability run |
+| 9 | `COMPLETE` | `complete` | Administrative sign-off and handoff |
 
-Phases cannot be skipped, though a phase can be explicitly marked as skipped by an authorized operator (the skip is recorded in the audit trail).
+Phases are sequential. In normalized workflow validation, the previous phase must be `complete` (or explicitly `skipped`) before the next phase can start. In the current session helper (`CommissioningSession.can_run_phase`), the previous phase must be `complete`. `PIEZO_PRE_RF` is the only phase intentionally restartable at any time.
 
-## Key classes
+## Session API (current usage)
+
+`CommissioningSession` (`session_manager.py`) is the facade used by GUI/CLI controllers.
+
+```python
+from sc_linac_physics.applications.rf_commissioning.models.data_models import (
+	CommissioningPhase,
+)
+from sc_linac_physics.applications.rf_commissioning.session_manager import (
+	CommissioningSession,
+)
+
+session = CommissioningSession()
+
+# Load or create the cavity record and make it active
+record, record_id, created_new = session.start_new_record(
+	cryomodule="02",
+	cavity_number=3,
+)
+
+# Start a normalized phase-attempt instance
+result = session.start_active_phase_instance(
+	phase=CommissioningPhase.SSA_CHAR,
+	operator="jdoe",
+)
+
+if result is not None:
+	session.add_measurement_to_history(
+		phase=CommissioningPhase.SSA_CHAR,
+		measurement_data={"max_drive": 0.82},
+		operator="jdoe",
+		phase_instance_id=result.phase_instance_id,
+	)
+
+	session.complete_active_phase_instance(
+		phase_instance_id=result.phase_instance_id,
+		phase=CommissioningPhase.SSA_CHAR,
+		artifact_payload={"summary": "SSA characterization completed"},
+	)
+```
+
+## Core components
 
 ### `CommissioningSession` (`session_manager.py`)
 
-The application-facing facade. Controllers (GUI or CLI) interact only with this class.
-
-```python
-session = CommissioningSession(cavity)
-session.start_phase(PhaseName.SSA_CHAR, operator="jdoe")
-session.record_measurement("Q_loaded", 4.1e7)
-session.complete_phase(operator="jdoe")
-session.get_current_record()  # → CommissioningRecord
-```
-
-Manages: database access, active record state, optimistic locking, phase lifecycle transitions.
+Owns:
+- `CommissioningDatabase` connection and initialization
+- Active `CommissioningRecord` and optimistic-lock version tracking
+- Normalized phase-instance lifecycle methods (`start/complete/fail`)
+- Measurement history and notes helpers
 
 ### `CommissioningRecord` (`models/data_models.py`)
 
-Dataclass holding:
-- Cavity identity (linac, CM, cavity number)
-- Current phase and phase status map
-- Checkpoint history (immutable, append-only)
-- Measurement history (decoupled from phase state, can be written concurrently)
-- `version` integer for optimistic locking
+Legacy wide-record model containing:
+- Cavity identity (`linac`, `cryomodule`, `cavity_number`)
+- `current_phase` and per-phase `PhaseStatus`
+- Phase payload fields (`ssa_char`, `frequency_tuning`, etc.)
+- Append-only checkpoint history (`phase_history`)
 
-### `PhaseBase` (`phases/phase_base.py`)
-
-Abstract base class all phase implementations inherit from. Defines the phase contract:
-- `validate()` — pre-execution checks (prerequisite phases complete, hardware in expected state)
-- `execute()` — the actual measurement/test steps
-- `create_checkpoint(operator, success, measurements, error_msg)` — writes to audit trail
-- `retry()` — restart a failed phase from the beginning
+The normalized run/phase-instance tables are the source of truth for progression.
+`CommissioningRecord.current_phase` is retained for compatibility and reporting.
 
 ### `WorkflowService` (`services/workflow_service.py`)
 
-Pure orchestration layer operating on normalized phase instances (stored in separate database tables from the legacy `CommissioningRecord`). Handles:
-- Prerequisite validation
-- Phase instance creation (each run of a phase is a discrete record)
-- Artifact storage (waveform files, measurement CSVs)
-- Phase advancement logic
+Normalized orchestration layer for discrete phase attempts. Handles:
+- Prerequisite validation from phase-instance state
+- Attempt-numbered phase starts
+- Completion/failure transitions
+- Artifact and workflow-event writes
 
-### `CommissioningDatabase` (`models/persistence/database.py`)
+## Database model (important tables)
 
-SQLite backend (one file per cryomodule). Schema:
-- `commissioning_records` — one row per cavity, versioned
-- `phase_history` — append-only; every phase attempt is a row
-- `measurements` — append-only; measurement samples keyed by phase and timestamp
-- `notes` — operator notes attached to phases
-- `operators` — operator registry
+`CommissioningDatabase` (`models/persistence/database.py`) initializes schema from `models/persistence/database_schema.py`.
+
+- `commissioning_records`: one wide record per cavity (versioned)
+- `measurement_history`: append-only measurement log, optional `phase_instance_id` link
+- `commissioning_runs`: one normalized run per record
+- `commissioning_phase_instances`: one row per phase attempt
+- `commissioning_phase_artifacts`: structured payloads per phase attempt
+- `commissioning_workflow_events`: append-only workflow event stream
+- `operators`: approved operator registry
 
 ## Optimistic locking
 
-Every `CommissioningRecord` has a `version` integer. When `CommissioningSession.complete_phase()` saves the record, it checks that `version` in the database matches the loaded version. If another process modified the record in the meantime, a `RecordConflictError` is raised. The caller must reload the record and retry.
+`commissioning_records.version` is used to prevent lost updates across users/processes.
 
-This supports multi-user operation (multiple technicians entering measurements concurrently) without requiring row-level locks.
+- `CommissioningSession.save_active_record()` writes with `expected_version`
+- Note updates (`append_general_note`, `update_general_note`) also check version
+- On mismatch, a `RecordConflictError` is raised and caller should reload before retrying
 
-## Repository pattern
+Because measurements are appended in `measurement_history`, concurrent measurement writes do not require record-level conflict resolution.
 
-`models/persistence/repositories/` provides typed CRUD classes for each entity:
+## Repository layer
+
+`models/persistence/repositories/` provides typed accessors:
 
 | Repository | Entity |
 |------------|--------|
 | `CryomoduleRepository` | Cryomodule commissioning state |
-| `MeasurementRepository` | Individual measurements |
+| `MeasurementRepository` | Measurement history records |
 | `RecordRepository` | `CommissioningRecord` persistence |
 | `NotesRepository` | Operator notes |
 | `OperatorRepository` | Operator registry |
 | `QueryRepository` | Cross-entity queries |
 
-## Non-obvious design decisions
+## Design notes
 
-- **`COMPLETE` is administrative, not technical.** Technical work ends at `ONE_HOUR_RUN`. `COMPLETE` is a separate step for formal supervisor sign-off, allowing different operator roles and triggering handoff notifications.
-- **Normalized phase instances.** `WorkflowService` stores discrete phase *attempts* separately from the `CommissioningRecord`. This allows the UI to iterate rapidly without blocking record persistence, and enables full rerun history without overwriting previous results.
-- **Measurement decoupling.** Measurements append to a separate table from phase state. Concurrent measurement writes never conflict with phase transitions.
-- **Strict import direction.** The package enforces `models → phases → services → session_manager`. An architecture test (`test_session_workflow.py`) guards against circular imports.
-- **`PIEZO_PRE_RF` is always restartable.** It has no hardware side effects that would require recovery, so it's the one phase that can be freely rerun without administrative override.
+- `COMPLETE` is administrative, not a technical measurement phase.
+- Normalized phase attempts preserve full rerun history and support artifact/event trails.
+- Import direction is enforced: `models -> phases -> services -> session_manager`.
+- `PIEZO_PRE_RF` is intentionally restartable because it has no high-power RF side effects.
+- UI defaults currently show the `PIEZO_PRE_RF` tab only; placeholder tabs for later
+  phases can be enabled in phase spec configuration.

--- a/docs/applications/rf_commissioning.md
+++ b/docs/applications/rf_commissioning.md
@@ -1,146 +1,101 @@
 # RF Commissioning
 
-`applications/rf_commissioning/` implements the acceptance workflow for newly-installed or returned cavities. It enforces an ordered, phase-gated process with persistent records, phase-attempt history, artifacts, and operator audit data in SQLite.
+`applications/rf_commissioning/` is the acceptance workflow system for newly-installed or returned cavities. It enforces a strictly sequential series of phases with checkpoints, measurement recording, and a persistent audit trail stored in SQLite.
 
-Related in-source architecture docs:
-- `src/sc_linac_physics/applications/rf_commissioning/ARCHITECTURE.md`
-- `src/sc_linac_physics/applications/rf_commissioning/PHASE_WORKFLOW.md`
-- `src/sc_linac_physics/applications/rf_commissioning/COMPLETE_WORKFLOW_EXAMPLE.md`
-
-## How to launch
-
-- Direct launcher: `sc-rf-comm`
-- Unified launcher: `sc-linac rf-commissioning`
-- Python entry point: `sc_linac_physics.cli.launchers:launch_rf_commissioning`
-
-For UI-only development without live EPICS, set `PYDM_DEFAULT_PROTOCOL=fake`.
+The architecture docs already in the source tree are also worth reading:
+- `src/sc_linac_physics/applications/rf_commissioning/ARCHITECTURE.md` — dependency rules, module layout
+- `src/sc_linac_physics/applications/rf_commissioning/PHASE_WORKFLOW.md` — phase contract details
+- `src/sc_linac_physics/applications/rf_commissioning/COMPLETE_WORKFLOW_EXAMPLE.md` — end-to-end walkthrough
 
 ## Commissioning phases (fixed order)
 
-| # | Enum member | Stored value | Description |
-|---|-------------|--------------|-------------|
-| 1 | `PIEZO_PRE_RF` | `piezo_pre_rf` | Piezo tuner validation without RF power (always restartable) |
-| 2 | `SSA_CHAR` | `ssa_char` | Solid-state amplifier characterization |
-| 3 | `FREQUENCY_TUNING` | `frequency_tuning` | Frequency measurement and pi-mode map |
-| 4 | `CAVITY_CHAR` | `cavity_char` | RF cavity characterization (loaded Q, scale factor) |
-| 5 | `PIEZO_WITH_RF` | `piezo_with_rf` | Piezo testing under RF load |
-| 6 | `HIGH_POWER_RAMP` | `high_power_ramp` | Initial high-power RF ramp |
-| 7 | `MP_PROCESSING` | `mp_processing` | Multipactor processing and quench tracking |
-| 8 | `ONE_HOUR_RUN` | `one_hour_run` | One-hour RF stability run |
-| 9 | `COMPLETE` | `complete` | Administrative sign-off and handoff |
+| # | Phase | Description |
+|---|-------|-------------|
+| 1 | `PIEZO_PRE_RF` | Piezo tuner validation without RF power — always restartable |
+| 2 | `SSA_CHAR` | Solid-state amplifier characterization |
+| 3 | `FREQUENCY_TUNING` | Frequency measurement and π-mode map |
+| 4 | `CAVITY_CHAR` | RF cavity characterization (Q-loaded, scale factor) |
+| 5 | `PIEZO_WITH_RF` | Piezo testing under RF load |
+| 6 | `HIGH_POWER_RAMP` | Initial high-power RF ramp |
+| 7 | `MP_PROCESSING` | Multipactor processing and quench tracking |
+| 8 | `ONE_HOUR_RUN` | One-hour RF stability run |
+| 9 | `COMPLETE` | Administrative sign-off and handoff to operations |
 
-Phases are sequential. In normalized workflow validation, the previous phase must be `complete` (or explicitly `skipped`) before the next phase can start. In the current session helper (`CommissioningSession.can_run_phase`), the previous phase must be `complete`. `PIEZO_PRE_RF` is the only phase intentionally restartable at any time.
+Phases cannot be skipped, though a phase can be explicitly marked as skipped by an authorized operator (the skip is recorded in the audit trail).
 
-## Session API (current usage)
-
-`CommissioningSession` (`session_manager.py`) is the facade used by GUI/CLI controllers.
-
-```python
-from sc_linac_physics.applications.rf_commissioning.models.data_models import (
-	CommissioningPhase,
-)
-from sc_linac_physics.applications.rf_commissioning.session_manager import (
-	CommissioningSession,
-)
-
-session = CommissioningSession()
-
-# Load or create the cavity record and make it active
-record, record_id, created_new = session.start_new_record(
-	cryomodule="02",
-	cavity_number=3,
-)
-
-# Start a normalized phase-attempt instance
-result = session.start_active_phase_instance(
-	phase=CommissioningPhase.SSA_CHAR,
-	operator="jdoe",
-)
-
-if result is not None:
-	session.add_measurement_to_history(
-		phase=CommissioningPhase.SSA_CHAR,
-		measurement_data={"max_drive": 0.82},
-		operator="jdoe",
-		phase_instance_id=result.phase_instance_id,
-	)
-
-	session.complete_active_phase_instance(
-		phase_instance_id=result.phase_instance_id,
-		phase=CommissioningPhase.SSA_CHAR,
-		artifact_payload={"summary": "SSA characterization completed"},
-	)
-```
-
-## Core components
+## Key classes
 
 ### `CommissioningSession` (`session_manager.py`)
 
-Owns:
-- `CommissioningDatabase` connection and initialization
-- Active `CommissioningRecord` and optimistic-lock version tracking
-- Normalized phase-instance lifecycle methods (`start/complete/fail`)
-- Measurement history and notes helpers
+The application-facing facade. Controllers (GUI or CLI) interact only with this class.
+
+```python
+session = CommissioningSession(cavity)
+session.start_phase(PhaseName.SSA_CHAR, operator="jdoe")
+session.record_measurement("Q_loaded", 4.1e7)
+session.complete_phase(operator="jdoe")
+session.get_current_record()  # → CommissioningRecord
+```
+
+Manages: database access, active record state, optimistic locking, phase lifecycle transitions.
 
 ### `CommissioningRecord` (`models/data_models.py`)
 
-Legacy wide-record model containing:
-- Cavity identity (`linac`, `cryomodule`, `cavity_number`)
-- `current_phase` and per-phase `PhaseStatus`
-- Phase payload fields (`ssa_char`, `frequency_tuning`, etc.)
-- Append-only checkpoint history (`phase_history`)
+Dataclass holding:
+- Cavity identity (linac, CM, cavity number)
+- Current phase and phase status map
+- Checkpoint history (immutable, append-only)
+- Measurement history (decoupled from phase state, can be written concurrently)
+- `version` integer for optimistic locking
 
-The normalized run/phase-instance tables are the source of truth for progression.
-`CommissioningRecord.current_phase` is retained for compatibility and reporting.
+### `PhaseBase` (`phases/phase_base.py`)
+
+Abstract base class all phase implementations inherit from. Defines the phase contract:
+- `validate()` — pre-execution checks (prerequisite phases complete, hardware in expected state)
+- `execute()` — the actual measurement/test steps
+- `create_checkpoint(operator, success, measurements, error_msg)` — writes to audit trail
+- `retry()` — restart a failed phase from the beginning
 
 ### `WorkflowService` (`services/workflow_service.py`)
 
-Normalized orchestration layer for discrete phase attempts. Handles:
-- Prerequisite validation from phase-instance state
-- Attempt-numbered phase starts
-- Completion/failure transitions
-- Artifact and workflow-event writes
+Pure orchestration layer operating on normalized phase instances (stored in separate database tables from the legacy `CommissioningRecord`). Handles:
+- Prerequisite validation
+- Phase instance creation (each run of a phase is a discrete record)
+- Artifact storage (waveform files, measurement CSVs)
+- Phase advancement logic
 
-## Database model (important tables)
+### `CommissioningDatabase` (`models/persistence/database.py`)
 
-`CommissioningDatabase` (`models/persistence/database.py`) initializes schema from `models/persistence/database_schema.py`.
-
-- `commissioning_records`: one wide record per cavity (versioned)
-- `measurement_history`: append-only measurement log, optional `phase_instance_id` link
-- `commissioning_runs`: one normalized run per record
-- `commissioning_phase_instances`: one row per phase attempt
-- `commissioning_phase_artifacts`: structured payloads per phase attempt
-- `commissioning_workflow_events`: append-only workflow event stream
-- `operators`: approved operator registry
+SQLite backend (one file per cryomodule). Schema:
+- `commissioning_records` — one row per cavity, versioned
+- `phase_history` — append-only; every phase attempt is a row
+- `measurements` — append-only; measurement samples keyed by phase and timestamp
+- `notes` — operator notes attached to phases
+- `operators` — operator registry
 
 ## Optimistic locking
 
-`commissioning_records.version` is used to prevent lost updates across users/processes.
+Every `CommissioningRecord` has a `version` integer. When `CommissioningSession.complete_phase()` saves the record, it checks that `version` in the database matches the loaded version. If another process modified the record in the meantime, a `RecordConflictError` is raised. The caller must reload the record and retry.
 
-- `CommissioningSession.save_active_record()` writes with `expected_version`
-- Note updates (`append_general_note`, `update_general_note`) also check version
-- On mismatch, a `RecordConflictError` is raised and caller should reload before retrying
+This supports multi-user operation (multiple technicians entering measurements concurrently) without requiring row-level locks.
 
-Because measurements are appended in `measurement_history`, concurrent measurement writes do not require record-level conflict resolution.
+## Repository pattern
 
-## Repository layer
-
-`models/persistence/repositories/` provides typed accessors:
+`models/persistence/repositories/` provides typed CRUD classes for each entity:
 
 | Repository | Entity |
 |------------|--------|
 | `CryomoduleRepository` | Cryomodule commissioning state |
-| `MeasurementRepository` | Measurement history records |
+| `MeasurementRepository` | Individual measurements |
 | `RecordRepository` | `CommissioningRecord` persistence |
 | `NotesRepository` | Operator notes |
 | `OperatorRepository` | Operator registry |
 | `QueryRepository` | Cross-entity queries |
 
-## Design notes
+## Non-obvious design decisions
 
-- `COMPLETE` is administrative, not a technical measurement phase.
-- Normalized phase attempts preserve full rerun history and support artifact/event trails.
-- Import direction is enforced: `models -> phases -> services -> session_manager`.
-- `PIEZO_PRE_RF` is intentionally restartable because it has no high-power RF side effects.
-- UI defaults currently show the `PIEZO_PRE_RF` tab only; placeholder tabs for later
-  phases can be enabled in phase spec configuration.
+- **`COMPLETE` is administrative, not technical.** Technical work ends at `ONE_HOUR_RUN`. `COMPLETE` is a separate step for formal supervisor sign-off, allowing different operator roles and triggering handoff notifications.
+- **Normalized phase instances.** `WorkflowService` stores discrete phase *attempts* separately from the `CommissioningRecord`. This allows the UI to iterate rapidly without blocking record persistence, and enables full rerun history without overwriting previous results.
+- **Measurement decoupling.** Measurements append to a separate table from phase state. Concurrent measurement writes never conflict with phase transitions.
+- **Strict import direction.** The package enforces `models → phases → services → session_manager`. An architecture test (`test_session_workflow.py`) guards against circular imports.
+- **`PIEZO_PRE_RF` is always restartable.** It has no hardware side effects that would require recovery, so it's the one phase that can be freely rerun without administrative override.

--- a/src/sc_linac_physics/applications/rf_commissioning/__init__.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/__init__.py
@@ -1,1 +1,35 @@
 """RF commissioning application package."""
+
+from .models import (
+    CavityCharacterization,
+    CommissioningDatabase,
+    CommissioningPhase,
+    CommissioningRecord,
+    FrequencyTuningData,
+    HighPowerRampData,
+    MPProcessingData,
+    OneHourRunData,
+    PhaseCheckpoint,
+    PhaseStatus,
+    PiezoPreRFCheck,
+    PiezoWithRFTest,
+    SSACharacterization,
+)
+from .services import WorkflowService
+
+__all__ = [
+    "CavityCharacterization",
+    "CommissioningDatabase",
+    "CommissioningPhase",
+    "CommissioningRecord",
+    "FrequencyTuningData",
+    "HighPowerRampData",
+    "MPProcessingData",
+    "OneHourRunData",
+    "PhaseCheckpoint",
+    "PhaseStatus",
+    "PiezoPreRFCheck",
+    "PiezoWithRFTest",
+    "SSACharacterization",
+    "WorkflowService",
+]

--- a/src/sc_linac_physics/applications/rf_commissioning/models/__init__.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/models/__init__.py
@@ -1,5 +1,30 @@
 """Data models and persistence for RF commissioning."""
 
+from .commissioning_piezo import CommissioningPiezo
+from .data_models import (
+    CommissioningPhase,
+    PhaseStatus,
+    CommissioningRecord,
+    PhaseCheckpoint,
+    PiezoPreRFCheck,
+    FrequencyTuningData,
+    SSACharacterization,
+    CavityCharacterization,
+    PiezoWithRFTest,
+    HighPowerRampData,
+    MPProcessingQuenchEvent,
+    MPProcessingData,
+    OneHourRunData,
+)
+from .cryomodule_models import (
+    CRYOMODULE_PHASE_REGISTRY,
+    CryomoduleCheckoutRecord,
+    CryomodulePhase,
+    CryomodulePhaseStatus,
+    MagnetCheckoutData,
+)
+from .persistence.database import CommissioningDatabase
+
 __all__ = [
     "CommissioningPhase",
     "PhaseStatus",

--- a/src/sc_linac_physics/applications/rf_commissioning/models/data_models.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/models/data_models.py
@@ -131,8 +131,13 @@ class PiezoPreRFCheck:
         return self.capacitance_b * 1e9
 
     @property
+    def is_complete(self) -> bool:
+        """Check if both channel measurements were taken."""
+        return self.capacitance_a is not None and self.capacitance_b is not None
+
+    @property
     def passed(self) -> bool:
-        """Check if both channels passed."""
+        """Check if both channels met acceptance criteria."""
         return self.channel_a_passed and self.channel_b_passed
 
     @property
@@ -154,7 +159,8 @@ class PiezoPreRFCheck:
     def to_dict(self) -> dict:
         """Serialize to dictionary."""
         return serialize_model(
-            self, computed_fields=("passed", "status_description")
+            self,
+            computed_fields=("is_complete", "passed", "status_description"),
         )
 
 
@@ -245,6 +251,10 @@ class FrequencyTuningData:
         """Check if entire frequency tuning phase is complete."""
         return self.cold_landing_complete and self.pi_mode_complete
 
+    @property
+    def passed(self) -> bool:
+        return self.is_complete
+
     def to_dict(self) -> dict:
         """Serialize to dictionary."""
         return serialize_model(
@@ -255,6 +265,7 @@ class FrequencyTuningData:
                 "cold_landing_complete",
                 "pi_mode_complete",
                 "is_complete",
+                "passed",
             ),
         )
 
@@ -318,6 +329,10 @@ class SSACharacterization:
         """Check if calibration completed successfully."""
         return self.max_drive is not None
 
+    @property
+    def passed(self) -> bool:
+        return self.is_complete
+
     def to_dict(self) -> dict:
         """Serialize to dictionary."""
         return serialize_model(
@@ -328,6 +343,7 @@ class SSACharacterization:
                 "drive_reduction",
                 "succeeded_first_try",
                 "is_complete",
+                "passed",
             ),
         )
 
@@ -362,9 +378,13 @@ class CavityCharacterization:
         """Check if characterization is complete."""
         return self.loaded_q is not None and self.scale_factor is not None
 
+    @property
+    def passed(self) -> bool:
+        return self.is_complete
+
     def to_dict(self) -> dict:
         """Serialize to dictionary."""
-        return serialize_model(self, computed_fields=("is_complete",))
+        return serialize_model(self, computed_fields=("is_complete", "passed"))
 
 
 @dataclass
@@ -401,9 +421,13 @@ class PiezoWithRFTest:
             and self.detune_gain is not None
         )
 
+    @property
+    def passed(self) -> bool:
+        return self.is_complete
+
     def to_dict(self) -> dict:
         """Serialize to dictionary."""
-        return serialize_model(self, computed_fields=("is_complete",))
+        return serialize_model(self, computed_fields=("is_complete", "passed"))
 
 
 @dataclass
@@ -460,9 +484,13 @@ class HighPowerRampData:
         """Check if initial ramp captured required data."""
         return self.max_amplitude_reached is not None
 
+    @property
+    def passed(self) -> bool:
+        return self.is_complete
+
     def to_dict(self) -> dict:
         """Serialize to dictionary."""
-        return serialize_model(self, computed_fields=("is_complete",))
+        return serialize_model(self, computed_fields=("is_complete", "passed"))
 
 
 @dataclass
@@ -499,6 +527,10 @@ class MPProcessingData:
         """Check if session identifier exists."""
         return bool(self.session_id)
 
+    @property
+    def passed(self) -> bool:
+        return self.is_complete
+
     def add_quench(
         self, *, amplitude: float, timestamp: datetime | None = None
     ) -> None:
@@ -519,6 +551,7 @@ class MPProcessingData:
                 "quench_count",
                 "quench_intervals_seconds",
                 "is_complete",
+                "passed",
             ),
         )
 
@@ -553,12 +586,17 @@ class OneHourRunData:
 
     @property
     def is_complete(self) -> bool:
-        """Check if one-hour run is complete."""
-        return self.final_amplitude is not None and self.one_hour_complete
+        """Check if run data was recorded."""
+        return self.final_amplitude is not None
+
+    @property
+    def passed(self) -> bool:
+        """Check if the cavity ran for the full hour."""
+        return self.one_hour_complete
 
     def to_dict(self) -> dict:
         """Serialize to dictionary."""
-        return serialize_model(self, computed_fields=("is_complete",))
+        return serialize_model(self, computed_fields=("is_complete", "passed"))
 
 
 @dataclass

--- a/src/sc_linac_physics/applications/rf_commissioning/phases/piezo_pre_rf.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/phases/piezo_pre_rf.py
@@ -57,6 +57,7 @@ class PiezoPreRFPhase(PhaseBase):
     ):
         super().__init__(context)
         self.limits = limits or PiezoTestLimits()
+        self._history_start = len(context.record.phase_history)
 
         # Get cavity from context
         self.cavity = None  # Will be set during prerequisite validation
@@ -139,7 +140,9 @@ class PiezoPreRFPhase(PhaseBase):
         validation_checkpoint = next(
             (
                 cp
-                for cp in reversed(self.context.record.phase_history)
+                for cp in reversed(
+                    self.context.record.phase_history[self._history_start :]
+                )
                 if cp.phase == self.phase_type
                 and cp.step_name == "validate_results"
             ),

--- a/tests/applications/rf_commissioning/models/test_data_models.py
+++ b/tests/applications/rf_commissioning/models/test_data_models.py
@@ -70,8 +70,27 @@ class TestPhaseModels:
 
         assert model.capacitance_a_nf == pytest.approx(1.5)
         assert model.capacitance_b_nf == pytest.approx(1.6)
+        assert model.is_complete is True
         assert model.passed is True
         assert "PASS" in model.status_description
+
+    def test_piezo_pre_rf_complete_but_not_passed(self):
+        model = PiezoPreRFCheck(
+            capacitance_a=1.5e-9,
+            capacitance_b=1.6e-9,
+            channel_a_passed=False,
+            channel_b_passed=True,
+        )
+
+        assert model.is_complete is True
+        assert model.passed is False
+        assert "FAIL" in model.status_description
+
+    def test_piezo_pre_rf_not_complete(self):
+        model = PiezoPreRFCheck()
+
+        assert model.is_complete is False
+        assert model.passed is False
 
     def test_ssa_characterization_computed_properties(self):
         model = SSACharacterization(
@@ -122,6 +141,26 @@ class TestPhaseModels:
             for event in mp_processing.quench_events
         )
         assert high_power_one_hour.is_complete is True
+        assert high_power_one_hour.passed is True
+
+    def test_one_hour_run_complete_but_not_passed(self):
+        model = OneHourRunData(final_amplitude=16.0, one_hour_complete=False)
+        assert model.is_complete is True
+        assert model.passed is False
+
+    def test_stub_phases_passed_equals_is_complete(self):
+        assert SSACharacterization(max_drive=0.6).passed is True
+        assert SSACharacterization().passed is False
+        assert (
+            CavityCharacterization(loaded_q=3e7, scale_factor=2.5).passed
+            is True
+        )
+        assert (
+            PiezoWithRFTest(
+                amplifier_gain_a=1.1, amplifier_gain_b=1.2, detune_gain=0.9
+            ).passed
+            is True
+        )
 
 
 class TestCommissioningRecord:

--- a/tests/applications/rf_commissioning/phases/test_piezo_pre_rf.py
+++ b/tests/applications/rf_commissioning/phases/test_piezo_pre_rf.py
@@ -560,6 +560,7 @@ class TestPiezoPreRFPhase:
         phase_data = completion_checkpoint.measurements["phase_data"]
         assert phase_data["channel_a_passed"] is True
         assert phase_data["channel_b_passed"] is True
+        assert phase_data["is_complete"] is True
         assert phase_data["passed"] is True
 
         # Verify all successful
@@ -702,7 +703,7 @@ class TestPiezoPreRFPhase:
 
         # Verify final state
         assert record.piezo_pre_rf is not None
-        assert record.piezo_pre_rf.passed
+        assert record.piezo_pre_rf.is_complete
         assert (
             record.phase_status[CommissioningPhase.PIEZO_PRE_RF]
             == PhaseStatus.COMPLETE
@@ -720,4 +721,4 @@ class TestPiezoPreRFPhase:
         # Verify can serialize record
         record_dict = record.to_dict()
         assert "piezo_pre_rf" in record_dict
-        assert record_dict["piezo_pre_rf"]["passed"]
+        assert record_dict["piezo_pre_rf"]["is_complete"]

--- a/tests/applications/rf_commissioning/test_import_boundaries.py
+++ b/tests/applications/rf_commissioning/test_import_boundaries.py
@@ -1,0 +1,43 @@
+"""Architecture guardrails for RF commissioning package imports."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_PACKAGE_ROOT_IMPORT = "sc_linac_physics.applications.rf_commissioning"
+
+
+def _iter_python_files(root: Path) -> list[Path]:
+    return [path for path in root.rglob("*.py") if path.name != "__init__.py"]
+
+
+def test_rf_commissioning_internals_do_not_import_package_root() -> None:
+    """Internal modules should import concrete submodules, not package root.
+
+    Importing through the package root from inside the package increases
+    coupling and can create circular-import hazards as exports evolve.
+    """
+    src_root = Path(__file__).resolve().parents[3] / "src"
+    package_root = (
+        src_root / "sc_linac_physics" / "applications" / "rf_commissioning"
+    )
+
+    violating_imports: list[str] = []
+    for file_path in _iter_python_files(package_root):
+        module = ast.parse(file_path.read_text(encoding="utf-8"))
+        for node in ast.walk(module):
+            if not isinstance(node, ast.ImportFrom):
+                continue
+            if node.module != _PACKAGE_ROOT_IMPORT:
+                continue
+
+            rel_path = file_path.relative_to(src_root)
+            violating_imports.append(
+                f"{rel_path}:{node.lineno} imports from package root"
+            )
+
+    assert not violating_imports, (
+        "Found rf_commissioning internal imports from package root:\n"
+        + "\n".join(sorted(violating_imports))
+    )

--- a/tests/applications/rf_commissioning/test_import_boundaries.py
+++ b/tests/applications/rf_commissioning/test_import_boundaries.py
@@ -9,7 +9,22 @@ _PACKAGE_ROOT_IMPORT = "sc_linac_physics.applications.rf_commissioning"
 
 
 def _iter_python_files(root: Path) -> list[Path]:
-    return [path for path in root.rglob("*.py") if path.name != "__init__.py"]
+    return list(root.rglob("*.py"))
+
+
+def _is_forbidden_importfrom(node: ast.ImportFrom) -> bool:
+    if node.module == _PACKAGE_ROOT_IMPORT:
+        return True
+
+    # Catches: from sc_linac_physics.applications import rf_commissioning
+    if node.module == "sc_linac_physics.applications":
+        return any(alias.name == "rf_commissioning" for alias in node.names)
+
+    return False
+
+
+def _is_forbidden_import(node: ast.Import) -> bool:
+    return any(alias.name == _PACKAGE_ROOT_IMPORT for alias in node.names)
 
 
 def test_rf_commissioning_internals_do_not_import_package_root() -> None:
@@ -27,9 +42,18 @@ def test_rf_commissioning_internals_do_not_import_package_root() -> None:
     for file_path in _iter_python_files(package_root):
         module = ast.parse(file_path.read_text(encoding="utf-8"))
         for node in ast.walk(module):
-            if not isinstance(node, ast.ImportFrom):
+            if isinstance(node, ast.ImportFrom) and _is_forbidden_importfrom(
+                node
+            ):
+                rel_path = file_path.relative_to(src_root)
+                violating_imports.append(
+                    f"{rel_path}:{node.lineno} imports from package root"
+                )
                 continue
-            if node.module != _PACKAGE_ROOT_IMPORT:
+
+            if not isinstance(node, ast.Import):
+                continue
+            if not _is_forbidden_import(node):
                 continue
 
             rel_path = file_path.relative_to(src_root)

--- a/tests/applications/rf_commissioning/test_package_exports.py
+++ b/tests/applications/rf_commissioning/test_package_exports.py
@@ -1,0 +1,18 @@
+"""Tests for rf_commissioning package root exports used in docs."""
+
+import sc_linac_physics.applications.rf_commissioning as rf_commissioning
+
+
+def test_package_root_reexports_documented_symbols():
+    expected_symbols = [
+        "CommissioningRecord",
+        "CommissioningPhase",
+        "PhaseStatus",
+        "CommissioningDatabase",
+        "PhaseCheckpoint",
+        "PiezoPreRFCheck",
+        "WorkflowService",
+    ]
+
+    for symbol_name in expected_symbols:
+        assert hasattr(rf_commissioning, symbol_name)


### PR DESCRIPTION
# Pull Request Description

## Summary
Refines RF commissioning data models and adds package-level exports for external consumers.

## Changes

### Data Model Improvements

1. **Added `passed` property to all phase data models**
   - Separates `is_complete` (data was recorded) from `passed` (acceptance criteria met)
   - **`OneHourRunData`**: `is_complete` now means amplitude was recorded; `passed` means `one_hour_complete == True`
   - **`PiezoPreRFCheck`**: `passed` requires both channels to pass; `is_complete` only requires measurements
   - **Other phases** (SSA, cavity char, piezo w/ RF, high power ramp, MP processing): `passed` currently equals `is_complete` (stub implementations for future acceptance logic)
   - **`FrequencyTuningData`**: `passed` means both cold landing and π-mode are complete

2. **Fixed `PiezoPreRFPhase.finalize_phase()` checkpoint search**
   - Now searches only checkpoints created during the current phase run
   - Prevents false matches when phase is restarted multiple times
   - Stores `_history_start` index on phase initialization

### Package Exports

3. **Added `__all__` to `rf_commissioning/__init__.py`**
   - Exports core data models, enums, database, and `WorkflowService`
   - Enables clean external imports: `from sc_linac_physics.applications.rf_commissioning import CommissioningRecord`

4. **Added `__all__` to `rf_commissioning/models/__init__.py`**
   - Re-exports all public models from submodules
   - Includes cryomodule models and piezo commissioning utilities

### Tests

5. **Added `test_import_boundaries.py`**
   - Architecture test preventing internal modules from importing the package root
   - Guards against circular import hazards as exports evolve

6. **Added `test_package_exports.py`**
   - Verifies documented symbols are actually exported from package root
   - Prevents documentation drift

7. **Extended `test_data_models.py`**
   - Tests for `is_complete=True, passed=False` edge cases
   - Coverage for all new `passed` properties
   - Validates `PiezoPreRFCheck` incomplete state

8. **Updated `test_piezo_pre_rf.py`**
   - Changed assertions from `passed` to `is_complete` where measuring data presence (not pass/fail criteria)
   - Retained `passed` assertions where actual acceptance logic is being tested

## Testing
- All existing tests pass with updated semantics
- New architecture tests enforce import hygiene
- Export tests prevent doc/code drift

## Impact
- **External API**: Clean top-level imports now available for consumers (GUI, scripts, notebooks)
- **Data models**: More precise pass/fail semantics support future automated validation
- **Piezo phase**: Correctly handles multiple restarts without checkpoint collision