### PR TITLE
fix(rf-commissioning): fix status presentation logic and add Result column to history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.claude/*
+
 # IDEs
 .vscode/*
 .idea/*

--- a/src/sc_linac_physics/applications/rf_commissioning/models/persistence/database_helpers.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/models/persistence/database_helpers.py
@@ -39,7 +39,7 @@ def serialize_measurement_data(measurement_data: Any) -> str:
 
 
 def parse_json_list(payload: str | None) -> list[dict]:
-    """Return a JSON list payload, tolerating missing or legacy values."""
+    """Return a JSON list payload, tolerating missing or invalid values."""
     if not payload:
         return []
 

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/displays/base_placeholder.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/displays/base_placeholder.py
@@ -166,38 +166,24 @@ class BasePlaceholderDisplay(PhaseDisplayBase):
 
     def _get_stored_status_presentation(self, phase_data) -> tuple[str, str]:
         """Choose the stored-data status text and styling."""
-        if hasattr(phase_data, "passed"):
-            passed = bool(getattr(phase_data, "passed"))
-            return (
-                "PASS" if passed else "FAIL",
-                (
-                    (
-                        LOCAL_LABEL_STYLE.replace("#2a2a1a", "#2d5016")
-                        + "color: #90ee90;"
-                    )
-                    if passed
-                    else (
-                        LOCAL_LABEL_STYLE.replace("#2a2a1a", "#5c1a1a")
-                        + "color: #ff6b6b;"
-                    )
-                ),
-            )
-
         if hasattr(phase_data, "is_complete"):
-            complete = bool(getattr(phase_data, "is_complete"))
+            if not phase_data.is_complete:
+                return (
+                    "INCOMPLETE",
+                    LOCAL_LABEL_STYLE.replace("#2a2a1a", "#5c4b1a")
+                    + "color: #ffd166;",
+                )
+            passed = getattr(phase_data, "passed", True)
+            if passed:
+                return (
+                    "PASS",
+                    LOCAL_LABEL_STYLE.replace("#2a2a1a", "#2d5016")
+                    + "color: #90ee90;",
+                )
             return (
-                "COMPLETE" if complete else "INCOMPLETE",
-                (
-                    (
-                        LOCAL_LABEL_STYLE.replace("#2a2a1a", "#2d5016")
-                        + "color: #90ee90;"
-                    )
-                    if complete
-                    else (
-                        LOCAL_LABEL_STYLE.replace("#2a2a1a", "#5c4b1a")
-                        + "color: #ffd166;"
-                    )
-                ),
+                "FAIL",
+                LOCAL_LABEL_STYLE.replace("#2a2a1a", "#5c1a1a")
+                + "color: #ff6b6b;",
             )
 
         return "AVAILABLE", LOCAL_LABEL_STYLE

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/measurement_history_dialog.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/measurement_history_dialog.py
@@ -1,5 +1,6 @@
 """Dialog for viewing measurement history."""
 
+from PyQt5.QtGui import QColor
 from PyQt5.QtWidgets import (
     QDialog,
     QVBoxLayout,
@@ -81,9 +82,16 @@ class MeasurementHistoryDialog(QDialog):
 
         # Table
         self.table = QTableWidget()
-        self.table.setColumnCount(5)
+        self.table.setColumnCount(6)
         self.table.setHorizontalHeaderLabels(
-            ["Timestamp", "Phase", "Operator", "Notes", "Data Summary"]
+            [
+                "Timestamp",
+                "Phase",
+                "Result",
+                "Operator",
+                "Notes",
+                "Data Summary",
+            ]
         )
 
         # Make columns resize appropriately
@@ -91,8 +99,9 @@ class MeasurementHistoryDialog(QDialog):
         header.setSectionResizeMode(0, QHeaderView.ResizeToContents)
         header.setSectionResizeMode(1, QHeaderView.ResizeToContents)
         header.setSectionResizeMode(2, QHeaderView.ResizeToContents)
-        header.setSectionResizeMode(3, QHeaderView.Stretch)
+        header.setSectionResizeMode(3, QHeaderView.ResizeToContents)
         header.setSectionResizeMode(4, QHeaderView.Stretch)
+        header.setSectionResizeMode(5, QHeaderView.Stretch)
 
         self.table.setAlternatingRowColors(True)
         self.table.setSelectionBehavior(QTableWidget.SelectRows)
@@ -149,17 +158,27 @@ class MeasurementHistoryDialog(QDialog):
             phase_item.setFlags(phase_item.flags() & ~Qt.ItemIsEditable)
             self.table.setItem(row, 1, phase_item)
 
+            # Result
+            result_label, result_color = self._result_for(
+                entry["measurement_data"]
+            )
+            result_item = QTableWidgetItem(result_label)
+            result_item.setFlags(result_item.flags() & ~Qt.ItemIsEditable)
+            result_item.setForeground(result_color)
+            result_item.setTextAlignment(Qt.AlignCenter)
+            self.table.setItem(row, 2, result_item)
+
             # Operator
             operator = entry.get("operator") or "Unknown"
             operator_item = QTableWidgetItem(operator)
             operator_item.setFlags(operator_item.flags() & ~Qt.ItemIsEditable)
-            self.table.setItem(row, 2, operator_item)
+            self.table.setItem(row, 3, operator_item)
 
             # Notes
             notes_list = entry.get("notes") or []
             notes_item = QTableWidgetItem(self._format_notes(notes_list))
             notes_item.setFlags(notes_item.flags() & ~Qt.ItemIsEditable)
-            self.table.setItem(row, 3, notes_item)
+            self.table.setItem(row, 4, notes_item)
 
             # Data summary
             data_summary = self._summarize_measurement_data(
@@ -167,7 +186,7 @@ class MeasurementHistoryDialog(QDialog):
             )
             data_item = QTableWidgetItem(data_summary)
             data_item.setFlags(data_item.flags() & ~Qt.ItemIsEditable)
-            self.table.setItem(row, 4, data_item)
+            self.table.setItem(row, 5, data_item)
 
         # Update count
         phase_name = (
@@ -185,7 +204,7 @@ class MeasurementHistoryDialog(QDialog):
 
         row = selected[0].row()
         entry_id = self.table.item(row, 0).data(Qt.UserRole)
-        current_operator = self.table.item(row, 2).text()
+        current_operator = self.table.item(row, 3).text()
 
         dialog = QDialog(self)
         dialog.setWindowTitle("Add Measurement Note")
@@ -219,6 +238,14 @@ class MeasurementHistoryDialog(QDialog):
 
         if self.session.append_measurement_note(entry_id, operator, note):
             self._load_history()
+
+    def _result_for(self, data: dict) -> tuple[str, QColor]:
+        """Return (label, color) indicating whether a measurement succeeded."""
+        if not data.get("is_complete"):
+            return "—", QColor("#888888")
+        if data.get("passed"):
+            return "Pass", QColor("#2e7d32")
+        return "Fail", QColor("#c62828")
 
     def _format_notes(self, notes_list: list[dict]) -> str:
         if not notes_list:

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/measurement_history_dialog.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/measurement_history_dialog.py
@@ -1,5 +1,7 @@
 """Dialog for viewing measurement history."""
 
+from collections.abc import Mapping
+
 from PyQt5.QtGui import QColor
 from PyQt5.QtWidgets import (
     QDialog,
@@ -239,12 +241,17 @@ class MeasurementHistoryDialog(QDialog):
         if self.session.append_measurement_note(entry_id, operator, note):
             self._load_history()
 
-    def _result_for(self, data: dict) -> tuple[str, QColor]:
+    def _result_for(self, data: object | None) -> tuple[str, QColor]:
         """Return (label, color) indicating whether a measurement succeeded."""
+        if not isinstance(data, Mapping):
+            return "—", QColor("#888888")
+
         if not data.get("is_complete"):
             return "—", QColor("#888888")
-        if data.get("passed"):
+
+        if data.get("passed", True):
             return "Pass", QColor("#2e7d32")
+
         return "Fail", QColor("#c62828")
 
     def _format_notes(self, notes_list: list[dict]) -> str:
@@ -263,10 +270,14 @@ class MeasurementHistoryDialog(QDialog):
 
         return "\n".join(lines)
 
-    def _summarize_measurement_data(self, data: dict) -> str:
+    def _summarize_measurement_data(self, data: object | None) -> str:
         """Create a brief summary of measurement data."""
         if not data:
             return "No data"
+
+        if not isinstance(data, Mapping):
+            rendered = str(data)
+            return rendered if len(rendered) < 40 else f"{rendered[:37]}..."
 
         # Show first few key-value pairs
         summary_parts = []

--- a/tests/applications/rf_commissioning/ui/test_commissioning_popups.py
+++ b/tests/applications/rf_commissioning/ui/test_commissioning_popups.py
@@ -73,7 +73,11 @@ def _session(has_record=True, history=None):
 
 
 def _history_entry(
-    id=1, phase="piezo_pre_rf", operator="Alice", notes=None, data=None
+    id=1,
+    phase="piezo_pre_rf",
+    operator: str | None = "Alice",
+    notes=None,
+    data=None,
 ):
     return {
         "id": id,
@@ -304,8 +308,51 @@ def test_mhd_history_entries_populate_table(qtbot):
     assert "2 measurement" in dlg.count_label.text()
 
 
+def test_mhd_null_measurement_data_shows_neutral_status(qtbot):
+    history = [
+        {
+            "id": 1,
+            "timestamp": "2025-01-01T10:00:00",
+            "phase": "piezo_pre_rf",
+            "operator": "Alice",
+            "notes": [],
+            "measurement_data": None,
+        }
+    ]
+    dlg = MeasurementHistoryDialog(_session(history=history))
+    qtbot.addWidget(dlg)
+    assert dlg.table.item(0, 2).text() == "—"
+    assert dlg.table.item(0, 5).text() == "No data"
+
+
+def test_mhd_non_mapping_measurement_data_shows_neutral_status(qtbot):
+    history = [
+        {
+            "id": 1,
+            "timestamp": "2025-01-01T10:00:00",
+            "phase": "piezo_pre_rf",
+            "operator": "Alice",
+            "notes": [],
+            "measurement_data": ["legacy", "payload"],
+        }
+    ]
+    dlg = MeasurementHistoryDialog(_session(history=history))
+    qtbot.addWidget(dlg)
+    assert dlg.table.item(0, 2).text() == "—"
+    assert dlg.table.item(0, 5).text() == "['legacy', 'payload']"
+
+
 def test_mhd_missing_operator_shows_unknown(qtbot):
-    history = [_history_entry(operator=None)]
+    history = [
+        {
+            "id": 1,
+            "timestamp": "2025-01-01T10:00:00",
+            "phase": "piezo_pre_rf",
+            "operator": None,
+            "notes": [],
+            "measurement_data": {},
+        }
+    ]
     dlg = MeasurementHistoryDialog(_session(history=history))
     qtbot.addWidget(dlg)
     assert dlg.table.item(0, 3).text() == "Unknown"
@@ -378,6 +425,27 @@ def test_mhd_summarize_data_complex_only(qtbot):
         dlg._summarize_measurement_data({"a": {"nested": True}})
         == "Complex data"
     )
+
+
+def test_mhd_result_for_complete_payload_without_passed_defaults_to_pass(qtbot):
+    dlg = MeasurementHistoryDialog(_session())
+    qtbot.addWidget(dlg)
+    label, _ = dlg._result_for({"is_complete": True})
+    assert label == "Pass"
+
+
+def test_mhd_result_for_complete_failed_payload(qtbot):
+    dlg = MeasurementHistoryDialog(_session())
+    qtbot.addWidget(dlg)
+    label, _ = dlg._result_for({"is_complete": True, "passed": False})
+    assert label == "Fail"
+
+
+def test_mhd_result_for_non_mapping_payload_is_neutral(qtbot):
+    dlg = MeasurementHistoryDialog(_session())
+    qtbot.addWidget(dlg)
+    label, _ = dlg._result_for(["legacy"])
+    assert label == "—"
 
 
 def test_mhd_history_notes_shown_in_table(qtbot):

--- a/tests/applications/rf_commissioning/ui/test_commissioning_popups.py
+++ b/tests/applications/rf_commissioning/ui/test_commissioning_popups.py
@@ -308,7 +308,7 @@ def test_mhd_missing_operator_shows_unknown(qtbot):
     history = [_history_entry(operator=None)]
     dlg = MeasurementHistoryDialog(_session(history=history))
     qtbot.addWidget(dlg)
-    assert dlg.table.item(0, 2).text() == "Unknown"
+    assert dlg.table.item(0, 3).text() == "Unknown"
 
 
 def test_mhd_phase_filter_change_reloads(qtbot):
@@ -387,7 +387,7 @@ def test_mhd_history_notes_shown_in_table(qtbot):
     history = [_history_entry(notes=notes, data={"val": 1.0})]
     dlg = MeasurementHistoryDialog(_session(history=history))
     qtbot.addWidget(dlg)
-    assert "test note" in dlg.table.item(0, 3).text()
+    assert "test note" in dlg.table.item(0, 4).text()
 
 
 # ── MergeDialog ────────────────────────────────────────────────────────────

--- a/tests/applications/rf_commissioning/ui/test_displays.py
+++ b/tests/applications/rf_commissioning/ui/test_displays.py
@@ -256,25 +256,27 @@ class TestBasePlaceholderDisplay:
         spec = SimpleNamespace(format_spec=None, unit=None)
         assert freq_display._format_spec_value("hello", spec) == "hello"
 
-    def test_stored_status_presentation_passed(self, freq_display):
-        data = SimpleNamespace(passed=True)
+    def test_stored_status_presentation_pass(self, freq_display):
+        data = SimpleNamespace(is_complete=True, passed=True)
         text, style = freq_display._get_stored_status_presentation(data)
         assert text == "PASS"
 
-    def test_stored_status_presentation_failed(self, freq_display):
-        data = SimpleNamespace(passed=False)
+    def test_stored_status_presentation_fail(self, freq_display):
+        data = SimpleNamespace(is_complete=True, passed=False)
         text, style = freq_display._get_stored_status_presentation(data)
         assert text == "FAIL"
-
-    def test_stored_status_presentation_complete(self, freq_display):
-        data = SimpleNamespace(is_complete=True)
-        text, style = freq_display._get_stored_status_presentation(data)
-        assert text == "COMPLETE"
 
     def test_stored_status_presentation_incomplete(self, freq_display):
         data = SimpleNamespace(is_complete=False)
         text, style = freq_display._get_stored_status_presentation(data)
         assert text == "INCOMPLETE"
+
+    def test_stored_status_presentation_complete_no_passed_attr(
+        self, freq_display
+    ):
+        data = SimpleNamespace(is_complete=True)
+        text, style = freq_display._get_stored_status_presentation(data)
+        assert text == "PASS"
 
     def test_stored_status_presentation_available(self, freq_display):
         data = SimpleNamespace()
@@ -351,9 +353,9 @@ class TestDisplayRegistry:
 
     def test_unknown_phase_class_name_is_camel_case(self):
         cls = get_phase_display_class(
-            CommissioningPhase.PIEZO_PRE_RF, "label", "attr", None
+            CommissioningPhase.COMPLETE, "label", "attr", None
         )
-        assert cls.__name__ == "PiezoPreRfDisplay"
+        assert cls.__name__ == "CompleteDisplay"
 
     def test_all_standard_phases_in_map(self):
         standard_phases = [


### PR DESCRIPTION

## Summary
Improves RF commissioning UI to display pass/fail results in measurement history and stored-phase status indicators.

## Changes

### UI Enhancements

1. **Added "Result" column to measurement history table** (`measurement_history_dialog.py`)
   - New column shows Pass/Fail/— status for each measurement entry
   - Color-coded: green for Pass, red for Fail, gray for incomplete/missing data
   - Uses `is_complete` and `passed` properties from phase data models
   - Column indices shifted (Operator now col 3, Notes col 4, Data Summary col 5)

2. **Refined stored-phase status presentation** (`base_placeholder.py`)
   - Now evaluates `is_complete` first, then `passed` if complete
   - Display logic:
     - `is_complete=False` → "INCOMPLETE" (amber)
     - `is_complete=True, passed=True` → "PASS" (green)
     - `is_complete=True, passed=False` → "FAIL" (red)
     - No attributes → "AVAILABLE" (neutral)
   - Removed legacy fallback to `passed`-only check
   - Simplified conditional nesting for readability

### Documentation & Comments

3. **Updated docstring in `database_helpers.py`**
   - Changed "legacy values" → "invalid values" in `parse_json_list()` docstring
   - More accurate description of error tolerance

### Test Updates

4. **Fixed column indices in `test_commissioning_popups.py`**
   - Operator column: `2` → `3`
   - Notes column: `3` → `4`

5. **Updated stored-status presentation tests** (`test_displays.py`)
   - Added `is_complete=True` to pass/fail test fixtures (now required by new logic)
   - Added test for `is_complete=True` with missing `passed` attribute (defaults to Pass)
   - Removed obsolete "COMPLETE" status test (no longer a display state)
   - Fixed dynamic class name test to use `COMPLETE` phase instead of `PIEZO_PRE_RF` (which has explicit display class)

6. **Created placeholder for measurement history dialog tests** (`test_measurement_history_dialog.py`)
   - Empty file reserved for future dedicated tests

## Testing
- All UI tests pass with updated column indices
- Status presentation logic covered by updated unit tests
- Manual verification: measurement history dialog displays result column correctly

## Impact
- **User-facing**: Operators can now see pass/fail status at a glance in measurement history
- **UI consistency**: Stored-phase status badges now correctly use `is_complete` + `passed` semantics introduced in previous PR
- **Developer-facing**: Test fixtures now reflect current data model contract