### PR TITLE
feat(rf-commissioning): add Piezo Pre-RF single-cavity display and controller

### DIFF
--- a/src/sc_linac_physics/applications/rf_commissioning/ui/__init__.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/__init__.py
@@ -6,6 +6,7 @@ from .builders import (
     LOCAL_LABEL_STYLE,
 )
 from .displays import (
+    PiezoPreRFDisplay,
     FrequencyTuningDisplay,
     SSACharDisplay,
     CavityCharDisplay,
@@ -17,6 +18,7 @@ from .displays import (
 from .phase_display_base import PhaseDisplayBase
 
 __all__ = [
+    "PiezoPreRFDisplay",
     "PiezoPreRFUI",
     "LOCAL_CAP_STYLE",
     "LOCAL_LABEL_STYLE",

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/controllers/__init__.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/controllers/__init__.py
@@ -1,0 +1,5 @@
+"""Controllers for RF commissioning UI flows."""
+
+from .piezo_pre_rf_controller import PiezoPreRFController
+
+__all__ = ["PiezoPreRFController"]

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/controllers/piezo_pre_rf_controller.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/controllers/piezo_pre_rf_controller.py
@@ -1,0 +1,896 @@
+"""Controller for Piezo Pre-RF display logic."""
+
+from datetime import datetime
+from threading import Thread
+
+
+from PyQt5.QtCore import QTimer, pyqtSignal, QObject
+
+from sc_linac_physics.applications.rf_commissioning.models.commissioning_piezo import (
+    CommissioningPiezo,
+)
+from sc_linac_physics.applications.rf_commissioning.models.data_models import (
+    CommissioningPhase,
+)
+from sc_linac_physics.applications.rf_commissioning.phases.phase_base import (
+    PhaseContext,
+)
+from sc_linac_physics.applications.rf_commissioning.phases.piezo_pre_rf import (
+    PiezoPreRFPhase,
+)
+from sc_linac_physics.applications.rf_commissioning.ui.controllers.piezo_pre_rf_pv import (
+    apply_pv_mapping,
+    build_pv_mapping,
+    format_pv_update_message,
+    get_piezo_from_selection,
+    resolve_cavity_selection,
+)
+from sc_linac_physics.applications.rf_commissioning.session_manager import (
+    CommissioningSession,
+)
+from sc_linac_physics.utils.sc_linac.linac import Machine
+
+
+class PiezoPreRFController(QObject):
+    """Owns phase execution and PV wiring for the display."""
+
+    phase_completed = pyqtSignal(object)  # Emits the updated record
+    phase_run_finished = pyqtSignal(bool, str)
+
+    def __init__(self, view, session: CommissioningSession) -> None:
+        super().__init__()  # Initialize QObject
+        self.view = view
+        self.session = session
+
+        self.context: PhaseContext | None = None
+        self.phase: PiezoPreRFPhase | None = None
+        self.machine: Machine | None = None
+
+        # Pause and step mode state
+        self._paused = False
+        self._step_mode = False
+        self._step_executing = False
+        self._current_step_index = 0
+        self._total_steps = 0
+        self._steps: list[str] = []
+        self._active_phase_instance_id: int | None = None
+
+        self.phase_run_finished.connect(self._on_phase_run_finished)
+
+    def setup_pv_connections(self) -> None:
+        """Connect to PVs based on active record's cavity.
+
+        PVs are updated when a record is loaded/started.
+        """
+        # Initial update if there's an active record
+        if self.session.has_active_record():
+            self.update_pv_addresses()
+
+    def _resolve_cavity_selection(
+        self, cryomodule: str | None, cavity_number: str | None
+    ) -> tuple[str | None, str | None]:
+        """Resolve cavity selection from arguments or parent dropdowns."""
+        return resolve_cavity_selection(self.view, cryomodule, cavity_number)
+
+    def _get_piezo_from_selection(
+        self, cryomodule: str, cavity_number: str
+    ) -> tuple[CommissioningPiezo, int, int]:
+        """Return piezo object and parsed CM/CAV numbers from selection."""
+        piezo, cm, cav, machine = get_piezo_from_selection(
+            self.machine,
+            cryomodule,
+            cavity_number,
+        )
+        self.machine = machine
+        return piezo, cm, cav
+
+    def update_pv_addresses(
+        self,
+        cryomodule: str | None = None,
+        cavity_number: str | None = None,
+    ) -> None:
+        """Update PV addresses based on selected cavity from dropdowns.
+
+        Args:
+            cryomodule: Cryomodule identifier (e.g., "02"). If None, gets from UI dropdowns via parent.
+            cavity_number: Cavity number (e.g., "1"). If None, gets from UI dropdowns via parent.
+        """
+        cryomodule, cavity_number = self._resolve_cavity_selection(
+            cryomodule, cavity_number
+        )
+        if cryomodule is None or cavity_number is None:
+            self.view.log_message("No cavity selected")
+            return
+
+        try:
+            piezo, cm, cav = self._get_piezo_from_selection(
+                cryomodule, cavity_number
+            )
+        except (ValueError, AttributeError) as exc:
+            self.view.log_message(f"Error parsing cavity info: {exc}")
+            return
+        except Exception as exc:
+            self.view.log_message(f"Error setting PVs: {exc}")
+            return
+
+        try:
+            pv_mapping = self._build_pv_mapping(piezo)
+            self._apply_pv_mapping(pv_mapping)
+            self._log_pv_update(cryomodule, cavity_number, cm, cav)
+            self._sync_piezo_readbacks(piezo)
+        except Exception as exc:
+            self.view.log_message(f"Error setting PVs: {exc}")
+
+    def _build_pv_mapping(self, piezo: CommissioningPiezo) -> dict:
+        """Build PV mapping dictionary for widgets."""
+        return build_pv_mapping(self.view, piezo)
+
+    def _apply_pv_mapping(self, pv_mapping: dict) -> None:
+        """Apply PV addresses to widgets."""
+        apply_pv_mapping(pv_mapping)
+
+    def _log_pv_update(
+        self, cryomodule: str, cavity_number: str, cm: int, cav: int
+    ) -> None:
+        """Log PV update with formatted cavity name."""
+        self.view.log_message(
+            format_pv_update_message(cryomodule, cavity_number, cm, cav)
+        )
+
+    def _sync_piezo_readbacks(
+        self, piezo: CommissioningPiezo | None = None
+    ) -> None:
+        """Sync piezo enable/manual UI from actual readback values."""
+        if not hasattr(self.view, "update_piezo_readbacks"):
+            return
+
+        try:
+            if piezo is None:
+                cryomodule, cavity_number = self._resolve_cavity_selection(
+                    None, None
+                )
+                if cryomodule is None or cavity_number is None:
+                    return
+                piezo, _, _ = self._get_piezo_from_selection(
+                    cryomodule, cavity_number
+                )
+
+            self.view.update_piezo_readbacks(piezo)
+        except Exception as exc:
+            self.view.log_message(f"Readback sync failed: {exc}")
+
+    def _parse_cavity_from_record(
+        self, cavity_name: str, cryomodule: str
+    ) -> tuple[int, int]:
+        """Parse cavity label and cryomodule into integer CM/CAV values."""
+        parts = cavity_name.split("_")
+        cav_part = parts[2] if len(parts) >= 3 else "CAV1"
+        cav = int(cav_part.replace("CAV", ""))
+        cm = int(cryomodule)
+        return cm, cav
+
+    def _prepare_phase_context(self, cavity, operator: str) -> bool:
+        """Build phase context and validate run prerequisites."""
+        record = self.session.get_active_record()
+        record_id = self.session.get_active_record_id()
+        self.view.log_message(f"Using record ID: {record_id}")
+
+        can_run, reason = self.session.can_run_phase(
+            CommissioningPhase.PIEZO_PRE_RF
+        )
+        if not can_run:
+            self.view.show_error(f"Cannot run PIEZO_PRE_RF phase: {reason}")
+            self.view.log_message(f"ERROR: {reason}")
+            return False
+
+        if record_id is not None:
+            phase_start = self.session.start_active_phase_instance(
+                CommissioningPhase.PIEZO_PRE_RF,
+                operator=operator,
+            )
+            self._active_phase_instance_id = (
+                phase_start.phase_instance_id
+                if phase_start is not None
+                else None
+            )
+
+        if self._active_phase_instance_id is not None:
+            self.view.log_message(
+                f"Tracking phase instance ID: {self._active_phase_instance_id}"
+            )
+
+        self.context = PhaseContext(
+            record=record,
+            operator=operator,
+            parameters={"cavity": cavity},
+            phase_instance_id=self._active_phase_instance_id,
+            run_intent="commissioning",
+        )
+        self.phase = PiezoPreRFPhase(self.context)
+
+        is_valid, message = self.phase.validate_prerequisites()
+        if not is_valid:
+            self.view.show_error(f"Prerequisites not met: {message}")
+            self.view.log_message(f"ERROR: {message}")
+            return False
+
+        return True
+
+    def _set_running_ui_state(self) -> None:
+        """Set UI widgets for an active test run."""
+        self.view.run_button.setEnabled(False)
+        self.view.pause_button.setEnabled(True)
+        self.view.abort_button.setEnabled(True)
+        self.view.local_phase_status.setText("RUNNING")
+
+    def _get_selected_cavity_info(self) -> tuple[str, int, int] | None:
+        """Get and validate selected cavity information.
+
+        Returns:
+            Tuple of (cavity_name, cm, cav) or None if invalid.
+        """
+        cavity_info = self.view.get_current_cavity()
+        if not cavity_info:
+            self.view.show_error(
+                "Unable to determine cavity information from active record."
+            )
+            return None
+
+        cavity_name, cryomodule = cavity_info
+        try:
+            cm, cav = self._parse_cavity_from_record(cavity_name, cryomodule)
+        except (ValueError, IndexError):
+            self.view.show_error(f"Invalid cavity name format: {cavity_name}")
+            return None
+
+        return cavity_name, cm, cav
+
+    def _get_machine_cavity(self, cm: int, cav: int):
+        """Resolve and return machine cavity object."""
+        if not self.machine:
+            self.machine = Machine(piezo_class=CommissioningPiezo)
+        return self.machine.cryomodules[f"{cm:02d}"].cavities[cav]
+
+    def on_run_automated_test(self) -> None:
+        """Handle Run Automated Test button click.
+
+        Auto-creates a record if needed based on parent's cavity selection.
+        """
+        operator = self._get_operator()
+        if not operator:
+            self.view.show_error(
+                "Please select an operator in the header before running the test."
+            )
+            self._focus_parent_widget("operator_combo")
+            return
+
+        if not self.session.has_active_record():
+            if not self._auto_create_record():
+                return
+
+        cavity_data = self._get_selected_cavity_info()
+        if not cavity_data:
+            return
+
+        cavity_name, cm, cav = cavity_data
+
+        self.view.log_message(f"Starting automated test for {cavity_name}")
+        self.view.clear_results()
+
+        try:
+            self.update_pv_addresses(f"{cm:02d}", str(cav))
+            cavity = self._get_machine_cavity(cm, cav)
+
+            if not self._prepare_phase_context(cavity, operator):
+                return
+
+            self._set_running_ui_state()
+
+            self.execute_phase_steps()
+
+        except Exception as exc:
+            import traceback
+
+            self.view.show_error(f"Failed to start test: {exc}")
+            self.view.log_message(f"Error: {exc}")
+            self.view.log_message(f"Traceback: {traceback.format_exc()}")
+
+    def _auto_create_record(self) -> bool:
+        """Auto-create a commissioning record based on parent's cavity selection.
+
+        Returns:
+            True if record created successfully, False otherwise
+        """
+        # Get cavity selection from parent
+        cryomodule, cavity_number = self._get_cavity_from_parent()
+
+        if not cryomodule or not cavity_number:
+            self.view.show_error(
+                "Please select a cavity in the header.\n\n"
+                "Use the CM and Cavity dropdowns in the header, then try again."
+            )
+            self._focus_parent_widget("cryomodule_combo")
+            return False
+
+        try:
+            cavity_display_name = f"{cryomodule}_CAV{cavity_number}"
+            self.view.log_message(
+                f"Auto-creating commissioning record for {cavity_display_name}..."
+            )
+
+            record, record_id, created = self.session.start_new_record(
+                cryomodule=cryomodule,
+                cavity_number=cavity_number,
+            )
+
+            status = "Created" if created else "Loaded"
+            self.view.log_message(
+                f"✓ {status} record ID: {record_id} for {cavity_display_name}"
+            )
+
+            # Notify parent container to update its UI
+            self._notify_parent_record_created(record, record_id)
+
+            # Update PVs for the new cavity
+            self.update_pv_addresses()
+
+            return True
+
+        except Exception as e:
+            import traceback
+
+            self.view.show_error(
+                f"Failed to create commissioning record:\n\n{e}"
+            )
+            self.view.log_message(f"ERROR: {e}")
+            self.view.log_message(f"Traceback: {traceback.format_exc()}")
+            return False
+
+    def _get_cavity_from_parent(self) -> tuple[str | None, str | None]:
+        """Get cavity selection from parent container.
+
+        Returns:
+            Tuple of (cryomodule, cavity_number) or (None, None)
+        """
+        parent = self.view.parent()
+        while parent:
+            if hasattr(parent, "cryomodule_combo") and hasattr(
+                parent, "cavity_combo"
+            ):
+                try:
+                    cm = parent.cryomodule_combo.currentText()
+                    cav = parent.cavity_combo.currentText()
+
+                    if not cm or not cav:
+                        return (None, None)
+
+                    # cm is already just the identifier like "02" or "H1"
+                    cryomodule = cm
+                    cavity_number = str(cav)
+
+                    return (cryomodule, cavity_number)
+
+                except Exception as e:
+                    self.view.log_message(
+                        f"Error getting cavity from parent: {e}"
+                    )
+                    return (None, None)
+            parent = parent.parent()
+
+        return (None, None)
+
+    def _focus_parent_widget(self, widget_name: str) -> None:
+        """Try to focus a widget in the parent container.
+
+        Args:
+            widget_name: Name of the widget to focus (e.g., 'operator_combo')
+        """
+        parent = self.view.parent()
+        while parent:
+            if hasattr(parent, widget_name):
+                widget = getattr(parent, widget_name)
+                widget.setFocus()
+                return
+            parent = parent.parent()
+
+    def execute_phase_steps(self) -> None:
+        """Execute phase steps using the controller-managed step loop."""
+        if not self.context or not self.phase:
+            self.view.show_error("No phase context available to run")
+            return
+
+        self.context.progress_callback = (
+            lambda step, prog: self.view.step_progress_signal.emit(step, prog)
+        )
+
+        # Get the steps and store for step mode
+        self._steps = self.phase.get_phase_steps()
+        self._total_steps = len(self._steps)
+        self._current_step_index = 0
+
+        def run_phase():
+            try:
+                if self._step_mode:
+                    # In step mode, show first step and wait for click
+                    self.view.log_message(
+                        f"Step mode: Ready for step 1/{self._total_steps}: {self._steps[0]}"
+                    )
+                    self._set_next_button_enabled(True)
+                else:
+                    self._run_phase_in_background()
+            except Exception as exc:
+                import traceback
+
+                self.view.log_message(
+                    f"Exception: {exc}\n{traceback.format_exc()}"
+                )
+                self.on_phase_failed(str(exc))
+
+        QTimer.singleShot(100, run_phase)
+
+    def _run_phase_in_background(self) -> None:
+        """Run blocking phase execution in a worker thread."""
+
+        def worker() -> None:
+            try:
+                steps = self.phase.get_phase_steps()
+                for step_name in steps:
+                    if not self._check_pause_and_abort():
+                        return
+
+                    # Execute the step
+                    success = self.phase._execute_step_with_retry(step_name)
+                    if not success:
+                        self.phase_run_finished.emit(
+                            False, f"Step failed: {step_name}"
+                        )
+                        return
+
+                self._finalize_background_phase()
+
+            except Exception as exc:
+                self.phase_run_finished.emit(False, str(exc))
+
+        Thread(target=worker, daemon=True).start()
+
+    def _check_pause_and_abort(self) -> bool:
+        """Check for pause/abort requests. Returns False if aborted."""
+        import time
+
+        # Wait while paused
+        while self._paused:
+            time.sleep(0.1)
+            if self.context and self.context.is_abort_requested():
+                self.phase_run_finished.emit(False, "Aborted")
+                return False
+
+        # Check for abort
+        if self.context and self.context.is_abort_requested():
+            self.phase_run_finished.emit(False, "Aborted")
+            return False
+
+        return True
+
+    def _finalize_background_phase(self) -> None:
+        """Finalize phase after all steps complete in background worker."""
+        try:
+            self.phase.finalize_phase()
+            self.phase._mark_phase_completed()
+            self.phase_run_finished.emit(True, "")
+        except Exception as e:
+            self.phase._handle_exception(e)
+            self.phase_run_finished.emit(False, str(e))
+
+    def _on_phase_run_finished(self, success: bool, error_msg: str) -> None:
+        """Handle worker-thread phase completion on UI thread."""
+        self._sync_piezo_readbacks()
+
+        if success:
+            self.on_phase_completed()
+            return
+
+        self.on_phase_failed(error_msg or "Phase execution failed")
+
+    def _execute_single_step(self, step_name: str) -> bool:
+        """Execute a single step with retry logic and checkpoint creation.
+
+        Args:
+            step_name: Name of the step to execute
+
+        Returns:
+            True if step succeeded, False otherwise
+        """
+        # Check for pause/abort before executing
+        if not self._wait_for_unpause():
+            return False
+
+        if self.context and self.context.is_abort_requested():
+            self.view.log_message(f"Abort during step: {step_name}")
+            return False
+
+        self._notify_step_progress(step_name)
+
+        # Execute with retry logic
+        return self._execute_step_with_retries(step_name, max_retries=3)
+
+    def _wait_for_unpause(self) -> bool:
+        """Wait while paused. Returns False if should abort."""
+        import time
+
+        while self._paused:
+            QTimer.singleShot(100, lambda: None)  # Process events while paused
+            time.sleep(0.1)
+        return True
+
+    def _notify_step_progress(self, step_name: str) -> None:
+        """Notify progress callback of current step."""
+        if self.context.progress_callback:
+            idx = (
+                self._steps.index(step_name) if step_name in self._steps else 0
+            )
+            progress = int((idx / len(self._steps)) * 100)
+            self.context.progress_callback(step_name, progress)
+
+    def _execute_step_with_retries(
+        self, step_name: str, max_retries: int
+    ) -> bool:
+        """Execute a step with retry logic."""
+        from sc_linac_physics.applications.rf_commissioning.phases.phase_base import (
+            PhaseResult,
+        )
+
+        retry_count = 0
+        while retry_count < max_retries:
+            try:
+                result = self.phase.execute_step(step_name)
+                self._create_step_checkpoint(step_name, result)
+
+                # Handle result
+                if result.result in (PhaseResult.SUCCESS, PhaseResult.SKIP):
+                    return self._handle_step_success(step_name, result)
+
+                if result.result == PhaseResult.RETRY:
+                    retry_count += 1
+                    if retry_count < max_retries:
+                        self.view.log_message(
+                            f"Retrying {retry_count}/{max_retries}: {result.message}"
+                        )
+                        continue
+                    self.view.log_message(f"Failed after {max_retries} retries")
+                    return False
+
+                # PhaseResult.FAILED
+                self.view.log_message(f"✗ {step_name} failed: {result.message}")
+                return False
+
+            except Exception as e:
+                retry_count += 1
+                if retry_count < max_retries:
+                    self.view.log_message(
+                        f"Exception on retry {retry_count}: {str(e)}"
+                    )
+                    continue
+                self.view.log_message(
+                    f"Exception after {max_retries} retries: {str(e)}"
+                )
+                return False
+
+        return False
+
+    def _create_step_checkpoint(self, step_name: str, result) -> None:
+        """Create checkpoint for step execution."""
+        from sc_linac_physics.applications.rf_commissioning.phases.phase_base import (
+            PhaseResult,
+        )
+        from sc_linac_physics.applications.rf_commissioning.models.data_models import (
+            PhaseCheckpoint,
+        )
+
+        checkpoint = PhaseCheckpoint(
+            phase=self.phase.phase_type,
+            timestamp=datetime.now(),
+            operator=self.context.operator,
+            step_name=step_name,
+            success=result.result in (PhaseResult.SUCCESS, PhaseResult.SKIP),
+            notes=result.message,
+            measurements=result.data,
+        )
+        self.context.record.phase_history.append(checkpoint)
+
+    def _handle_step_success(self, step_name: str, result) -> bool:
+        """Handle successful step execution."""
+        from sc_linac_physics.applications.rf_commissioning.phases.phase_base import (
+            PhaseResult,
+        )
+
+        if result.result == PhaseResult.SUCCESS:
+            self.view.log_message(f"✓ {step_name} completed")
+            if step_name == "setup_piezo":
+                self._sync_piezo_readbacks()
+        else:  # SKIP
+            self.view.log_message(f"⊘ {step_name} skipped")
+        return True
+
+    def _finalize_phase_execution(self) -> None:
+        """Finalize phase after all steps complete in step mode."""
+        try:
+            self.phase.finalize_phase()
+
+            # Log what data was populated
+            if self.context and self.context.record.piezo_pre_rf:
+                self.view.log_message(
+                    f"Phase data populated: Cap A={self.context.record.piezo_pre_rf.capacitance_a}, "
+                    f"Cap B={self.context.record.piezo_pre_rf.capacitance_b}, "
+                    f"Passed={self.context.record.piezo_pre_rf.passed}"
+                )
+            else:
+                self.view.log_message(
+                    "Warning: piezo_pre_rf data was not populated after finalize_phase()"
+                )
+
+            self.on_phase_completed()
+        except Exception as e:
+            import traceback
+
+            self.view.log_message(f"Error finalizing phase: {str(e)}")
+            self.view.log_message(f"Traceback: {traceback.format_exc()}")
+            self.on_phase_failed(str(e))
+
+    def on_phase_completed(self) -> None:
+        """Handle phase completion."""
+        # Reset pause and step mode state
+        self._paused = False
+        self._step_mode = False
+        self._step_executing = False
+        self._current_step_index = 0
+
+        self.view.log_message("Phase completed successfully")
+        self.view.local_phase_status.setText("COMPLETED")
+        self.view.local_progress_bar.setValue(100)
+        self._update_toolbar_state("complete")
+
+        try:
+            if self.context and self.context.record.piezo_pre_rf:
+                if self._active_phase_instance_id is not None:
+                    success = self.session.complete_active_phase_instance(
+                        phase_instance_id=self._active_phase_instance_id,
+                        phase=CommissioningPhase.PIEZO_PRE_RF,
+                        artifact_payload=self.context.record.piezo_pre_rf.to_dict(),
+                    )
+                    if success and self.session.has_active_record():
+                        self.view.log_message(
+                            f"✓ Advanced to {self.session.get_active_record().current_phase.value}"
+                        )
+                    elif not success:
+                        self.view.log_message(
+                            "Warning: Failed to advance phase lifecycle"
+                        )
+
+                # Save after lifecycle completion so current_phase/status are persisted.
+                if self.session.save_active_record():
+                    record_id = self.session.get_active_record_id()
+                    self.view.log_message(
+                        f"Results saved to database (ID: {record_id})"
+                    )
+                    # Emit signal with updated record after progression/save.
+                    self.phase_completed.emit(self.session.get_active_record())
+                else:
+                    self.view.log_message("Warning: Failed to save to database")
+
+                self.view.log_message("Updating UI with phase results...")
+                self._append_measurement_history()
+                self.view._update_local_results(
+                    self.context.record.piezo_pre_rf
+                )
+                self.view._update_stored_readout(
+                    self.context.record.piezo_pre_rf
+                )
+                self.view.log_message("UI updated with stored data")
+            else:
+                self.view.log_message(
+                    "Warning: No piezo_pre_rf data to display"
+                )
+
+        except Exception as exc:
+            import traceback
+
+            self.view.log_message(f"Warning: Failed to save results: {exc}")
+            self.view.log_message(f"Traceback: {traceback.format_exc()}")
+            if self._active_phase_instance_id is not None:
+                self.session.fail_active_phase_instance(
+                    phase_instance_id=self._active_phase_instance_id,
+                    phase=CommissioningPhase.PIEZO_PRE_RF,
+                    error_message=str(exc),
+                )
+        finally:
+            self._active_phase_instance_id = None
+
+        self.view.run_button.setEnabled(True)
+        self.view.pause_button.setEnabled(False)
+        self.view.abort_button.setEnabled(False)
+        self._set_next_button_enabled(False)
+
+    def on_phase_failed(self, error_msg: str) -> None:
+        """Handle phase failure."""
+        # Reset pause and step mode state
+        self._paused = False
+        self._step_mode = False
+        self._step_executing = False
+        self._current_step_index = 0
+
+        self.view.log_message(f"Phase failed: {error_msg}")
+        self.view.local_phase_status.setText("FAILED")
+        self._update_toolbar_state("error")
+
+        try:
+            if self.phase:
+                self.phase.finalize_phase()
+
+            if self.session.save_active_record():
+                self.view.log_message("Partial results saved to database")
+
+            if self._active_phase_instance_id is not None:
+                snapshot = None
+                if self.context and self.context.record.piezo_pre_rf:
+                    snapshot = self.context.record.piezo_pre_rf.to_dict()
+
+                self.session.fail_active_phase_instance(
+                    phase_instance_id=self._active_phase_instance_id,
+                    phase=CommissioningPhase.PIEZO_PRE_RF,
+                    error_message=error_msg,
+                    artifact_payload=snapshot,
+                )
+
+            if self.context and self.context.record.piezo_pre_rf:
+                self._append_measurement_history(error_msg=error_msg)
+                self.view._update_local_results(
+                    self.context.record.piezo_pre_rf
+                )
+                self.view._update_stored_readout(
+                    self.context.record.piezo_pre_rf
+                )
+
+        except Exception as exc:
+            import traceback
+
+            self.view.log_message(
+                f"Warning: Failed to save partial results: {exc}"
+            )
+            self.view.log_message(f"Traceback: {traceback.format_exc()}")
+            if self._active_phase_instance_id is not None:
+                self.session.fail_active_phase_instance(
+                    phase_instance_id=self._active_phase_instance_id,
+                    phase=CommissioningPhase.PIEZO_PRE_RF,
+                    error_message=str(exc),
+                )
+        finally:
+            self._active_phase_instance_id = None
+
+        self.view.run_button.setEnabled(True)
+        self.view.pause_button.setEnabled(False)
+        self.view.abort_button.setEnabled(False)
+        self._set_next_button_enabled(False)
+        self.view.show_error(f"Test failed: {error_msg}")
+
+    def _get_operator(self) -> str:
+        """Get the currently selected operator from the view or parent."""
+        if hasattr(self.view, "get_current_operator"):
+            operator = self.view.get_current_operator()
+            if operator:
+                return operator
+
+        return ""
+
+    def _append_measurement_history(self, error_msg: str | None = None) -> None:
+        """Add measurement to history.
+
+        Notes are added manually by users via the UI, not automatically.
+        Only error messages are auto-added as notes.
+        """
+        if not (self.context and self.context.record.piezo_pre_rf):
+            return
+
+        # Only auto-add notes for errors
+        notes = f"Phase failed: {error_msg}" if error_msg else None
+
+        self.session.add_measurement_to_history(
+            CommissioningPhase.PIEZO_PRE_RF,
+            self.context.record.piezo_pre_rf,
+            operator=self._get_operator(),
+            notes=notes,
+            phase_instance_id=self._active_phase_instance_id,
+        )
+
+    def on_abort(self) -> None:
+        """Handle abort button click."""
+        if self.context:
+            self.context.request_abort()
+            self.view.log_message("Abort requested...")
+            self.view.abort_button.setEnabled(False)
+
+    def _set_next_button_enabled(self, enabled: bool) -> None:
+        """Safely enable/disable next step button."""
+        if hasattr(self.view, "next_step_btn"):
+            self.view.next_step_btn.setEnabled(enabled)
+
+    def _update_toolbar_state(self, state: str) -> None:
+        """Safely update toolbar state."""
+        if hasattr(self.view, "ui") and hasattr(
+            self.view.ui, "update_toolbar_state"
+        ):
+            self.view.ui.update_toolbar_state(state)
+
+    def on_pause_test(self) -> None:
+        """Handle pause button click."""
+        if self._paused:
+            # Resume
+            self._paused = False
+            self.view.log_message("Test resumed...")
+            self.view.pause_button.setText("⏸ Pause")
+            self._update_toolbar_state("running")
+        else:
+            # Pause
+            self._paused = True
+            self.view.log_message("Test paused...")
+            self.view.pause_button.setText("▶ Resume")
+            self._update_toolbar_state("paused")
+
+    def on_toggle_step_mode(self) -> None:
+        """Handle step mode toggle."""
+        self._step_mode = not self._step_mode
+        if self._step_mode:
+            self.view.log_message(
+                "✓ Step mode enabled - Start Test, then use 'Next' to execute steps"
+            )
+            # Next button will be enabled when test starts
+        else:
+            self.view.log_message("Step mode disabled")
+            self._set_next_button_enabled(False)
+            self._step_executing = False
+
+    def on_next_step(self) -> None:
+        """Handle next step button click."""
+        if not self._step_mode or self._step_executing:
+            return
+
+        if self._current_step_index >= len(self._steps):
+            self.view.log_message("All steps completed!")
+            return
+
+        step_name = self._steps[self._current_step_index]
+        self._step_executing = True
+        self._set_next_button_enabled(False)
+
+        def execute_step():
+            try:
+                success = self._execute_single_step(step_name)
+                self._current_step_index += 1
+
+                if success and self._current_step_index < len(self._steps):
+                    # More steps to execute
+                    next_step = self._steps[self._current_step_index]
+                    self.view.log_message(
+                        f"Ready for step {self._current_step_index + 1}/{len(self._steps)}: {next_step}"
+                    )
+                    self._set_next_button_enabled(True)
+                elif success:
+                    # All steps done
+                    self.view.log_message("All steps completed. Finalizing...")
+                    self._finalize_phase_execution()
+                else:
+                    # Step failed
+                    self.on_phase_failed("Step execution failed")
+            except Exception as exc:
+                import traceback
+
+                self.view.log_message(f"Error: {exc}\n{traceback.format_exc()}")
+                self.on_phase_failed(str(exc))
+            finally:
+                self._step_executing = False
+
+        QTimer.singleShot(100, execute_step)
+
+    def _notify_parent_record_created(self, record, record_id: int) -> None:
+        """Notify parent container that a record was created."""
+        self.view._notify_parent_of_record_update(record, "Record created")
+        self.view.log_message("Notified parent container of new record")

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/controllers/piezo_pre_rf_controller.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/controllers/piezo_pre_rf_controller.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from threading import Thread
 
 
-from PyQt5.QtCore import QTimer, pyqtSignal, QObject
+from PyQt5.QtCore import QEventLoop, QObject, QTimer, pyqtSignal
 
 from sc_linac_physics.applications.rf_commissioning.models.commissioning_piezo import (
     CommissioningPiezo,
@@ -500,7 +500,6 @@ class PiezoPreRFController(QObject):
         Returns:
             True if step succeeded, False otherwise
         """
-        # Check for pause/abort before executing
         if not self._wait_for_unpause():
             return False
 
@@ -514,17 +513,23 @@ class PiezoPreRFController(QObject):
         return self._execute_step_with_retries(step_name, max_retries=3)
 
     def _wait_for_unpause(self) -> bool:
-        """Wait while paused. Returns False if should abort."""
+        """Wait for pause to clear and stop early if abort is requested."""
         import time
 
         while self._paused:
-            QTimer.singleShot(100, lambda: None)  # Process events while paused
+            if self.context and self.context.is_abort_requested():
+                return False
+
+            QTimer.singleShot(100, lambda: None)
             time.sleep(0.1)
-        return True
+
+        return not (
+            self.context is not None and self.context.is_abort_requested()
+        )
 
     def _notify_step_progress(self, step_name: str) -> None:
         """Notify progress callback of current step."""
-        if self.context.progress_callback:
+        if self.context and self.context.progress_callback:
             idx = (
                 self._steps.index(step_name) if step_name in self._steps else 0
             )
@@ -552,9 +557,17 @@ class PiezoPreRFController(QObject):
                 if result.result == PhaseResult.RETRY:
                     retry_count += 1
                     if retry_count < max_retries:
-                        self.view.log_message(
-                            f"Retrying {retry_count}/{max_retries}: {result.message}"
+                        retry_delay = max(
+                            0.0, float(result.retry_delay_seconds)
                         )
+                        self.view.log_message(
+                            f"Retrying {retry_count}/{max_retries} in {retry_delay:.1f}s: {result.message}"
+                        )
+                        if not self._wait_for_retry_delay(retry_delay):
+                            self.view.log_message(
+                                f"Abort during retry backoff: {step_name}"
+                            )
+                            return False
                         continue
                     self.view.log_message(f"Failed after {max_retries} retries")
                     return False
@@ -577,6 +590,40 @@ class PiezoPreRFController(QObject):
 
         return False
 
+    def _wait_for_retry_delay(self, delay_seconds: float) -> bool:
+        """Wait for retry delay while keeping UI responsive.
+
+        Returns False if abort is requested during the delay.
+        """
+        if delay_seconds <= 0:
+            return not (
+                self.context is not None and self.context.is_abort_requested()
+            )
+
+        if self.context and self.context.is_abort_requested():
+            return False
+
+        event_loop = QEventLoop()
+        aborted = False
+
+        def check_abort() -> None:
+            nonlocal aborted
+            if self.context and self.context.is_abort_requested():
+                aborted = True
+                event_loop.quit()
+
+        abort_timer = QTimer()
+        abort_timer.setInterval(100)
+        abort_timer.timeout.connect(check_abort)
+        abort_timer.start()
+
+        QTimer.singleShot(int(delay_seconds * 1000), event_loop.quit)
+        event_loop.exec_()
+
+        abort_timer.stop()
+        abort_timer.deleteLater()
+        return not aborted
+
     def _create_step_checkpoint(self, step_name: str, result) -> None:
         """Create checkpoint for step execution."""
         from sc_linac_physics.applications.rf_commissioning.phases.phase_base import (
@@ -586,6 +633,12 @@ class PiezoPreRFController(QObject):
             PhaseCheckpoint,
         )
 
+        checkpoint_measurements = dict(result.data or {})
+        if self.context.phase_instance_id is not None:
+            checkpoint_measurements.setdefault(
+                "phase_instance_id", self.context.phase_instance_id
+            )
+
         checkpoint = PhaseCheckpoint(
             phase=self.phase.phase_type,
             timestamp=datetime.now(),
@@ -593,7 +646,7 @@ class PiezoPreRFController(QObject):
             step_name=step_name,
             success=result.result in (PhaseResult.SUCCESS, PhaseResult.SKIP),
             notes=result.message,
-            measurements=result.data,
+            measurements=checkpoint_measurements,
         )
         self.context.record.phase_history.append(checkpoint)
 
@@ -657,10 +710,19 @@ class PiezoPreRFController(QObject):
                         phase=CommissioningPhase.PIEZO_PRE_RF,
                         artifact_payload=self.context.record.piezo_pre_rf.to_dict(),
                     )
-                    if success and self.session.has_active_record():
-                        self.view.log_message(
-                            f"✓ Advanced to {self.session.get_active_record().current_phase.value}"
+                    if success:
+                        projection = self.session.get_active_phase_projection()
+                        current_phase = (
+                            projection.get("current_phase")
+                            if projection
+                            else CommissioningPhase.PIEZO_PRE_RF.get_next_phase()
                         )
+                        phase_label = (
+                            current_phase.value
+                            if hasattr(current_phase, "value")
+                            else str(current_phase)
+                        )
+                        self.view.log_message(f"✓ Advanced to {phase_label}")
                     elif not success:
                         self.view.log_message(
                             "Warning: Failed to advance phase lifecycle"
@@ -792,11 +854,12 @@ class PiezoPreRFController(QObject):
 
         # Only auto-add notes for errors
         notes = f"Phase failed: {error_msg}" if error_msg else None
+        operator = self.context.operator or self._get_operator()
 
         self.session.add_measurement_to_history(
             CommissioningPhase.PIEZO_PRE_RF,
             self.context.record.piezo_pre_rf,
-            operator=self._get_operator(),
+            operator=operator,
             notes=notes,
             phase_instance_id=self._active_phase_instance_id,
         )
@@ -860,35 +923,50 @@ class PiezoPreRFController(QObject):
         step_name = self._steps[self._current_step_index]
         self._step_executing = True
         self._set_next_button_enabled(False)
+        self._execute_step_when_resumed(step_name)
 
-        def execute_step():
-            try:
-                success = self._execute_single_step(step_name)
-                self._current_step_index += 1
+    def _execute_step_when_resumed(self, step_name: str) -> None:
+        """Run a step once pause clears; keep polling abort while paused."""
+        if self.context and self.context.is_abort_requested():
+            self._step_executing = False
+            self.on_phase_failed("Aborted")
+            return
 
-                if success and self._current_step_index < len(self._steps):
-                    # More steps to execute
-                    next_step = self._steps[self._current_step_index]
-                    self.view.log_message(
-                        f"Ready for step {self._current_step_index + 1}/{len(self._steps)}: {next_step}"
-                    )
-                    self._set_next_button_enabled(True)
-                elif success:
-                    # All steps done
-                    self.view.log_message("All steps completed. Finalizing...")
-                    self._finalize_phase_execution()
-                else:
-                    # Step failed
-                    self.on_phase_failed("Step execution failed")
-            except Exception as exc:
-                import traceback
+        if self._paused:
+            QTimer.singleShot(
+                100, lambda: self._execute_step_when_resumed(step_name)
+            )
+            return
 
-                self.view.log_message(f"Error: {exc}\n{traceback.format_exc()}")
-                self.on_phase_failed(str(exc))
-            finally:
-                self._step_executing = False
+        QTimer.singleShot(100, lambda: self._execute_step(step_name))
 
-        QTimer.singleShot(100, execute_step)
+    def _execute_step(self, step_name: str) -> None:
+        """Execute one step and advance state machine."""
+        try:
+            success = self._execute_single_step(step_name)
+            self._current_step_index += 1
+
+            if success and self._current_step_index < len(self._steps):
+                # More steps to execute
+                next_step = self._steps[self._current_step_index]
+                self.view.log_message(
+                    f"Ready for step {self._current_step_index + 1}/{len(self._steps)}: {next_step}"
+                )
+                self._set_next_button_enabled(True)
+            elif success:
+                # All steps done
+                self.view.log_message("All steps completed. Finalizing...")
+                self._finalize_phase_execution()
+            else:
+                # Step failed
+                self.on_phase_failed("Step execution failed")
+        except Exception as exc:
+            import traceback
+
+            self.view.log_message(f"Error: {exc}\n{traceback.format_exc()}")
+            self.on_phase_failed(str(exc))
+        finally:
+            self._step_executing = False
 
     def _notify_parent_record_created(self, record, record_id: int) -> None:
         """Notify parent container that a record was created."""

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/controllers/piezo_pre_rf_pv.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/controllers/piezo_pre_rf_pv.py
@@ -1,0 +1,98 @@
+"""PV wiring helpers for Piezo Pre-RF controller."""
+
+from __future__ import annotations
+
+
+from sc_linac_physics.applications.rf_commissioning.models.commissioning_piezo import (
+    CommissioningPiezo,
+)
+from sc_linac_physics.utils.sc_linac.linac import Machine
+from sc_linac_physics.utils.sc_linac.linac_utils import get_linac_for_cryomodule
+
+
+def resolve_cavity_selection(
+    view,
+    cryomodule: str | None,
+    cavity_number: str | None,
+) -> tuple[str | None, str | None]:
+    """Resolve cavity selection from explicit args or parent dropdowns."""
+    if cryomodule is not None and cavity_number is not None:
+        return cryomodule, cavity_number
+
+    parent = view.parent()
+    while parent:
+        if hasattr(parent, "cryomodule_combo") and hasattr(
+            parent, "cavity_combo"
+        ):
+            selected_cm = parent.cryomodule_combo.currentText()
+            selected_cavity = parent.cavity_combo.currentText()
+            if (
+                selected_cm == "Select CM..."
+                or selected_cavity == "Select Cav..."
+            ):
+                return None, None
+            return selected_cm, selected_cavity
+        parent = parent.parent()
+
+    return None, None
+
+
+def get_piezo_from_selection(
+    machine: Machine | None,
+    cryomodule: str,
+    cavity_number: str,
+) -> tuple[CommissioningPiezo, int, int, Machine]:
+    """Return piezo object, parsed CM/CAV values, and resolved machine."""
+    cav = int(cavity_number)
+    cm = int(cryomodule)
+
+    active_machine = machine or Machine(piezo_class=CommissioningPiezo)
+    cm_str = f"{cm:02d}"
+    cryomodule_obj = active_machine.cryomodules[cm_str]
+    cavity = cryomodule_obj.cavities[cav]
+    return cavity.piezo, cm, cav, active_machine
+
+
+def build_pv_mapping(view, piezo: CommissioningPiezo) -> dict:
+    """Build widget-to-PV mapping for Piezo Pre-RF display."""
+    pv_mapping = {
+        view.pv_overall: piezo.prerf_test_status_pv,
+        view.pv_cha_status: piezo.prerf_cha_status_pv,
+        view.pv_chb_status: piezo.prerf_chb_status_pv,
+        view.pv_cha_cap: piezo.capacitance_a_pv,
+        view.pv_chb_cap: piezo.capacitance_b_pv,
+    }
+
+    optional_mappings = [
+        ("pydm_enable_ctrl", piezo.enable_pv),
+        ("pydm_enable_stat", piezo.enable_stat_pv),
+        ("pydm_mode_ctrl", piezo.feedback_control_pv),
+        ("pydm_mode_stat", piezo.feedback_stat_pv),
+    ]
+    for widget_name, pv_addr in optional_mappings:
+        if hasattr(view, widget_name):
+            pv_mapping[getattr(view, widget_name)] = pv_addr
+
+    return pv_mapping
+
+
+def apply_pv_mapping(pv_mapping: dict) -> None:
+    """Apply EPICS channel addresses to mapped widgets."""
+    for widget, pv_addr in pv_mapping.items():
+        widget.channel = f"ca://{pv_addr}"
+
+
+def format_pv_update_message(
+    cryomodule: str,
+    cavity_number: str,
+    cm: int,
+    cav: int,
+) -> str:
+    """Format user-facing message describing active PV source."""
+    linac = get_linac_for_cryomodule(cryomodule)
+    cavity_display_name = (
+        f"{linac}_CM{cryomodule}_CAV{cavity_number}"
+        if linac
+        else f"CM{cryomodule}_CAV{cavity_number}"
+    )
+    return f"PVs updated for {cavity_display_name} (CM{cm:02d} Cav{cav})"

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/displays/__init__.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/displays/__init__.py
@@ -1,6 +1,7 @@
 """Public exports for RF commissioning phase displays."""
 
 from .base_placeholder import BasePlaceholderDisplay
+from .piezo_pre_rf import PiezoPreRFDisplay
 from .registry import PHASE_DISPLAY_MAP, get_phase_display_class
 from .standard import (
     CavityCharDisplay,
@@ -14,6 +15,7 @@ from .standard import (
 
 __all__ = [
     "BasePlaceholderDisplay",
+    "PiezoPreRFDisplay",
     "FrequencyTuningDisplay",
     "SSACharDisplay",
     "CavityCharDisplay",

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/displays/piezo_pre_rf.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/displays/piezo_pre_rf.py
@@ -1,0 +1,207 @@
+"""Piezo Pre-RF commissioning display."""
+
+from PyQt5.QtCore import pyqtSlot
+
+from sc_linac_physics.applications.rf_commissioning.ui.controllers.piezo_pre_rf_controller import (
+    PiezoPreRFController,
+)
+from sc_linac_physics.applications.rf_commissioning.models.data_models import (
+    CommissioningRecord,
+    PiezoPreRFCheck,
+)
+from sc_linac_physics.applications.rf_commissioning.session_manager import (
+    CommissioningSession,
+)
+from sc_linac_physics.applications.rf_commissioning.ui.builders import (
+    LOCAL_CAP_STYLE,
+    LOCAL_LABEL_STYLE,
+    PiezoPreRFUI,
+)
+
+from .base_placeholder import BasePlaceholderDisplay
+
+
+class PiezoPreRFDisplay(BasePlaceholderDisplay):
+    """Display for Piezo Pre-RF phase (fully implemented)."""
+
+    UI_CLASS = PiezoPreRFUI
+    PHASE_NAME = "Piezo Pre-RF"
+    DATA_ATTR = "piezo_pre_rf"
+    DATA_MODEL = PiezoPreRFCheck
+
+    def __init__(
+        self, parent=None, session: CommissioningSession | None = None
+    ):
+        super().__init__(parent, session=session)
+        self.setWindowTitle("Piezo Pre-RF Test - PyDM")
+
+        self.controller = PiezoPreRFController(self, self.session)
+        if hasattr(self.controller, "phase_completed"):
+            self.controller.phase_completed.connect(
+                self._on_controller_phase_completed
+            )
+        if hasattr(self.controller, "setup_pv_connections"):
+            self.controller.setup_pv_connections()
+
+    def setup_ui(self):
+        """Create the main UI layout."""
+        callbacks = {
+            "toggle_piezo_enable": self.toggle_piezo_enable,
+            "toggle_manual_mode": self.toggle_manual_mode,
+            "on_run_automated_test": self.on_run_automated_test,
+            "on_abort_test": self.on_abort,
+            "on_pause_test": self.on_pause_test,
+            "on_toggle_step_mode": self.on_toggle_step_mode,
+            "on_next_step": self.on_next_step,
+        }
+        self.ui = self.UI_CLASS(self, callbacks)
+        main_layout = self.ui.build()
+        self._bind_ui_widgets()
+        self.setLayout(main_layout)
+        self.update_timestamp()
+
+    def refresh_from_record(self, record: CommissioningRecord) -> None:
+        """Refresh display when active record changes."""
+        result = record.piezo_pre_rf
+        if result:
+            self._update_local_results(result)
+        else:
+            self.clear_results()
+
+        self._update_stored_readout(result)
+
+    def on_record_loaded(
+        self, record: CommissioningRecord, record_id: int
+    ) -> None:
+        """Update display when a record is loaded."""
+        if hasattr(self.controller, "update_pv_addresses"):
+            self.controller.update_pv_addresses(
+                record.cryomodule, str(record.cavity_number)
+            )
+        self.refresh_from_record(record)
+
+    def _on_controller_phase_completed(self, record):
+        """Handle phase completion from controller - notify parent container."""
+        parent = self.parent()
+        while parent:
+            if hasattr(parent, "on_phase_advanced"):
+                parent.on_phase_advanced(record)
+                break
+            parent = parent.parent()
+
+    def _update_local_results(self, result: PiezoPreRFCheck):
+        """Update local result displays (orange-bordered widgets on right panel)."""
+        pass_style = (
+            LOCAL_LABEL_STYLE.replace("#2a2a1a", "#2d5016")
+            + "color: #90ee90; font-weight: bold;"
+        )
+        fail_style = (
+            LOCAL_LABEL_STYLE.replace("#2a2a1a", "#5c1a1a")
+            + "color: #ff6b6b; font-weight: bold;"
+        )
+
+        if hasattr(self, "local_cha_result"):
+            self.local_cha_result.setText(
+                "PASS" if result.channel_a_passed else "FAIL"
+            )
+            self.local_cha_result.setStyleSheet(
+                pass_style if result.channel_a_passed else fail_style
+            )
+
+        if hasattr(self, "local_chb_result"):
+            self.local_chb_result.setText(
+                "PASS" if result.channel_b_passed else "FAIL"
+            )
+            self.local_chb_result.setStyleSheet(
+                pass_style if result.channel_b_passed else fail_style
+            )
+
+        if hasattr(self, "local_overall_result"):
+            self.local_overall_result.setText(
+                "PASS" if result.passed else "FAIL"
+            )
+            overall_style = (
+                pass_style if result.passed else fail_style
+            ) + "font-weight: bold;"
+            self.local_overall_result.setStyleSheet(overall_style)
+
+        if hasattr(self, "local_phase_status"):
+            self.local_phase_status.setText(
+                "Complete" if result.passed else "Incomplete"
+            )
+
+    def _update_stored_readout(self, result: PiezoPreRFCheck | None) -> None:
+        """Update stored-data labels from the record dataclass."""
+        if result is None:
+            self._clear_phase_specific_readouts()
+            return
+
+        self._set_generic_stored_data(result)
+        self._apply_phase_specific_readouts(result)
+
+    def clear_results(self):
+        """Clear all result displays."""
+        super().clear_results()
+
+        if hasattr(self, "local_cha_result"):
+            self.local_cha_result.setText("-")
+            self.local_cha_result.setStyleSheet(LOCAL_LABEL_STYLE)
+        if hasattr(self, "local_chb_result"):
+            self.local_chb_result.setText("-")
+            self.local_chb_result.setStyleSheet(LOCAL_LABEL_STYLE)
+        if hasattr(self, "local_cha_cap"):
+            self.local_cha_cap.setText("-")
+            self.local_cha_cap.setStyleSheet(LOCAL_CAP_STYLE)
+        if hasattr(self, "local_chb_cap"):
+            self.local_chb_cap.setText("-")
+            self.local_chb_cap.setStyleSheet(LOCAL_CAP_STYLE)
+        if hasattr(self, "local_overall_result"):
+            self.local_overall_result.setText("-")
+            self.local_overall_result.setStyleSheet(
+                LOCAL_LABEL_STYLE + "font-weight: bold;"
+            )
+
+        self._clear_generic_stored_data()
+        if hasattr(self, "local_stored_cap_a"):
+            self.local_stored_cap_a.setText("-")
+        if hasattr(self, "local_stored_cap_b"):
+            self.local_stored_cap_b.setText("-")
+
+    def update_piezo_readbacks(self, piezo) -> None:
+        """No-op: PyDM widgets are the source of truth for readbacks."""
+        return
+
+    @pyqtSlot()
+    def toggle_piezo_enable(self):
+        """Toggle piezo enable/disable state."""
+        self.log_message("Use the PyDM enable control for PV writes")
+
+    @pyqtSlot()
+    def toggle_manual_mode(self):
+        """Toggle manual/feedback mode."""
+        self.log_message("Use the PyDM mode control for PV writes")
+
+    @pyqtSlot()
+    def on_run_automated_test(self):
+        """Handle Run Automated Test button click."""
+        self.controller.on_run_automated_test()
+
+    @pyqtSlot()
+    def on_abort(self):
+        """Handle abort button click."""
+        self.controller.on_abort()
+
+    @pyqtSlot()
+    def on_pause_test(self):
+        """Handle pause button click."""
+        self.controller.on_pause_test()
+
+    @pyqtSlot()
+    def on_toggle_step_mode(self):
+        """Handle step mode toggle."""
+        self.controller.on_toggle_step_mode()
+
+    @pyqtSlot()
+    def on_next_step(self):
+        """Handle next step button click."""
+        self.controller.on_next_step()

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/displays/piezo_pre_rf.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/displays/piezo_pre_rf.py
@@ -125,10 +125,8 @@ class PiezoPreRFDisplay(BasePlaceholderDisplay):
             ) + "font-weight: bold;"
             self.local_overall_result.setStyleSheet(overall_style)
 
-        if hasattr(self, "local_phase_status"):
-            self.local_phase_status.setText(
-                "Complete" if result.passed else "Incomplete"
-            )
+        # local_phase_status is owned by the controller (RUNNING/COMPLETED/FAILED)
+        # and should not be overwritten by pass/fail result rendering.
 
     def _update_stored_readout(self, result: PiezoPreRFCheck | None) -> None:
         """Update stored-data labels from the record dataclass."""

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/displays/registry.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/displays/registry.py
@@ -10,6 +10,7 @@ from sc_linac_physics.applications.rf_commissioning.ui.builders import (
 )
 
 from .base_placeholder import BasePlaceholderDisplay
+from .piezo_pre_rf import PiezoPreRFDisplay
 from .standard import (
     CavityCharDisplay,
     FrequencyTuningDisplay,
@@ -21,6 +22,7 @@ from .standard import (
 )
 
 PHASE_DISPLAY_MAP: dict[CommissioningPhase, type[BasePlaceholderDisplay]] = {
+    CommissioningPhase.PIEZO_PRE_RF: PiezoPreRFDisplay,
     CommissioningPhase.FREQUENCY_TUNING: FrequencyTuningDisplay,
     CommissioningPhase.SSA_CHAR: SSACharDisplay,
     CommissioningPhase.CAVITY_CHAR: CavityCharDisplay,

--- a/tests/applications/rf_commissioning/test_piezo_pre_rf_controller.py
+++ b/tests/applications/rf_commissioning/test_piezo_pre_rf_controller.py
@@ -1,0 +1,1250 @@
+"""Targeted tests for Piezo Pre-RF controller helpers."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+import sc_linac_physics.applications.rf_commissioning.ui.controllers.piezo_pre_rf_controller as controller_module
+from sc_linac_physics.applications.rf_commissioning.ui.controllers.piezo_pre_rf_controller import (
+    PiezoPreRFController,
+)
+from sc_linac_physics.applications.rf_commissioning.models.commissioning_piezo import (
+    CommissioningPiezo,
+)
+from sc_linac_physics.applications.rf_commissioning.models.data_models import (
+    CommissioningRecord,
+    PiezoPreRFCheck,
+)
+from sc_linac_physics.applications.rf_commissioning.phases.phase_base import (
+    PhaseContext,
+    PhaseResult,
+    PhaseStepResult,
+)
+
+
+class _ButtonStub:
+    def __init__(self):
+        self.enabled = True
+        self.text = ""
+
+    def setEnabled(self, enabled: bool) -> None:
+        self.enabled = enabled
+
+    def setText(self, text: str) -> None:
+        self.text = text
+
+
+class _ViewStub:
+    def __init__(
+        self,
+        *,
+        current_operator: str = "Test Operator",
+        selected_operator: str = "",
+        cavity: tuple[str, str] | None = ("L1B_CM02_CAV1", "02"),
+    ):
+        self._current_operator = current_operator
+        self._selected_operator = selected_operator
+        self._cavity = cavity
+        self.logs: list[str] = []
+        self.errors: list[str] = []
+
+        self.run_button = _ButtonStub()
+        self.pause_button = _ButtonStub()
+        self.abort_button = _ButtonStub()
+        self.next_step_btn = _ButtonStub()
+        self.local_phase_status = Mock()
+        self.local_progress_bar = Mock()
+        self.ui = SimpleNamespace(update_toolbar_state=Mock())
+        self.step_progress_signal = SimpleNamespace(emit=Mock())
+        self.update_piezo_readbacks = Mock()
+        self._update_local_results = Mock()
+        self._update_stored_readout = Mock()
+
+    def get_current_operator(self) -> str:
+        return self._current_operator
+
+    def get_selected_operator(self) -> str:
+        return self._selected_operator
+
+    def get_current_cavity(self):
+        return self._cavity
+
+    def log_message(self, message: str) -> None:
+        self.logs.append(message)
+
+    def show_error(self, message: str) -> None:
+        self.errors.append(message)
+
+    def clear_results(self) -> None:
+        return None
+
+    def parent(self):
+        return None
+
+    def _notify_parent_of_record_update(self, record, message: str) -> None:
+        return None
+
+
+def _make_controller(view=None, session=None):
+    return PiezoPreRFController(view or _ViewStub(), session or Mock())
+
+
+def _record_with_result() -> CommissioningRecord:
+    record = CommissioningRecord(linac=1, cryomodule="02", cavity_number=1)
+    record.piezo_pre_rf = PiezoPreRFCheck(
+        capacitance_a=25.3e-9,
+        capacitance_b=24.8e-9,
+        channel_a_passed=True,
+        channel_b_passed=True,
+    )
+    return record
+
+
+def test_append_measurement_history_uses_active_phase_instance_id() -> None:
+    session = Mock()
+    controller = _make_controller(session=session)
+    record = _record_with_result()
+    controller.context = PhaseContext(record=record, operator="Test Operator")
+    controller._active_phase_instance_id = 42
+
+    controller._append_measurement_history()
+
+    session.add_measurement_to_history.assert_called_once()
+    args, kwargs = session.add_measurement_to_history.call_args
+    assert kwargs["phase_instance_id"] == 42
+    assert kwargs["operator"] == "Test Operator"
+    assert args[1] is record.piezo_pre_rf
+
+
+def test_append_measurement_history_adds_error_note() -> None:
+    session = Mock()
+    controller = _make_controller(session=session)
+    controller.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+
+    controller._append_measurement_history(error_msg="boom")
+
+    kwargs = session.add_measurement_to_history.call_args[1]
+    assert kwargs["notes"] == "Phase failed: boom"
+
+
+def test_append_measurement_history_no_context_is_noop() -> None:
+    session = Mock()
+    controller = _make_controller(session=session)
+    controller.context = None
+
+    controller._append_measurement_history()
+
+    session.add_measurement_to_history.assert_not_called()
+
+
+def test_get_machine_cavity_builds_machine_with_commissioning_piezo(
+    monkeypatch,
+) -> None:
+    class _MachineStub:
+        def __init__(self, *, piezo_class):
+            self.piezo_class = piezo_class
+            self.cryomodules = {
+                "02": SimpleNamespace(cavities={1: "cavity-object"})
+            }
+
+    monkeypatch.setattr(controller_module, "Machine", _MachineStub)
+    controller = _make_controller()
+
+    cavity = controller._get_machine_cavity(2, 1)
+
+    assert cavity == "cavity-object"
+    assert isinstance(controller.machine, _MachineStub)
+    assert controller.machine.piezo_class is CommissioningPiezo
+
+
+def test_get_operator_does_not_use_legacy_selector() -> None:
+    view = _ViewStub(current_operator="", selected_operator="Legacy Operator")
+    controller = _make_controller(view=view)
+
+    assert controller._get_operator() == ""
+
+
+def test_update_pv_addresses_no_selection_logs_message() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller._resolve_cavity_selection = Mock(return_value=(None, None))
+
+    controller.update_pv_addresses()
+
+    assert "No cavity selected" in view.logs
+
+
+def test_update_pv_addresses_parse_error_logs_message() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller._resolve_cavity_selection = Mock(return_value=("02", "bad"))
+    controller._get_piezo_from_selection = Mock(side_effect=ValueError("bad"))
+
+    controller.update_pv_addresses()
+
+    assert any("Error parsing cavity info" in msg for msg in view.logs)
+
+
+def test_update_pv_addresses_success_runs_mapping_and_sync() -> None:
+    controller = _make_controller()
+    controller._resolve_cavity_selection = Mock(return_value=("02", "1"))
+    controller._get_piezo_from_selection = Mock(return_value=(Mock(), 2, 1))
+    controller._build_pv_mapping = Mock(return_value={"k": Mock()})
+    controller._apply_pv_mapping = Mock()
+    controller._log_pv_update = Mock()
+    controller._sync_piezo_readbacks = Mock()
+
+    controller.update_pv_addresses()
+
+    controller._apply_pv_mapping.assert_called_once()
+    controller._log_pv_update.assert_called_once_with("02", "1", 2, 1)
+    controller._sync_piezo_readbacks.assert_called_once()
+
+
+def test_get_selected_cavity_info_handles_missing_cavity() -> None:
+    view = _ViewStub(cavity=None)
+    controller = _make_controller(view=view)
+
+    assert controller._get_selected_cavity_info() is None
+    assert "Unable to determine cavity information" in view.errors[0]
+
+
+def test_get_selected_cavity_info_handles_parse_error() -> None:
+    view = _ViewStub(cavity=("bad-format", "02"))
+    controller = _make_controller(view=view)
+    controller._parse_cavity_from_record = Mock(side_effect=ValueError())
+
+    assert controller._get_selected_cavity_info() is None
+    assert "Invalid cavity name format" in view.errors[0]
+
+
+def test_get_selected_cavity_info_returns_parsed_values() -> None:
+    controller = _make_controller()
+    controller._parse_cavity_from_record = Mock(return_value=(2, 1))
+
+    result = controller._get_selected_cavity_info()
+
+    assert result == ("L1B_CM02_CAV1", 2, 1)
+
+
+def test_execute_step_with_retries_success_calls_success_handler() -> None:
+    controller = _make_controller()
+    controller.phase = Mock()
+    controller.phase.execute_step.return_value = PhaseStepResult(
+        result=PhaseResult.SUCCESS,
+        message="ok",
+    )
+    controller._create_step_checkpoint = Mock()
+    controller._handle_step_success = Mock(return_value=True)
+
+    result = controller._execute_step_with_retries("setup_piezo", max_retries=3)
+
+    assert result is True
+    controller._create_step_checkpoint.assert_called_once()
+    controller._handle_step_success.assert_called_once()
+
+
+def test_execute_step_with_retries_retry_exhausted_returns_false() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller.phase = Mock()
+    controller.phase.execute_step.return_value = PhaseStepResult(
+        result=PhaseResult.RETRY,
+        message="try again",
+    )
+    controller._create_step_checkpoint = Mock()
+
+    result = controller._execute_step_with_retries("validate", max_retries=2)
+
+    assert result is False
+    assert any("Failed after 2 retries" in msg for msg in view.logs)
+
+
+def test_execute_step_with_retries_failed_result_returns_false() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller.phase = Mock()
+    controller.phase.execute_step.return_value = PhaseStepResult(
+        result=PhaseResult.FAILED,
+        message="bad",
+    )
+    controller._create_step_checkpoint = Mock()
+
+    result = controller._execute_step_with_retries("validate", max_retries=2)
+
+    assert result is False
+    assert any("validate failed" in msg for msg in view.logs)
+
+
+def test_execute_step_with_retries_exception_exhausted_returns_false() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller.phase = Mock()
+    controller.phase.execute_step.side_effect = RuntimeError("rpc down")
+
+    result = controller._execute_step_with_retries("validate", max_retries=2)
+
+    assert result is False
+    assert any("Exception after 2 retries" in msg for msg in view.logs)
+
+
+def test_on_phase_run_finished_routes_to_completed_handler() -> None:
+    controller = _make_controller()
+    controller._sync_piezo_readbacks = Mock()
+    controller.on_phase_completed = Mock()
+    controller.on_phase_failed = Mock()
+
+    controller._on_phase_run_finished(True, "")
+
+    controller._sync_piezo_readbacks.assert_called_once()
+    controller.on_phase_completed.assert_called_once()
+    controller.on_phase_failed.assert_not_called()
+
+
+def test_on_phase_run_finished_uses_default_error_message() -> None:
+    controller = _make_controller()
+    controller._sync_piezo_readbacks = Mock()
+    controller.on_phase_completed = Mock()
+    controller.on_phase_failed = Mock()
+
+    controller._on_phase_run_finished(False, "")
+
+    controller.on_phase_failed.assert_called_once_with("Phase execution failed")
+
+
+def test_on_abort_requests_abort_and_disables_button() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+
+    controller.on_abort()
+
+    assert controller.context.abort_requested is True
+    assert view.abort_button.enabled is False
+    assert "Abort requested..." in view.logs
+
+
+def test_on_pause_test_toggles_pause_state_and_button_text() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+
+    controller.on_pause_test()
+    assert controller._paused is True
+    assert view.pause_button.text == "\u25b6 Resume"
+
+    controller.on_pause_test()
+    assert controller._paused is False
+    assert view.pause_button.text == "\u23f8 Pause"
+
+
+def test_set_next_button_enabled_no_next_step_button_is_safe() -> None:
+    controller = PiezoPreRFController(SimpleNamespace(), Mock())
+    controller._set_next_button_enabled(True)
+
+
+@pytest.mark.parametrize(
+    "view_like",
+    [SimpleNamespace(), SimpleNamespace(ui=SimpleNamespace())],
+)
+def test_update_toolbar_state_without_handler_is_safe(view_like) -> None:
+    controller = PiezoPreRFController(view_like, Mock())
+    controller._update_toolbar_state("running")
+
+
+def test_setup_pv_connections_updates_when_active_record_exists() -> None:
+    session = Mock()
+    session.has_active_record.return_value = True
+    controller = _make_controller(session=session)
+    controller.update_pv_addresses = Mock()
+
+    controller.setup_pv_connections()
+
+    controller.update_pv_addresses.assert_called_once()
+
+
+def test_resolve_and_get_piezo_wrappers(monkeypatch) -> None:
+    controller = _make_controller()
+    piezo = Mock()
+
+    monkeypatch.setattr(
+        controller_module,
+        "resolve_cavity_selection",
+        lambda view, cm, cav: ("02", "1"),
+    )
+    monkeypatch.setattr(
+        controller_module,
+        "get_piezo_from_selection",
+        lambda machine, cm, cav: (piezo, 2, 1, "machine-obj"),
+    )
+
+    assert controller._resolve_cavity_selection(None, None) == ("02", "1")
+    result = controller._get_piezo_from_selection("02", "1")
+    assert result == (piezo, 2, 1)
+    assert controller.machine == "machine-obj"
+
+
+def test_update_pv_addresses_generic_error_logs_message() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller._resolve_cavity_selection = Mock(return_value=("02", "1"))
+    controller._get_piezo_from_selection = Mock(
+        side_effect=RuntimeError("oops")
+    )
+
+    controller.update_pv_addresses()
+
+    assert any("Error setting PVs" in msg for msg in view.logs)
+
+
+def test_update_pv_addresses_mapping_error_logs_message() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller._resolve_cavity_selection = Mock(return_value=("02", "1"))
+    controller._get_piezo_from_selection = Mock(return_value=(Mock(), 2, 1))
+    controller._build_pv_mapping = Mock(side_effect=RuntimeError("map fail"))
+
+    controller.update_pv_addresses()
+
+    assert any("Error setting PVs" in msg for msg in view.logs)
+
+
+def test_build_apply_log_wrappers_delegate(monkeypatch) -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    piezo = Mock()
+    called = {"apply": False}
+
+    monkeypatch.setattr(
+        controller_module,
+        "build_pv_mapping",
+        lambda in_view, in_piezo: {"ok": (in_view, in_piezo)},
+    )
+    monkeypatch.setattr(
+        controller_module,
+        "apply_pv_mapping",
+        lambda mapping: called.__setitem__("apply", bool(mapping)),
+    )
+    monkeypatch.setattr(
+        controller_module,
+        "format_pv_update_message",
+        lambda cm, cav, cm_i, cav_i: f"{cm}-{cav}-{cm_i}-{cav_i}",
+    )
+
+    mapping = controller._build_pv_mapping(piezo)
+    controller._apply_pv_mapping(mapping)
+    controller._log_pv_update("02", "1", 2, 1)
+
+    assert called["apply"] is True
+    assert view.logs[-1] == "02-1-2-1"
+
+
+def test_sync_piezo_readbacks_branches() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    piezo = Mock()
+
+    controller._sync_piezo_readbacks(piezo)
+    view.update_piezo_readbacks.assert_called_once_with(piezo)
+
+    controller._resolve_cavity_selection = Mock(return_value=("02", "1"))
+    controller._get_piezo_from_selection = Mock(return_value=(piezo, 2, 1))
+    controller._sync_piezo_readbacks(None)
+    assert controller._get_piezo_from_selection.called
+
+
+def test_sync_piezo_readbacks_error_and_no_handler_paths() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller._resolve_cavity_selection = Mock(return_value=("02", "1"))
+    controller._get_piezo_from_selection = Mock(
+        side_effect=RuntimeError("rb fail")
+    )
+
+    controller._sync_piezo_readbacks(None)
+    assert any("Readback sync failed" in msg for msg in view.logs)
+
+    controller_no_hook = PiezoPreRFController(SimpleNamespace(), Mock())
+    controller_no_hook._sync_piezo_readbacks(Mock())
+
+
+def test_parse_cavity_from_record() -> None:
+    controller = _make_controller()
+    assert controller._parse_cavity_from_record("L1B_CM02_CAV8", "02") == (2, 8)
+    assert controller._parse_cavity_from_record("SHORT", "02") == (2, 1)
+
+
+def test_prepare_phase_context_can_run_false() -> None:
+    view = _ViewStub()
+    session = Mock()
+    session.get_active_record.return_value = _record_with_result()
+    session.get_active_record_id.return_value = 7
+    session.can_run_phase.return_value = (False, "blocked")
+    controller = _make_controller(view=view, session=session)
+
+    ok = controller._prepare_phase_context(Mock(), "op")
+
+    assert ok is False
+    assert any("ERROR: blocked" in msg for msg in view.logs)
+
+
+def test_prepare_phase_context_prerequisites_fail(monkeypatch) -> None:
+    view = _ViewStub()
+    session = Mock()
+    session.get_active_record.return_value = _record_with_result()
+    session.get_active_record_id.return_value = 7
+    session.can_run_phase.return_value = (True, "")
+    session.start_active_phase_instance.return_value = SimpleNamespace(
+        phase_instance_id=99
+    )
+
+    class _PhaseStub:
+        def __init__(self, context):
+            self.context = context
+
+        def validate_prerequisites(self):
+            return (False, "bad state")
+
+    monkeypatch.setattr(controller_module, "PiezoPreRFPhase", _PhaseStub)
+    controller = _make_controller(view=view, session=session)
+
+    ok = controller._prepare_phase_context(Mock(), "op")
+
+    assert ok is False
+    assert any("ERROR: bad state" in msg for msg in view.logs)
+
+
+def test_prepare_phase_context_success_without_record_id(monkeypatch) -> None:
+    session = Mock()
+    session.get_active_record.return_value = _record_with_result()
+    session.get_active_record_id.return_value = None
+    session.can_run_phase.return_value = (True, "")
+
+    class _PhaseStub:
+        def __init__(self, context):
+            self.context = context
+
+        def validate_prerequisites(self):
+            return (True, "ok")
+
+    monkeypatch.setattr(controller_module, "PiezoPreRFPhase", _PhaseStub)
+    controller = _make_controller(session=session)
+
+    ok = controller._prepare_phase_context(Mock(), "op")
+
+    assert ok is True
+    assert controller._active_phase_instance_id is None
+
+
+def test_set_running_ui_state_sets_expected_controls() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+
+    controller._set_running_ui_state()
+
+    assert view.run_button.enabled is False
+    assert view.pause_button.enabled is True
+    assert view.abort_button.enabled is True
+    view.local_phase_status.setText.assert_called_once_with("RUNNING")
+
+
+def test_on_run_automated_test_no_operator_focuses_parent() -> None:
+    view = _ViewStub(current_operator="")
+    controller = _make_controller(view=view)
+    controller._focus_parent_widget = Mock()
+
+    controller.on_run_automated_test()
+
+    controller._focus_parent_widget.assert_called_once_with("operator_combo")
+
+
+def test_on_run_automated_test_stops_when_auto_create_fails() -> None:
+    session = Mock()
+    session.has_active_record.return_value = False
+    controller = _make_controller(session=session)
+    controller._auto_create_record = Mock(return_value=False)
+
+    controller.on_run_automated_test()
+
+    controller._auto_create_record.assert_called_once()
+
+
+def test_on_run_automated_test_stops_when_no_cavity() -> None:
+    session = Mock()
+    session.has_active_record.return_value = True
+    controller = _make_controller(session=session)
+    controller._get_selected_cavity_info = Mock(return_value=None)
+
+    controller.on_run_automated_test()
+
+    controller._get_selected_cavity_info.assert_called_once()
+
+
+def test_on_run_automated_test_success_path() -> None:
+    view = _ViewStub()
+    session = Mock()
+    session.has_active_record.return_value = True
+    controller = _make_controller(view=view, session=session)
+    controller._get_selected_cavity_info = Mock(
+        return_value=("L1B_CM02_CAV1", 2, 1)
+    )
+    controller.update_pv_addresses = Mock()
+    controller._get_machine_cavity = Mock(return_value=Mock())
+    controller._prepare_phase_context = Mock(return_value=True)
+    controller._set_running_ui_state = Mock()
+    controller.execute_phase_steps = Mock()
+
+    controller.on_run_automated_test()
+
+    controller.update_pv_addresses.assert_called_once_with("02", "1")
+    controller._set_running_ui_state.assert_called_once()
+    controller.execute_phase_steps.assert_called_once()
+
+
+def test_on_run_automated_test_exception_is_logged() -> None:
+    view = _ViewStub()
+    session = Mock()
+    session.has_active_record.return_value = True
+    controller = _make_controller(view=view, session=session)
+    controller._get_selected_cavity_info = Mock(
+        return_value=("L1B_CM02_CAV1", 2, 1)
+    )
+    controller.update_pv_addresses = Mock(side_effect=RuntimeError("kaboom"))
+
+    controller.on_run_automated_test()
+
+    assert any("Failed to start test" in msg for msg in view.errors)
+
+
+def test_auto_create_record_paths(monkeypatch) -> None:
+    view = _ViewStub()
+    session = Mock()
+    controller = _make_controller(view=view, session=session)
+
+    controller._get_cavity_from_parent = Mock(return_value=(None, None))
+    controller._focus_parent_widget = Mock()
+    assert controller._auto_create_record() is False
+
+    controller._get_cavity_from_parent = Mock(return_value=("02", "1"))
+    session.start_new_record.return_value = (_record_with_result(), 10, True)
+    controller._notify_parent_record_created = Mock()
+    controller.update_pv_addresses = Mock()
+    assert controller._auto_create_record() is True
+
+    session.start_new_record.return_value = (_record_with_result(), 10, False)
+    assert controller._auto_create_record() is True
+
+    controller._get_cavity_from_parent = Mock(return_value=("02", "1"))
+    session.start_new_record.side_effect = RuntimeError("db down")
+    assert controller._auto_create_record() is False
+
+
+class _Combo:
+    def __init__(self, text):
+        self._text = text
+
+    def currentText(self):
+        return self._text
+
+
+class _ParentWithCavitySelection:
+    def __init__(self, cm="02", cav="1"):
+        self.cryomodule_combo = _Combo(cm)
+        self.cavity_combo = _Combo(cav)
+
+    def parent(self):
+        return None
+
+
+class _BrokenCombo:
+    def currentText(self):
+        raise RuntimeError("bad parent")
+
+
+class _BadParentWithBrokenCombos:
+    def __init__(self):
+        self.cryomodule_combo = _BrokenCombo()
+        self.cavity_combo = _BrokenCombo()
+
+    def parent(self):
+        return None
+
+
+class _FocusableParent:
+    def __init__(self):
+        self.operator_combo = SimpleNamespace(setFocus=Mock())
+
+    def parent(self):
+        return None
+
+
+class _ChainParent:
+    def __init__(self, parent_obj):
+        self._parent_obj = parent_obj
+
+    def parent(self):
+        return self._parent_obj
+
+
+def test_get_cavity_from_parent_returns_selected_cm_and_cavity() -> None:
+    controller = _make_controller()
+    view = _ViewStub()
+    view.parent = lambda: _ParentWithCavitySelection(cm="02", cav="1")
+    controller.view = view
+
+    assert controller._get_cavity_from_parent() == ("02", "1")
+
+
+def test_get_cavity_from_parent_returns_none_when_selection_empty() -> None:
+    controller = _make_controller()
+    view = _ViewStub()
+    view.parent = lambda: _ParentWithCavitySelection(cm="", cav="")
+    controller.view = view
+
+    assert controller._get_cavity_from_parent() == (None, None)
+
+
+def test_get_cavity_from_parent_returns_none_when_parent_combo_fails() -> None:
+    controller = _make_controller()
+    view = _ViewStub()
+    view.parent = lambda: _BadParentWithBrokenCombos()
+    controller.view = view
+
+    assert controller._get_cavity_from_parent() == (None, None)
+
+
+def test_focus_parent_widget_focuses_direct_parent_attribute() -> None:
+    controller = _make_controller()
+    view = _ViewStub()
+    focus_parent = _FocusableParent()
+    view.parent = lambda: focus_parent
+    controller.view = view
+
+    controller._focus_parent_widget("operator_combo")
+
+    focus_parent.operator_combo.setFocus.assert_called_once()
+
+
+def test_focus_parent_widget_traverses_parent_chain() -> None:
+    controller = _make_controller()
+    view = _ViewStub()
+    focus_parent = _FocusableParent()
+    view.parent = lambda: _ChainParent(focus_parent)
+    controller.view = view
+
+    controller._focus_parent_widget("operator_combo")
+
+    focus_parent.operator_combo.setFocus.assert_called_once()
+
+
+def test_on_run_automated_test_stops_when_prepare_context_fails() -> None:
+    session = Mock()
+    session.has_active_record.return_value = True
+    controller = _make_controller(session=session)
+    controller._get_selected_cavity_info = Mock(
+        return_value=("L1B_CM02_CAV1", 2, 1)
+    )
+    controller.update_pv_addresses = Mock()
+    controller._get_machine_cavity = Mock(return_value=Mock())
+    controller._prepare_phase_context = Mock(return_value=False)
+    controller.execute_phase_steps = Mock()
+
+    controller.on_run_automated_test()
+
+    controller.execute_phase_steps.assert_not_called()
+
+
+def test_execute_phase_steps_paths(monkeypatch) -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+
+    controller.context = None
+    controller.phase = None
+    controller.execute_phase_steps()
+    assert "No phase context available" in view.errors[-1]
+
+    controller.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+    controller.phase = Mock()
+    controller.phase.get_phase_steps.return_value = ["a"]
+    controller._step_mode = True
+    controller._set_next_button_enabled = Mock()
+    monkeypatch.setattr(
+        controller_module.QTimer, "singleShot", lambda _ms, fn: fn()
+    )
+
+    controller.execute_phase_steps()
+    controller._set_next_button_enabled.assert_called_once_with(True)
+
+    controller._step_mode = False
+    controller._run_phase_in_background = Mock(
+        side_effect=RuntimeError("run boom")
+    )
+    controller.on_phase_failed = Mock()
+    controller.execute_phase_steps()
+    controller.on_phase_failed.assert_called_once_with("run boom")
+
+
+def test_run_phase_in_background_worker_paths(monkeypatch) -> None:
+    controller = _make_controller()
+    controller.phase = Mock()
+    controller.phase.get_phase_steps.return_value = ["step"]
+    controller._check_pause_and_abort = Mock(return_value=False)
+
+    class _ThreadStub:
+        def __init__(self, target, daemon):
+            self.target = target
+
+        def start(self):
+            self.target()
+
+    monkeypatch.setattr(controller_module, "Thread", _ThreadStub)
+    controller._run_phase_in_background()
+
+    controller = _make_controller()
+    controller.phase = Mock()
+    controller.phase.get_phase_steps.return_value = ["step"]
+    controller.phase._execute_step_with_retry.return_value = False
+    controller._check_pause_and_abort = Mock(return_value=True)
+    monkeypatch.setattr(controller_module, "Thread", _ThreadStub)
+    emitted = []
+    controller.phase_run_finished.connect(
+        lambda ok, msg: emitted.append((ok, msg))
+    )
+    controller._run_phase_in_background()
+    assert emitted[-1] == (False, "Step failed: step")
+
+    controller = _make_controller()
+    controller.phase = Mock()
+    controller.phase.get_phase_steps.side_effect = RuntimeError("worker fail")
+    monkeypatch.setattr(controller_module, "Thread", _ThreadStub)
+    emitted = []
+    controller.phase_run_finished.connect(
+        lambda ok, msg: emitted.append((ok, msg))
+    )
+    controller._run_phase_in_background()
+    assert emitted[-1] == (False, "worker fail")
+
+    controller = _make_controller()
+    controller.phase = Mock()
+    controller.phase.get_phase_steps.return_value = ["step"]
+    controller.phase._execute_step_with_retry.return_value = True
+    controller._check_pause_and_abort = Mock(return_value=True)
+    controller._finalize_background_phase = Mock()
+    monkeypatch.setattr(controller_module, "Thread", _ThreadStub)
+    controller._run_phase_in_background()
+    controller._finalize_background_phase.assert_called_once()
+
+
+def test_check_pause_and_abort_paths(monkeypatch) -> None:
+    controller = _make_controller()
+    controller.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+    controller._paused = True
+
+    def _sleep(_):
+        controller.context.request_abort()
+
+    monkeypatch.setitem(
+        __import__("sys").modules, "time", SimpleNamespace(sleep=_sleep)
+    )
+    emitted = []
+    controller.phase_run_finished.connect(
+        lambda ok, msg: emitted.append((ok, msg))
+    )
+    assert controller._check_pause_and_abort() is False
+    assert emitted[-1] == (False, "Aborted")
+
+    controller = _make_controller()
+    controller.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+    controller.context.request_abort()
+    emitted = []
+    controller.phase_run_finished.connect(
+        lambda ok, msg: emitted.append((ok, msg))
+    )
+    assert controller._check_pause_and_abort() is False
+    assert emitted[-1] == (False, "Aborted")
+
+    controller = _make_controller()
+    assert controller._check_pause_and_abort() is True
+
+
+def test_finalize_background_phase_paths() -> None:
+    controller = _make_controller()
+    controller.phase = Mock()
+    emitted = []
+    controller.phase_run_finished.connect(
+        lambda ok, msg: emitted.append((ok, msg))
+    )
+    controller._finalize_background_phase()
+    assert emitted[-1] == (True, "")
+
+    controller = _make_controller()
+    controller.phase = Mock()
+    controller.phase.finalize_phase.side_effect = RuntimeError("finalize fail")
+    emitted = []
+    controller.phase_run_finished.connect(
+        lambda ok, msg: emitted.append((ok, msg))
+    )
+    controller._finalize_background_phase()
+    assert emitted[-1] == (False, "finalize fail")
+
+
+def test_execute_single_step_and_wait_notify_helpers(monkeypatch) -> None:
+    controller = _make_controller()
+    controller._wait_for_unpause = Mock(return_value=False)
+    assert controller._execute_single_step("step") is False
+
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller._wait_for_unpause = Mock(return_value=True)
+    controller.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+    controller.context.request_abort()
+    assert controller._execute_single_step("step") is False
+    assert any("Abort during step" in msg for msg in view.logs)
+
+    controller = _make_controller()
+    controller._wait_for_unpause = Mock(return_value=True)
+    controller._notify_step_progress = Mock()
+    controller._execute_step_with_retries = Mock(return_value=True)
+    assert controller._execute_single_step("step") is True
+
+    controller = _make_controller()
+    assert controller._wait_for_unpause() is True
+    controller._paused = True
+    calls = {"n": 0}
+    monkeypatch.setattr(
+        controller_module.QTimer, "singleShot", lambda _ms, fn: fn()
+    )
+
+    def _sleep(_):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            controller._paused = False
+
+    monkeypatch.setitem(
+        __import__("sys").modules, "time", SimpleNamespace(sleep=_sleep)
+    )
+    assert controller._wait_for_unpause() is True
+
+    events = []
+    controller.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+    controller.context.progress_callback = lambda step, prog: events.append(
+        (step, prog)
+    )
+    controller._steps = ["a", "b"]
+    controller._notify_step_progress("b")
+    controller._notify_step_progress("x")
+    assert events[0] == ("b", 50)
+    assert events[1] == ("x", 0)
+
+
+def test_execute_step_with_retries_skip_and_retry_then_success() -> None:
+    controller = _make_controller()
+    controller.phase = Mock()
+    controller.phase.execute_step.return_value = PhaseStepResult(
+        result=PhaseResult.SKIP,
+        message="skip",
+    )
+    controller._create_step_checkpoint = Mock()
+    controller._handle_step_success = Mock(return_value=True)
+    assert controller._execute_step_with_retries("step", 2) is True
+
+    controller = _make_controller(view=_ViewStub())
+    controller.phase = Mock()
+    controller.phase.execute_step.side_effect = [
+        PhaseStepResult(result=PhaseResult.RETRY, message="retry"),
+        PhaseStepResult(result=PhaseResult.SUCCESS, message="ok"),
+    ]
+    controller._create_step_checkpoint = Mock()
+    controller._handle_step_success = Mock(return_value=True)
+    assert controller._execute_step_with_retries("step", 3) is True
+
+
+def test_execute_step_with_retries_zero_retries_returns_false() -> None:
+    controller = _make_controller()
+    controller.phase = Mock()
+    assert controller._execute_step_with_retries("step", 0) is False
+
+
+def test_create_checkpoint_and_handle_step_success_paths() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    record = _record_with_result()
+    record.phase_history = []
+    controller.context = PhaseContext(record=record, operator="op")
+    controller.phase = Mock()
+    controller.phase.phase_type = "PHASE"
+
+    result = PhaseStepResult(
+        result=PhaseResult.SUCCESS, message="done", data={"a": 1}
+    )
+    controller._create_step_checkpoint("step", result)
+    assert len(record.phase_history) == 1
+
+    controller._sync_piezo_readbacks = Mock()
+    assert controller._handle_step_success("setup_piezo", result) is True
+    controller._sync_piezo_readbacks.assert_called_once()
+
+    skip = PhaseStepResult(result=PhaseResult.SKIP, message="skip")
+    assert controller._handle_step_success("validate", skip) is True
+
+
+def test_finalize_phase_execution_paths() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller.phase = Mock()
+    controller.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+    controller.on_phase_completed = Mock()
+    controller._finalize_phase_execution()
+    controller.on_phase_completed.assert_called_once()
+
+    controller = _make_controller(view=_ViewStub())
+    controller.phase = Mock()
+    rec = _record_with_result()
+    rec.piezo_pre_rf = None
+    controller.context = PhaseContext(record=rec, operator="op")
+    controller.on_phase_completed = Mock()
+    controller._finalize_phase_execution()
+    assert any("not populated" in msg for msg in controller.view.logs)
+
+    controller = _make_controller(view=_ViewStub())
+    controller.phase = Mock()
+    controller.phase.finalize_phase.side_effect = RuntimeError("boom")
+    controller.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+    controller.on_phase_failed = Mock()
+    controller._finalize_phase_execution()
+    controller.on_phase_failed.assert_called_once_with("boom")
+
+
+def test_on_phase_completed_paths() -> None:
+    view = _ViewStub()
+    session = Mock()
+    session.complete_active_phase_instance.return_value = True
+    session.has_active_record.return_value = True
+    session.get_active_record.return_value = SimpleNamespace(
+        current_phase=SimpleNamespace(value="NEXT")
+    )
+    session.save_active_record.return_value = True
+    session.get_active_record_id.return_value = 77
+    controller = _make_controller(view=view, session=session)
+    controller.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+    controller._active_phase_instance_id = 3
+    captured = []
+    controller.phase_completed.connect(lambda rec: captured.append(rec))
+    controller._append_measurement_history = Mock()
+
+    controller.on_phase_completed()
+
+    assert controller._active_phase_instance_id is None
+    assert view.run_button.enabled is True
+    assert captured
+
+    view2 = _ViewStub()
+    session2 = Mock()
+    session2.complete_active_phase_instance.return_value = False
+    session2.save_active_record.return_value = False
+    controller2 = _make_controller(view=view2, session=session2)
+    controller2.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+    controller2._active_phase_instance_id = 5
+    controller2.on_phase_completed()
+    assert any("Warning: Failed to advance" in msg for msg in view2.logs)
+    assert any("Warning: Failed to save" in msg for msg in view2.logs)
+
+    view3 = _ViewStub()
+    controller3 = _make_controller(view=view3, session=Mock())
+    rec = _record_with_result()
+    rec.piezo_pre_rf = None
+    controller3.context = PhaseContext(record=rec, operator="op")
+    controller3.on_phase_completed()
+    assert any("No piezo_pre_rf" in msg for msg in view3.logs)
+
+
+def test_on_phase_completed_exception_fails_active_phase() -> None:
+    view = _ViewStub()
+    session = Mock()
+    session.complete_active_phase_instance.side_effect = RuntimeError(
+        "svc down"
+    )
+    controller = _make_controller(view=view, session=session)
+    controller.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+    controller._active_phase_instance_id = 11
+
+    controller.on_phase_completed()
+
+    session.fail_active_phase_instance.assert_called_once()
+
+
+def test_on_phase_failed_paths() -> None:
+    view = _ViewStub()
+    session = Mock()
+    session.save_active_record.return_value = True
+    controller = _make_controller(view=view, session=session)
+    controller.phase = Mock()
+    controller.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+    controller._active_phase_instance_id = 9
+    controller._append_measurement_history = Mock()
+
+    controller.on_phase_failed("bad")
+
+    session.fail_active_phase_instance.assert_called_once()
+    assert view.run_button.enabled is True
+    assert view.pause_button.enabled is False
+    assert view.abort_button.enabled is False
+
+    view2 = _ViewStub()
+    session2 = Mock()
+    controller2 = _make_controller(view=view2, session=session2)
+    controller2.phase = Mock()
+    rec = _record_with_result()
+    rec.piezo_pre_rf = None
+    controller2.context = PhaseContext(record=rec, operator="op")
+    controller2._active_phase_instance_id = 4
+    controller2.on_phase_failed("bad2")
+    kwargs = session2.fail_active_phase_instance.call_args[1]
+    assert kwargs["artifact_payload"] is None
+
+
+def test_on_phase_failed_exception_branch() -> None:
+    view = _ViewStub()
+    session = Mock()
+    session.save_active_record.side_effect = RuntimeError("db exploded")
+    controller = _make_controller(view=view, session=session)
+    controller.phase = Mock()
+    controller.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+    controller._active_phase_instance_id = 10
+
+    controller.on_phase_failed("orig")
+
+    session.fail_active_phase_instance.assert_called_once()
+
+
+def test_get_operator_empty_when_no_methods() -> None:
+    controller = PiezoPreRFController(SimpleNamespace(), Mock())
+    assert controller._get_operator() == ""
+
+
+def test_on_abort_without_context_is_noop() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller.context = None
+    controller.on_abort()
+    assert view.abort_button.enabled is True
+
+
+def test_set_next_button_enabled_and_update_toolbar_positive_paths() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller._set_next_button_enabled(True)
+    assert view.next_step_btn.enabled is True
+
+    controller._update_toolbar_state("running")
+    view.ui.update_toolbar_state.assert_called_once_with("running")
+
+
+def test_toggle_step_mode_and_next_step_paths(monkeypatch) -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller._set_next_button_enabled = Mock()
+
+    controller.on_toggle_step_mode()
+    assert controller._step_mode is True
+
+    controller.on_toggle_step_mode()
+    assert controller._step_mode is False
+    controller._set_next_button_enabled.assert_called_with(False)
+
+    controller._step_mode = False
+    controller._step_executing = False
+    controller.on_next_step()
+
+    controller._step_mode = True
+    controller._step_executing = True
+    controller.on_next_step()
+
+    controller._step_executing = False
+    controller._steps = ["a"]
+    controller._current_step_index = 1
+    controller.on_next_step()
+    assert any("All steps completed" in msg for msg in view.logs)
+
+    monkeypatch.setattr(
+        controller_module.QTimer, "singleShot", lambda _ms, fn: fn()
+    )
+    controller._current_step_index = 0
+    controller._steps = ["a", "b"]
+    controller._execute_single_step = Mock(return_value=True)
+    controller._set_next_button_enabled = Mock()
+    controller.on_next_step()
+    assert controller._current_step_index == 1
+
+    controller._steps = ["a"]
+    controller._current_step_index = 0
+    controller._execute_single_step = Mock(return_value=True)
+    controller._finalize_phase_execution = Mock()
+    controller.on_next_step()
+    controller._finalize_phase_execution.assert_called_once()
+
+    controller._steps = ["a"]
+    controller._current_step_index = 0
+    controller._execute_single_step = Mock(return_value=False)
+    controller.on_phase_failed = Mock()
+    controller.on_next_step()
+    controller.on_phase_failed.assert_called_once_with("Step execution failed")
+
+    controller._steps = ["a"]
+    controller._current_step_index = 0
+    controller._execute_single_step = Mock(
+        side_effect=RuntimeError("step kaboom")
+    )
+    controller.on_phase_failed = Mock()
+    controller.on_next_step()
+    controller.on_phase_failed.assert_called_once_with("step kaboom")
+
+
+def test_notify_parent_record_created_logs_message() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    record = _record_with_result()
+
+    controller._notify_parent_record_created(record, 1)
+
+    assert any("Notified parent container" in msg for msg in view.logs)
+
+
+def test_get_cavity_from_parent_returns_none_when_no_matching_parent() -> None:
+    controller = _make_controller()
+
+    class _NoCombos:
+        def parent(self):
+            return None
+
+    controller.view.parent = lambda: _NoCombos()
+
+    assert controller._get_cavity_from_parent() == (None, None)

--- a/tests/applications/rf_commissioning/ui/test_displays.py
+++ b/tests/applications/rf_commissioning/ui/test_displays.py
@@ -18,6 +18,9 @@ from sc_linac_physics.applications.rf_commissioning.session_manager import (
 from sc_linac_physics.applications.rf_commissioning.ui.displays.base_placeholder import (
     BasePlaceholderDisplay,
 )
+from sc_linac_physics.applications.rf_commissioning.ui.displays.piezo_pre_rf import (
+    PiezoPreRFDisplay,
+)
 from sc_linac_physics.applications.rf_commissioning.ui.displays.registry import (
     PHASE_DISPLAY_MAP,
     get_phase_display_class,
@@ -323,6 +326,23 @@ class TestBasePlaceholderDisplay:
         freq_display.get_current_operator = lambda: "op1"
         freq_display.get_current_cavity = lambda: ("01-1", "01")
         freq_display.on_run_automated_test()
+
+    def test_piezo_update_local_results_does_not_touch_run_status(self):
+        display = PiezoPreRFDisplay.__new__(PiezoPreRFDisplay)
+        display.local_cha_result = MagicMock()
+        display.local_chb_result = MagicMock()
+        display.local_overall_result = MagicMock()
+        display.local_phase_status = MagicMock()
+
+        result = SimpleNamespace(
+            channel_a_passed=True,
+            channel_b_passed=False,
+            passed=False,
+        )
+
+        PiezoPreRFDisplay._update_local_results(display, result)
+
+        display.local_phase_status.setText.assert_not_called()
 
 
 # =============================================================================


### PR DESCRIPTION

## Summary
Implemented Piezo Pre-RF commissioning phase with automated testing, step-by-step execution, and full EPICS PV integration.

## Changes Made

### New Files
- **`ui/controllers/__init__.py`**: New controllers subpackage for phase execution logic
- **`ui/controllers/piezo_pre_rf_controller.py`**: Controller implementing Piezo Pre-RF phase execution (896 lines)
- **`ui/controllers/piezo_pre_rf_pv.py`**: PV address resolution and widget binding helpers (98 lines)
- **`ui/displays/piezo_pre_rf.py`**: PyDM-based display for Piezo Pre-RF phase (207 lines)
- **`tests/applications/rf_commissioning/test_piezo_pre_rf_controller.py`**: Comprehensive test suite with 1,250 lines of coverage

### Modified Files
- **`ui/__init__.py`**: Added `PiezoPreRFDisplay` to public exports
- **`ui/displays/__init__.py`**: Added `PiezoPreRFDisplay` to display exports
- **`ui/displays/registry.py`**: Registered `PiezoPreRFDisplay` for `CommissioningPhase.PIEZO_PRE_RF` phase

## Features

### Automated Test Execution
- One-click automated piezo characterization test
- Background thread execution with progress tracking
- Automatic retry logic for transient failures
- Step-by-step progress updates with checkpoint creation

### Test Control
- **Pause/Resume**: Pause execution and resume from current step
- **Abort**: Safe abort with partial result preservation
- **Step Mode**: Manual step-by-step execution for debugging/training

### Auto-Record Management
- Automatically creates commissioning record if none exists
- Uses cavity selection from parent UI (CM/Cavity dropdowns)
- Validates operator selection before execution
- Notifies parent container of record creation

### EPICS PV Integration
- Dynamic PV address resolution based on selected cavity
- PyDM widgets for real-time piezo status monitoring
- Piezo enable/disable and manual/feedback mode controls
- Capacitance readbacks for Channel A and Channel B

### Phase Lifecycle Tracking
- Integrates with `CommissioningSession` phase instance tracking
- Records phase start, completion, and failure states
- Stores measurement artifacts in database
- Advances commissioning workflow on successful completion

### UI Features
- Live capacitance and test status displays
- Stored data readout from previous test runs
- Pass/fail indicators with color-coded styling
- Detailed execution log with timestamps

## Architecture

### Controller Pattern
Follows MVC pattern with clear separation:
- **Display**: UI layout and PyDM widget management
- **Controller**: Phase execution, state management, session coordination
- **PV Helpers**: EPICS address resolution and widget binding

### Thread Safety
- Background worker thread for blocking phase execution
- Qt signal/slot communication for UI updates
- Thread-safe abort and pause state checking

### Error Handling
- Comprehensive exception handling with user-friendly messages
- Partial result preservation on failure
- Automatic phase instance failure recording
- Detailed error logging with stack traces

## Testing
Comprehensive test coverage including:
- PV address resolution and widget binding
- Controller state machine (running, paused, aborted, completed)
- Step execution with retry logic
- Phase lifecycle integration
- Parent widget interaction (operator selection, cavity selection)
- Auto-record creation flows
- Error handling paths
- Thread worker execution

## Integration
- Seamlessly integrates with existing RF commissioning framework
- Uses `BasePlaceholderDisplay` pattern for consistency
- Leverages `CommissioningSession` for database persistence
- Compatible with existing phase display registry

## Breaking Changes
None - this is a new feature that extends the existing commissioning system.