### PR TITLE
feat(rf-commissioning): Implement SSA Calibration Phase

### DIFF
--- a/src/sc_linac_physics/applications/rf_commissioning/models/data_models.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/models/data_models.py
@@ -282,18 +282,28 @@ class SSACharacterization:
         format_spec=".2f",
         unit="%",
     )  # 0.0-1.0
-    initial_drive: float | None = phase_display_field(
+    slope_new: float | None = phase_display_field(
         default=None,
-        label="Initial Drive",
-        widget_name="ssa_initial_drive",
-        source_attr="initial_drive_percent",
-        format_spec=".2f",
-        unit="%",
+        label="Slope",
+        widget_name="ssa_slope_new",
+        source_attr="slope_new",
+        format_spec=".5f",
     )
-    num_attempts: int = phase_display_field(
-        default=0,
-        label="Attempts",
-        widget_name="ssa_num_attempts",
+    max_fwd_pwr_w: float | None = phase_display_field(
+        default=None,
+        label="Max Fwd Pwr",
+        widget_name="ssa_max_fwd_pwr",
+        source_attr="max_fwd_pwr_w",
+        format_spec=".1f",
+        unit="W",
+    )
+    calibration_passed: bool = phase_display_field(
+        default=False,
+        label="Calibration",
+        widget_name="ssa_cal_passed",
+        source_attr="calibration_passed",
+        true_text="PASS",
+        false_text="FAIL",
     )
     timestamp: datetime = field(default_factory=datetime.now)
     notes: str = ""
@@ -306,32 +316,13 @@ class SSACharacterization:
         return self.max_drive * 100
 
     @property
-    def initial_drive_percent(self) -> float | None:
-        """Initial drive as percentage (0-100)."""
-        if self.initial_drive is None:
-            return None
-        return self.initial_drive * 100
-
-    @property
-    def drive_reduction(self) -> float | None:
-        """Total reduction in drive level."""
-        if self.initial_drive is None or self.max_drive is None:
-            return None
-        return self.initial_drive - self.max_drive
-
-    @property
-    def succeeded_first_try(self) -> bool:
-        """Check if calibration succeeded on first attempt."""
-        return self.num_attempts == 1
-
-    @property
     def is_complete(self) -> bool:
         """Check if calibration completed successfully."""
-        return self.max_drive is not None
+        return self.slope_new is not None
 
     @property
     def passed(self) -> bool:
-        return self.is_complete
+        return self.calibration_passed
 
     def to_dict(self) -> dict:
         """Serialize to dictionary."""
@@ -339,9 +330,6 @@ class SSACharacterization:
             self,
             computed_fields=(
                 "max_drive_percent",
-                "initial_drive_percent",
-                "drive_reduction",
-                "succeeded_first_try",
                 "is_complete",
                 "passed",
             ),

--- a/src/sc_linac_physics/applications/rf_commissioning/models/data_models.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/models/data_models.py
@@ -289,11 +289,10 @@ class SSACharacterization:
         source_attr="slope_new",
         format_spec=".5f",
     )
-    max_fwd_pwr_w: float | None = phase_display_field(
+    max_fwd_pwr: float | None = phase_display_field(
         default=None,
         label="Max Fwd Pwr",
         widget_name="ssa_max_fwd_pwr",
-        source_attr="max_fwd_pwr_w",
         format_spec=".1f",
         unit="W",
     )

--- a/src/sc_linac_physics/applications/rf_commissioning/models/registry.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/models/registry.py
@@ -53,7 +53,7 @@ def create_phase_registry() -> dict:
         CommissioningPhase.SSA_CHAR: PhaseRegistration(
             record_attr="ssa_char",
             data_model=SSACharacterization,
-            display_label="SSA Characterization",
+            display_label="SSA Calibration",
             progress_label="SSA\nChar",
         ),
         CommissioningPhase.FREQUENCY_TUNING: PhaseRegistration(

--- a/src/sc_linac_physics/applications/rf_commissioning/phases/__init__.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/phases/__init__.py
@@ -11,6 +11,7 @@ from .phase_base import (
     PhaseExecutionError,
 )
 from .piezo_pre_rf import PiezoPreRFPhase
+from .ssa_char import SSACharPhase
 
 __all__ = [
     "PhaseBase",
@@ -19,4 +20,5 @@ __all__ = [
     "PhaseStepResult",
     "PhaseExecutionError",
     "PiezoPreRFPhase",
+    "SSACharPhase",
 ]

--- a/src/sc_linac_physics/applications/rf_commissioning/phases/ssa_char.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/phases/ssa_char.py
@@ -1,5 +1,5 @@
 """
-SSA Characterization Phase
+SSA Calibration Phase
 
 Runs SSA calibration: resets the SSA, powers it on, triggers the calibration
 scan, validates results, and auto-pushes the new slope to the active cavity
@@ -34,7 +34,7 @@ class SSACalLimits:
 
 class SSACharPhase(PhaseBase):
     """
-    SSA Characterization Phase.
+    SSA Calibration Phase.
 
     Sequence:
     1. verify_initial_state  – confirm SSA is accessible and not mid-run

--- a/src/sc_linac_physics/applications/rf_commissioning/phases/ssa_char.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/phases/ssa_char.py
@@ -1,0 +1,366 @@
+"""
+SSA Characterization Phase
+
+Runs SSA calibration: resets the SSA, powers it on, triggers the calibration
+scan, validates results, and auto-pushes the new slope to the active cavity
+register so the operator can review before choosing to save.
+"""
+
+import time
+from dataclasses import dataclass
+
+from sc_linac_physics.applications.rf_commissioning.models.data_models import (
+    CommissioningPhase,
+    SSACharacterization,
+)
+from sc_linac_physics.applications.rf_commissioning.phases.phase_base import (
+    PhaseBase,
+    PhaseContext,
+    PhaseExecutionError,
+    PhaseResult,
+    PhaseStepResult,
+)
+from sc_linac_physics.utils.sc_linac import linac_utils
+
+
+@dataclass
+class SSACalLimits:
+    """Configurable limits for SSA calibration."""
+
+    cal_timeout: float = 120.0
+    poll_interval: float = 1.0
+    post_start_delay: float = 2.0
+
+
+class SSACharPhase(PhaseBase):
+    """
+    SSA Characterization Phase.
+
+    Sequence:
+    1. verify_initial_state  – confirm SSA is accessible and not mid-run
+    2. set_drive_max         – write requested drive max to DRV_MAX_REQ
+    3. reset_and_power_on    – reset faults, turn on SSA, reset cavity interlocks
+    4. start_calibration     – trigger CALSTRT and wait for scan to begin
+    5. wait_for_completion   – poll until CALSTS leaves Running state
+    6. validate_and_push     – check results and push new slope to cavity register
+    """
+
+    def __init__(
+        self, context: PhaseContext, limits: SSACalLimits | None = None
+    ):
+        super().__init__(context)
+        self.limits = limits or SSACalLimits()
+        self._history_start = len(context.record.phase_history)
+        self.cavity = None
+
+    @property
+    def phase_type(self) -> CommissioningPhase:
+        return CommissioningPhase.SSA_CHAR
+
+    def validate_prerequisites(self) -> tuple[bool, str]:
+        cavity = self.context.parameters.get("cavity")
+        if cavity is None:
+            return False, "No cavity specified in context"
+
+        if not hasattr(cavity, "ssa") or cavity.ssa is None:
+            return False, "Cavity has no SSA object"
+
+        drive_max = self.context.parameters.get("drive_max")
+        if drive_max is None:
+            return False, "No drive_max specified in context parameters"
+
+        if not (0.0 < drive_max <= 1.0):
+            return False, f"drive_max {drive_max} out of range (0, 1]"
+
+        self.cavity = cavity
+        return True, "Prerequisites validated"
+
+    def get_phase_steps(self) -> list[str]:
+        return [
+            "verify_initial_state",
+            "set_drive_max",
+            "reset_and_power_on",
+            "start_calibration",
+            "wait_for_completion",
+            "validate_and_push",
+        ]
+
+    def execute_step(self, step_name: str) -> PhaseStepResult:
+        if self.cavity is None:
+            raise PhaseExecutionError(
+                "Cavity not set — validate_prerequisites must be called first"
+            )
+
+        step_methods = {
+            "verify_initial_state": self._verify_initial_state,
+            "set_drive_max": self._set_drive_max,
+            "reset_and_power_on": self._reset_and_power_on,
+            "start_calibration": self._start_calibration,
+            "wait_for_completion": self._wait_for_completion,
+            "validate_and_push": self._validate_and_push,
+        }
+
+        if step_name not in step_methods:
+            return PhaseStepResult(
+                result=PhaseResult.FAILED,
+                message=f"Unknown step: {step_name}",
+            )
+
+        return step_methods[step_name]()
+
+    # ------------------------------------------------------------------
+    # Step implementations
+    # ------------------------------------------------------------------
+
+    def _verify_initial_state(self) -> PhaseStepResult:
+        if self.context.dry_run:
+            return PhaseStepResult(
+                result=PhaseResult.SUCCESS,
+                message="Dry run: skipping initial state check",
+                data={"dry_run": True},
+            )
+
+        ssa = self.cavity.ssa
+
+        if ssa.calibration_running:
+            return PhaseStepResult(
+                result=PhaseResult.FAILED,
+                message="SSA calibration already running — abort or wait",
+            )
+
+        try:
+            current_slope = ssa.measured_slope
+            current_drive = ssa.drive_max
+        except Exception as exc:
+            return PhaseStepResult(
+                result=PhaseResult.RETRY,
+                message=f"Could not read SSA state: {exc}",
+                retry_delay_seconds=3.0,
+            )
+
+        return PhaseStepResult(
+            result=PhaseResult.SUCCESS,
+            message="Initial state verified",
+            data={
+                "initial_slope": current_slope,
+                "initial_drive_max": current_drive,
+            },
+        )
+
+    def _set_drive_max(self) -> PhaseStepResult:
+        drive_max = self.context.parameters["drive_max"]
+
+        if self.context.dry_run:
+            return PhaseStepResult(
+                result=PhaseResult.SUCCESS,
+                message=f"Dry run: would set drive max to {drive_max:.3f}",
+                data={"drive_max": drive_max, "dry_run": True},
+            )
+
+        self.cavity.ssa.drive_max = drive_max
+
+        return PhaseStepResult(
+            result=PhaseResult.SUCCESS,
+            message=f"Drive max set to {drive_max:.3f}",
+            data={"drive_max": drive_max},
+        )
+
+    def _reset_and_power_on(self) -> PhaseStepResult:
+        if self.context.dry_run:
+            return PhaseStepResult(
+                result=PhaseResult.SUCCESS,
+                message="Dry run: skipping SSA reset / power-on",
+                data={"dry_run": True},
+            )
+
+        ssa = self.cavity.ssa
+        try:
+            ssa.reset()
+            ssa.turn_on()
+            self.cavity.reset_interlocks()
+        except (
+            linac_utils.SSAFaultError,
+            linac_utils.SSACalibrationError,
+        ) as exc:
+            return PhaseStepResult(
+                result=PhaseResult.FAILED,
+                message=f"SSA reset/power-on failed: {exc}",
+            )
+        except Exception as exc:
+            return PhaseStepResult(
+                result=PhaseResult.RETRY,
+                message=f"Transient error during reset/power-on: {exc}",
+                retry_delay_seconds=5.0,
+            )
+
+        return PhaseStepResult(
+            result=PhaseResult.SUCCESS,
+            message="SSA reset, powered on, and interlocks cleared",
+        )
+
+    def _start_calibration(self) -> PhaseStepResult:
+        if self.context.dry_run:
+            return PhaseStepResult(
+                result=PhaseResult.SUCCESS,
+                message="Dry run: calibration start simulated",
+                data={"dry_run": True},
+            )
+
+        ssa = self.cavity.ssa
+        ssa.start_calibration()
+        time.sleep(self.limits.post_start_delay)
+
+        if ssa.calibration_crashed:
+            return PhaseStepResult(
+                result=PhaseResult.FAILED,
+                message="Calibration crashed immediately after start",
+            )
+
+        return PhaseStepResult(
+            result=PhaseResult.SUCCESS,
+            message="Calibration scan started",
+        )
+
+    def _wait_for_completion(self) -> PhaseStepResult:
+        if self.context.dry_run:
+            return PhaseStepResult(
+                result=PhaseResult.SUCCESS,
+                message="Dry run: calibration completion simulated",
+                data={
+                    "dry_run": True,
+                    "slope_new": 1.02345,
+                    "max_fwd_pwr": 4500.0,
+                },
+            )
+
+        ssa = self.cavity.ssa
+        elapsed = 0.0
+
+        while ssa.calibration_running:
+            if self.context.is_abort_requested():
+                return PhaseStepResult(
+                    result=PhaseResult.FAILED,
+                    message="Abort requested during calibration",
+                )
+            if elapsed >= self.limits.cal_timeout:
+                return PhaseStepResult(
+                    result=PhaseResult.FAILED,
+                    message=f"Calibration timed out after {self.limits.cal_timeout:.0f}s",
+                )
+            time.sleep(self.limits.poll_interval)
+            elapsed += self.limits.poll_interval
+
+        time.sleep(self.limits.post_start_delay)
+
+        try:
+            slope_new = ssa.measured_slope
+            max_fwd_pwr = ssa.max_fwd_pwr
+        except Exception:
+            slope_new = None
+            max_fwd_pwr = None
+
+        return PhaseStepResult(
+            result=PhaseResult.SUCCESS,
+            message="Calibration scan complete",
+            data={"slope_new": slope_new, "max_fwd_pwr": max_fwd_pwr},
+        )
+
+    def _validate_and_push(self) -> PhaseStepResult:
+        drive_max = self.context.parameters["drive_max"]
+
+        if self.context.dry_run:
+            return PhaseStepResult(
+                result=PhaseResult.SUCCESS,
+                message="Dry run: validation passed, slope push simulated",
+                data={
+                    "slope_new": 1.02345,
+                    "slope_current": 1.02345,
+                    "max_fwd_pwr": 4500.0,
+                    "max_drive": drive_max,
+                    "calibration_passed": True,
+                    "dry_run": True,
+                },
+            )
+
+        ssa = self.cavity.ssa
+
+        if ssa.calibration_crashed:
+            return PhaseStepResult(
+                result=PhaseResult.FAILED,
+                message="Calibration status shows crashed",
+            )
+
+        if not ssa.calibration_result_good:
+            return PhaseStepResult(
+                result=PhaseResult.FAILED,
+                message="Calibration result not good (CALSTAT)",
+            )
+
+        max_fwd_pwr = ssa.max_fwd_pwr
+        if max_fwd_pwr < ssa.fwd_power_lower_limit:
+            return PhaseStepResult(
+                result=PhaseResult.FAILED,
+                message=(
+                    f"Forward power {max_fwd_pwr:.0f} W below limit "
+                    f"{ssa.fwd_power_lower_limit} W"
+                ),
+            )
+
+        if not ssa.measured_slope_in_tolerance:
+            slope = ssa.measured_slope
+            return PhaseStepResult(
+                result=PhaseResult.FAILED,
+                message=(
+                    f"Slope {slope:.5f} out of tolerance "
+                    f"[{linac_utils.SSA_SLOPE_LOWER_LIMIT}, "
+                    f"{linac_utils.SSA_SLOPE_UPPER_LIMIT}]"
+                ),
+            )
+
+        slope_new = ssa.measured_slope
+
+        self.cavity.push_ssa_slope()
+        time.sleep(0.5)
+
+        try:
+            slope_current = ssa.measured_slope
+        except Exception:
+            slope_current = slope_new
+
+        return PhaseStepResult(
+            result=PhaseResult.SUCCESS,
+            message=f"Validation passed, slope {slope_new:.5f} pushed to cavity",
+            data={
+                "slope_new": slope_new,
+                "slope_current": slope_current,
+                "max_fwd_pwr": max_fwd_pwr,
+                "max_drive": drive_max,
+                "calibration_passed": True,
+            },
+        )
+
+    # ------------------------------------------------------------------
+    # Finalization
+    # ------------------------------------------------------------------
+
+    def finalize_phase(self) -> None:
+        validate_checkpoint = next(
+            (
+                cp
+                for cp in reversed(
+                    self.context.record.phase_history[self._history_start :]
+                )
+                if cp.phase == self.phase_type
+                and cp.step_name == "validate_and_push"
+            ),
+            None,
+        )
+
+        data = validate_checkpoint.measurements if validate_checkpoint else {}
+
+        self.context.record.ssa_char = SSACharacterization(
+            max_drive=data.get("max_drive"),
+            slope_new=data.get("slope_new"),
+            max_fwd_pwr_w=data.get("max_fwd_pwr"),
+            calibration_passed=data.get("calibration_passed", False),
+        )

--- a/src/sc_linac_physics/applications/rf_commissioning/phases/ssa_char.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/phases/ssa_char.py
@@ -301,8 +301,8 @@ class SSACharPhase(PhaseBase):
             return PhaseStepResult(
                 result=PhaseResult.FAILED,
                 message=(
-                    f"Forward power {max_fwd_pwr:.0f} W below limit "
-                    f"{ssa.fwd_power_lower_limit} W"
+                    f"Measured forward power {max_fwd_pwr:.0f} W is below "
+                    f"the minimum limit of {ssa.fwd_power_lower_limit} W"
                 ),
             )
 
@@ -361,6 +361,6 @@ class SSACharPhase(PhaseBase):
         self.context.record.ssa_char = SSACharacterization(
             max_drive=data.get("max_drive"),
             slope_new=data.get("slope_new"),
-            max_fwd_pwr_w=data.get("max_fwd_pwr"),
+            max_fwd_pwr=data.get("max_fwd_pwr"),
             calibration_passed=data.get("calibration_passed", False),
         )

--- a/src/sc_linac_physics/applications/rf_commissioning/phases/ssa_char.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/phases/ssa_char.py
@@ -129,7 +129,7 @@ class SSACharPhase(PhaseBase):
             )
 
         try:
-            current_slope = ssa.measured_slope
+            current_slope = ssa.current_slope
             current_drive = ssa.drive_max
         except Exception as exc:
             return PhaseStepResult(
@@ -142,7 +142,7 @@ class SSACharPhase(PhaseBase):
             result=PhaseResult.SUCCESS,
             message="Initial state verified",
             data={
-                "initial_slope": current_slope,
+                "initial_current_slope": current_slope,
                 "initial_drive_max": current_drive,
             },
         )
@@ -323,7 +323,7 @@ class SSACharPhase(PhaseBase):
         time.sleep(0.5)
 
         try:
-            slope_current = ssa.measured_slope
+            slope_current = ssa.current_slope
         except Exception:
             slope_current = slope_new
 

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/builders/__init__.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/builders/__init__.py
@@ -4,6 +4,7 @@ from .base import PhaseUIBase
 from .phase_builders import (
     GenericPhaseUI,
     PiezoPreRFUI,
+    SSACharUI,
 )
 from .styles import (
     LOCAL_CAP_STYLE,
@@ -16,6 +17,7 @@ from .styles import (
 __all__ = [
     "PhaseUIBase",
     "PiezoPreRFUI",
+    "SSACharUI",
     "GenericPhaseUI",
     "MONO_FONT_STACK",
     "PV_LABEL_STYLE",

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/builders/base.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/builders/base.py
@@ -367,6 +367,8 @@ class PhaseUIBase:
 
         grid = QGridLayout()
         grid.setSpacing(5)
+        grid.setColumnMinimumWidth(0, 110)
+        grid.setColumnStretch(1, 1)
 
         row = 0
 

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/builders/phase_builders.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/builders/phase_builders.py
@@ -3,7 +3,6 @@
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import (
     QComboBox,
-    QDoubleSpinBox,
     QFrame,
     QGridLayout,
     QGroupBox,
@@ -13,7 +12,7 @@ from PyQt5.QtWidgets import (
     QSpinBox,
     QVBoxLayout,
 )
-from pydm.widgets import PyDMEnumComboBox, PyDMLabel
+from pydm.widgets import PyDMEnumComboBox, PyDMLabel, PyDMSpinbox
 
 from .base import PhaseUIBase
 from .styles import PV_CAP_STYLE, PV_LABEL_STYLE
@@ -356,11 +355,21 @@ class SSACharUI(PhaseUIBase):
         layout.setContentsMargins(8, 8, 8, 8)
 
         layout.addWidget(QLabel("Calibration Drive Max:"), 0, 0)
-        spinbox = self._register("drive_max_spinbox", QDoubleSpinBox())
+        spinbox = self._register(
+            "drive_max_spinbox", PyDMSpinbox(parent=self.parent)
+        )
         spinbox.setRange(0.01, 1.0)
+        spinbox.userDefinedLimits = True
+        spinbox.userMinimum = 0.01
+        spinbox.userMaximum = 1.0
         spinbox.setSingleStep(0.01)
         spinbox.setDecimals(3)
-        spinbox.setValue(0.670)
+        spinbox.setValue(0.5)
+        spinbox.precisionFromPV = False
+        spinbox.precision = 3
+        spinbox.showStepExponent = False
+        spinbox.writeOnPress = True
+        spinbox.editingFinished.connect(spinbox.send_value)
         spinbox.setFixedWidth(90)
         layout.addWidget(spinbox, 0, 1)
         layout.addWidget(QLabel("(range 0–1)"), 0, 2)

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/builders/phase_builders.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/builders/phase_builders.py
@@ -427,7 +427,7 @@ class SSACharUI(PhaseUIBase):
         grid.addWidget(QLabel("Drive Max:"), 2, 0)
 
         pv_drv_req = self._register(
-            "pydm_drive_max_req", PyDMLabel(parent=self.parent)
+            "pydm_drive_max_new", PyDMLabel(parent=self.parent)
         )
         pv_drv_req.setStyleSheet(PV_CAP_STYLE)
         pv_drv_req.setAlignment(Qt.AlignCenter)

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/builders/phase_builders.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/builders/phase_builders.py
@@ -321,7 +321,7 @@ class GenericPhaseUI(_StandardPlaceholderUI):
 
 
 class SSACharUI(PhaseUIBase):
-    """Builds the SSA Characterization display UI and exposes widget references."""
+    """Builds the SSA Calibration display UI and exposes widget references."""
 
     def build(self) -> QHBoxLayout:
         main_layout = QHBoxLayout()
@@ -482,7 +482,9 @@ class SSACharUI(PhaseUIBase):
         btn_row.setSpacing(8)
         btn_row.setContentsMargins(0, 6, 0, 0)
 
-        push_btn = self._register("push_btn", QPushButton("Push →"))
+        push_btn = self._register(
+            "push_btn", QPushButton("Push New Slope to Cavity")
+        )
         push_btn.setStyleSheet(
             "QPushButton { background-color: #1d6a3a; color: white; "
             "font-weight: bold; padding: 6px 18px; border-radius: 4px; } "
@@ -491,16 +493,6 @@ class SSACharUI(PhaseUIBase):
         )
         self._connect(push_btn, "on_push_slope")
         btn_row.addWidget(push_btn)
-
-        save_btn = self._register("save_btn", QPushButton("Save"))
-        save_btn.setStyleSheet(
-            "QPushButton { background-color: #7c3aed; color: white; "
-            "font-weight: bold; padding: 6px 18px; border-radius: 4px; } "
-            "QPushButton:hover { background-color: #9d4edd; } "
-            "QPushButton:disabled { background-color: #374151; color: #6b7280; }"
-        )
-        self._connect(save_btn, "on_save_slope")
-        btn_row.addWidget(save_btn)
 
         btn_row.addStretch()
         outer.addLayout(btn_row)

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/builders/phase_builders.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/builders/phase_builders.py
@@ -3,11 +3,13 @@
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import (
     QComboBox,
+    QDoubleSpinBox,
     QFrame,
     QGridLayout,
     QGroupBox,
     QHBoxLayout,
     QLabel,
+    QPushButton,
     QSpinBox,
     QVBoxLayout,
 )
@@ -316,3 +318,193 @@ class GenericPhaseUI(_StandardPlaceholderUI):
     @property
     def PHASE_TITLE(self) -> str:  # type: ignore[override]
         return getattr(self.parent, "PHASE_NAME", "Phase")
+
+
+class SSACharUI(PhaseUIBase):
+    """Builds the SSA Characterization display UI and exposes widget references."""
+
+    def build(self) -> QHBoxLayout:
+        main_layout = QHBoxLayout()
+        main_layout.setContentsMargins(5, 5, 5, 5)
+        main_layout.setSpacing(8)
+
+        left_panel = QVBoxLayout()
+        left_panel.setSpacing(6)
+        left_panel.addLayout(self._build_main_toolbar())
+        left_panel.addWidget(self._build_ssa_inputs())
+        left_panel.addWidget(self._build_history())
+        left_panel.addStretch()
+
+        right_panel = QVBoxLayout()
+        right_panel.setSpacing(6)
+        right_panel.addWidget(self._build_ssa_results(), stretch=1)
+        right_panel.addWidget(
+            self._build_stored_data_section(
+                self._get_parent_stored_data_fields()
+            )
+        )
+
+        main_layout.addLayout(left_panel, 1)
+        main_layout.addLayout(right_panel, 1)
+        return main_layout
+
+    def _build_ssa_inputs(self) -> QGroupBox:
+        """Build the Inputs section matching the EDM screen."""
+        group = QGroupBox("SSA Calibration Inputs")
+        layout = QGridLayout()
+        layout.setSpacing(6)
+        layout.setContentsMargins(8, 8, 8, 8)
+
+        layout.addWidget(QLabel("Calibration Drive Max:"), 0, 0)
+        spinbox = self._register("drive_max_spinbox", QDoubleSpinBox())
+        spinbox.setRange(0.01, 1.0)
+        spinbox.setSingleStep(0.01)
+        spinbox.setDecimals(3)
+        spinbox.setValue(0.670)
+        spinbox.setFixedWidth(90)
+        layout.addWidget(spinbox, 0, 1)
+        layout.addWidget(QLabel("(range 0–1)"), 0, 2)
+
+        plot_btn = self._register("plot_btn", QPushButton("Plot"))
+        plot_btn.setStyleSheet(
+            "QPushButton { background-color: #374151; color: #d1d5db; "
+            "padding: 6px 14px; border-radius: 4px; border: 1px solid #4b5563; } "
+            "QPushButton:hover { background-color: #4b5563; }"
+        )
+        self._connect(plot_btn, "on_plot")
+        layout.addWidget(plot_btn, 1, 1)
+
+        group.setLayout(layout)
+        return group
+
+    def _build_ssa_results(self) -> QGroupBox:
+        """Build the Results section with live PV labels and local result indicators."""
+        group = QGroupBox("SSA Calibration — Status && Results")
+        outer = QVBoxLayout()
+        outer.setSpacing(6)
+        outer.setContentsMargins(8, 8, 8, 8)
+
+        # Single unified grid: col 0 = label, cols 1-3 = New / Current / Saved
+        grid = QGridLayout()
+        grid.setHorizontalSpacing(6)
+        grid.setVerticalSpacing(5)
+        grid.setColumnMinimumWidth(0, 80)
+        grid.setColumnStretch(1, 1)
+        grid.setColumnStretch(2, 1)
+        for col, text, color in (
+            (1, "New", "#4a9eff"),
+            (2, "Current", "#e0e0e0"),
+        ):
+            hdr = QLabel(text)
+            hdr.setStyleSheet(
+                f"color: {color}; font-weight: bold; font-size: 9pt;"
+            )
+            hdr.setAlignment(Qt.AlignCenter)
+            grid.addWidget(hdr, 0, col)
+
+        # SSA Slope row
+        grid.addWidget(QLabel("SSA Slope:"), 1, 0)
+
+        pv_slope_new = self._register(
+            "pydm_slope_new", PyDMLabel(parent=self.parent)
+        )
+        pv_slope_new.setStyleSheet(PV_CAP_STYLE)
+        pv_slope_new.setAlignment(Qt.AlignCenter)
+        pv_slope_new.precisionFromPV = False
+        pv_slope_new.precision = 5
+        grid.addWidget(pv_slope_new, 1, 1)
+
+        pv_slope_cur = self._register(
+            "pydm_slope_current", PyDMLabel(parent=self.parent)
+        )
+        pv_slope_cur.setStyleSheet(PV_CAP_STYLE)
+        pv_slope_cur.setAlignment(Qt.AlignCenter)
+        pv_slope_cur.precisionFromPV = False
+        pv_slope_cur.precision = 5
+        grid.addWidget(pv_slope_cur, 1, 2)
+
+        # Drive Max row
+        grid.addWidget(QLabel("Drive Max:"), 2, 0)
+
+        pv_drv_req = self._register(
+            "pydm_drive_max_req", PyDMLabel(parent=self.parent)
+        )
+        pv_drv_req.setStyleSheet(PV_CAP_STYLE)
+        pv_drv_req.setAlignment(Qt.AlignCenter)
+        pv_drv_req.precisionFromPV = False
+        pv_drv_req.precision = 3
+        grid.addWidget(pv_drv_req, 2, 1)
+
+        pv_drv_cur = self._register(
+            "pydm_drive_max_current", PyDMLabel(parent=self.parent)
+        )
+        pv_drv_cur.setStyleSheet(PV_CAP_STYLE)
+        pv_drv_cur.setAlignment(Qt.AlignCenter)
+        pv_drv_cur.precisionFromPV = False
+        pv_drv_cur.precision = 3
+        grid.addWidget(pv_drv_cur, 2, 2)
+
+        # Max Fwd Pwr row (single live value)
+        grid.addWidget(QLabel("Max Fwd Pwr:"), 3, 0)
+        pv_fwd_pwr = self._register(
+            "pydm_max_fwd_pwr", PyDMLabel(parent=self.parent)
+        )
+        pv_fwd_pwr.setStyleSheet(PV_CAP_STYLE)
+        pv_fwd_pwr.setAlignment(Qt.AlignCenter)
+        pv_fwd_pwr.showUnits = True
+        grid.addWidget(pv_fwd_pwr, 3, 1, 1, 2)
+
+        # Cal Status row (EPICS value + local pass/fail)
+        grid.addWidget(QLabel("Cal Status:"), 4, 0)
+        pv_cal_status = self._register(
+            "pydm_cal_status", PyDMLabel(parent=self.parent)
+        )
+        pv_cal_status.setStyleSheet(PV_LABEL_STYLE)
+        pv_cal_status.setAlignment(Qt.AlignCenter)
+        grid.addWidget(pv_cal_status, 4, 1)
+
+        local_phase = self._register(
+            "local_phase_status", self._make_local_label("-")
+        )
+        grid.addWidget(local_phase, 4, 2)
+
+        # Step row
+        grid.addWidget(QLabel("Step:"), 5, 0)
+        local_step = self._register(
+            "local_current_step", self._make_local_label("-")
+        )
+        grid.addWidget(local_step, 5, 1, 1, 2)
+
+        outer.addLayout(grid)
+
+        # Push / Save buttons
+        btn_row = QHBoxLayout()
+        btn_row.setSpacing(8)
+        btn_row.setContentsMargins(0, 6, 0, 0)
+
+        push_btn = self._register("push_btn", QPushButton("Push →"))
+        push_btn.setStyleSheet(
+            "QPushButton { background-color: #1d6a3a; color: white; "
+            "font-weight: bold; padding: 6px 18px; border-radius: 4px; } "
+            "QPushButton:hover { background-color: #2d8a4a; } "
+            "QPushButton:disabled { background-color: #374151; color: #6b7280; }"
+        )
+        self._connect(push_btn, "on_push_slope")
+        btn_row.addWidget(push_btn)
+
+        save_btn = self._register("save_btn", QPushButton("Save"))
+        save_btn.setStyleSheet(
+            "QPushButton { background-color: #7c3aed; color: white; "
+            "font-weight: bold; padding: 6px 18px; border-radius: 4px; } "
+            "QPushButton:hover { background-color: #9d4edd; } "
+            "QPushButton:disabled { background-color: #374151; color: #6b7280; }"
+        )
+        self._connect(save_btn, "on_save_slope")
+        btn_row.addWidget(save_btn)
+
+        btn_row.addStretch()
+        outer.addLayout(btn_row)
+        outer.addStretch()
+
+        group.setLayout(outer)
+        return group

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/container/phase_specs.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/container/phase_specs.py
@@ -25,6 +25,7 @@ class PhaseTabSpec:
 
 DEFAULT_BETA_VISIBLE_PHASES: tuple[CommissioningPhase, ...] = (
     CommissioningPhase.PIEZO_PRE_RF,
+    CommissioningPhase.SSA_CHAR,
 )
 
 

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/controllers/ssa_char_controller.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/controllers/ssa_char_controller.py
@@ -1,4 +1,4 @@
-"""Controller for SSA Characterization display logic."""
+"""Controller for SSA Calibration display logic."""
 
 from datetime import datetime
 from threading import Thread
@@ -24,6 +24,7 @@ from sc_linac_physics.applications.rf_commissioning.ui.controllers.piezo_pre_rf_
     format_pv_update_message,
     resolve_cavity_selection,
 )
+from sc_linac_physics.utils.platform_paths import get_ssa_cal_base_dir
 from sc_linac_physics.utils.sc_linac.linac import Machine
 
 
@@ -101,8 +102,8 @@ class SSACharController(QObject):
             ("pydm_max_fwd_pwr", ssa.max_fwd_pwr_pv),
             ("pydm_slope_new", ssa.measured_slope_pv),
             ("pydm_slope_current", ssa.current_slope_pv),
-            ("pydm_drive_max_req", ssa.drive_max_setpoint_pv),
-            ("pydm_drive_max_current", ssa.drive_max_setpoint_pv),
+            ("pydm_drive_max_req", ssa.drive_max_new_pv),
+            ("pydm_drive_max_current", ssa.drive_max_current_pv),
         ]
         for widget_name, pv_addr in optional:
             if hasattr(self.view, widget_name):
@@ -490,19 +491,48 @@ class SSACharController(QObject):
 
         Thread(target=_push, daemon=True).start()
 
-    def on_save_slope(self) -> None:
+    def on_plot(self) -> None:
         cavity = self._resolve_cavity()
         if cavity is None:
             return
 
-        def _save():
-            try:
-                cavity.save_ssa_slope()
-                self.view.log_message("✓ SSA slope saved to persistent storage")
-            except Exception as exc:
-                self.view.log_message(f"Save failed: {exc}")
+        pv_base = cavity.pv_prefix.rstrip(":")
+        cavity_dir_name = pv_base.replace(":", "_")
+        base = get_ssa_cal_base_dir() / cavity_dir_name
 
-        Thread(target=_save, daemon=True).start()
+        if not base.is_dir():
+            self.view.log_message(f"No SSA cal directory found: {base}")
+            return
+
+        for subdir in sorted(base.iterdir(), reverse=True):
+            if not subdir.is_dir():
+                continue
+            png = subdir / "ssa_cal.png"
+            if png.exists():
+                self._show_plot(png)
+                return
+
+        self.view.log_message(f"No ssa_cal.png found under {base}")
+
+    def _show_plot(self, png_path) -> None:
+        from PyQt5.QtGui import QPixmap
+        from PyQt5.QtWidgets import QDialog, QLabel, QScrollArea, QVBoxLayout
+
+        dlg = QDialog(self.view)
+        dlg.setWindowTitle(f"SSA Cal Plot — {png_path.parent.name}")
+
+        label = QLabel()
+        label.setPixmap(QPixmap(str(png_path)))
+
+        scroll = QScrollArea()
+        scroll.setWidget(label)
+        scroll.setWidgetResizable(True)
+
+        layout = QVBoxLayout()
+        layout.addWidget(scroll)
+        dlg.setLayout(layout)
+        dlg.resize(800, 600)
+        dlg.show()
 
     def _resolve_cavity(self):
         if self._cavity is not None:

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/controllers/ssa_char_controller.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/controllers/ssa_char_controller.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from threading import Thread
 
 from PyQt5.QtCore import QObject, QTimer, pyqtSignal
+from PyQt5.QtWidgets import QDoubleSpinBox
 
 from sc_linac_physics.applications.rf_commissioning.models.data_models import (
     CommissioningPhase,
@@ -106,6 +107,7 @@ class SSACharController(QObject):
             ("pydm_max_fwd_pwr", ssa.max_fwd_pwr_pv),
             ("pydm_slope_new", ssa.measured_slope_pv),
             ("pydm_slope_current", ssa.current_slope_pv),
+            ("drive_max_spinbox", ssa.drive_max_setpoint_pv),
             ("pydm_drive_max_new", ssa.drive_max_new_pv),
             ("pydm_drive_max_current", ssa.drive_max_current_pv),
         ]
@@ -125,56 +127,90 @@ class SSACharController(QObject):
     # ------------------------------------------------------------------
 
     def on_run_calibration(self) -> None:
-        operator = self._get_operator()
-        if not operator:
-            self.view.show_error(
-                "Please select an operator in the header before running."
-            )
+        operator = self._validate_operator_for_run()
+        if operator is None:
             return
 
-        if not self.session.has_active_record():
-            if not self._auto_create_record():
-                return
-
-        cavity_info = self.view.get_current_cavity()
-        if not cavity_info:
-            self.view.show_error(
-                "Unable to determine cavity. Select a cavity and try again."
-            )
+        if not self._ensure_active_record_for_run():
             return
 
-        cavity_name, cryomodule = cavity_info
-        try:
-            cm, cav = self._parse_cavity_from_record(cavity_name, cryomodule)
-        except (ValueError, IndexError):
-            self.view.show_error(f"Invalid cavity name format: {cavity_name}")
+        run_target = self._resolve_run_target()
+        if run_target is None:
             return
 
+        cavity_name, cm, cav = run_target
         self.view.log_message(f"Starting SSA calibration for {cavity_name}")
         self.view.clear_results()
 
         try:
-            self.update_pv_addresses(f"{cm:02d}", str(cav))
-            cavity = self._get_machine_cavity(cm, cav)
-            self._cavity = cavity
-
-            drive_max = self._get_drive_max()
-            if not self._prepare_phase_context(cavity, operator, drive_max):
-                return
-
-            self._set_running_ui_state()
-            self._execute_phase_async()
-
+            self._start_run_for_target(cm=cm, cav=cav, operator=operator)
         except Exception as exc:
             import traceback
 
             self.view.show_error(f"Failed to start calibration: {exc}")
             self.view.log_message(f"Traceback: {traceback.format_exc()}")
 
-    def _get_drive_max(self) -> float:
-        if hasattr(self.view, "drive_max_spinbox"):
-            return self.view.drive_max_spinbox.value()
-        return 0.670
+    def _validate_operator_for_run(self) -> str | None:
+        operator = self._get_operator()
+        if operator:
+            return operator
+        self.view.show_error(
+            "Please select an operator in the header before running."
+        )
+        return None
+
+    def _ensure_active_record_for_run(self) -> bool:
+        if self.session.has_active_record():
+            return True
+        return self._auto_create_record()
+
+    def _resolve_run_target(self) -> tuple[str, int, int] | None:
+        cavity_info = self.view.get_current_cavity()
+        if not cavity_info:
+            self.view.show_error(
+                "Unable to determine cavity. Select a cavity and try again."
+            )
+            return None
+
+        cavity_name, cryomodule = cavity_info
+        try:
+            cm, cav = self._parse_cavity_from_record(cavity_name, cryomodule)
+        except (ValueError, IndexError):
+            self.view.show_error(f"Invalid cavity name format: {cavity_name}")
+            return None
+
+        return cavity_name, cm, cav
+
+    def _start_run_for_target(self, cm: int, cav: int, operator: str) -> None:
+        self.update_pv_addresses(f"{cm:02d}", str(cav))
+        cavity = self._get_machine_cavity(cm, cav)
+        self._cavity = cavity
+
+        drive_max = self._get_drive_max()
+        if drive_max is None:
+            self.view.show_error(
+                "Unable to read the SSA drive max from the PV."
+            )
+            return
+
+        if not self._prepare_phase_context(cavity, operator, drive_max):
+            return
+
+        self._set_running_ui_state()
+        self._execute_phase_async()
+
+    def _get_drive_max(self) -> float | None:
+        spinbox = getattr(self.view, "drive_max_spinbox", None)
+        if spinbox is None:
+            return None
+
+        try:
+            if isinstance(spinbox, QDoubleSpinBox):
+                return float(QDoubleSpinBox.value(spinbox))
+        except (AttributeError, TypeError, ValueError):
+            return None
+
+        return None
 
     def _prepare_phase_context(
         self, cavity, operator: str, drive_max: float

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/controllers/ssa_char_controller.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/controllers/ssa_char_controller.py
@@ -40,7 +40,8 @@ class SSACharController(QObject):
         super().__init__()
         self.view = view
         self.session = session
-        self._log_signal.connect(self.view.log_message)
+        if hasattr(self.view, "log_message"):
+            self._log_signal.connect(self.view.log_message)
 
         self.context: PhaseContext | None = None
         self.phase: SSACharPhase | None = None

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/controllers/ssa_char_controller.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/controllers/ssa_char_controller.py
@@ -29,15 +29,18 @@ from sc_linac_physics.utils.sc_linac.linac import Machine
 
 
 class SSACharController(QObject):
-    """Owns phase execution and PV wiring for the SSA Characterisation display."""
+    """Owns phase execution and PV wiring for the SSA Calibration display."""
 
     phase_completed = pyqtSignal(object)
     phase_run_finished = pyqtSignal(bool, str)
+    # Thread-safe logging: emit from any thread; slot runs on the GUI thread.
+    _log_signal = pyqtSignal(str)
 
     def __init__(self, view, session: CommissioningSession) -> None:
         super().__init__()
         self.view = view
         self.session = session
+        self._log_signal.connect(self.view.log_message)
 
         self.context: PhaseContext | None = None
         self.phase: SSACharPhase | None = None
@@ -102,7 +105,7 @@ class SSACharController(QObject):
             ("pydm_max_fwd_pwr", ssa.max_fwd_pwr_pv),
             ("pydm_slope_new", ssa.measured_slope_pv),
             ("pydm_slope_current", ssa.current_slope_pv),
-            ("pydm_drive_max_req", ssa.drive_max_new_pv),
+            ("pydm_drive_max_new", ssa.drive_max_new_pv),
             ("pydm_drive_max_current", ssa.drive_max_current_pv),
         ]
         for widget_name, pv_addr in optional:
@@ -288,35 +291,35 @@ class SSACharController(QObject):
                 self._create_step_checkpoint(step_name, result)
 
                 if result.result in (PhaseResult.SUCCESS, PhaseResult.SKIP):
-                    self.view.log_message(f"✓ {step_name}")
+                    self._log_signal.emit(f"✓ {step_name}")
                     return True
 
                 if result.result == PhaseResult.RETRY:
                     retry_count += 1
                     if retry_count < max_retries:
                         delay = max(0.0, float(result.retry_delay_seconds))
-                        self.view.log_message(
+                        self._log_signal.emit(
                             f"Retrying {retry_count}/{max_retries} in {delay:.1f}s: "
                             f"{result.message}"
                         )
                         time.sleep(delay)
                         continue
-                    self.view.log_message(
+                    self._log_signal.emit(
                         f"Failed after {max_retries} retries: {result.message}"
                     )
                     return False
 
-                self.view.log_message(f"✗ {step_name}: {result.message}")
+                self._log_signal.emit(f"✗ {step_name}: {result.message}")
                 return False
 
             except Exception as exc:
                 retry_count += 1
                 if retry_count < max_retries:
-                    self.view.log_message(
+                    self._log_signal.emit(
                         f"Exception on retry {retry_count}: {exc}"
                     )
                     continue
-                self.view.log_message(
+                self._log_signal.emit(
                     f"Exception after {max_retries} retries: {exc}"
                 )
                 return False
@@ -485,9 +488,9 @@ class SSACharController(QObject):
         def _push():
             try:
                 cavity.push_ssa_slope()
-                self.view.log_message("✓ SSA slope pushed to cavity register")
+                self._log_signal.emit("✓ SSA slope pushed to cavity register")
             except Exception as exc:
-                self.view.log_message(f"Push failed: {exc}")
+                self._log_signal.emit(f"Push failed: {exc}")
 
         Thread(target=_push, daemon=True).start()
 

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/controllers/ssa_char_controller.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/controllers/ssa_char_controller.py
@@ -1,0 +1,626 @@
+"""Controller for SSA Characterization display logic."""
+
+from datetime import datetime
+from threading import Thread
+
+from PyQt5.QtCore import QObject, QTimer, pyqtSignal
+
+from sc_linac_physics.applications.rf_commissioning.models.data_models import (
+    CommissioningPhase,
+    PhaseCheckpoint,
+)
+from sc_linac_physics.applications.rf_commissioning.phases.phase_base import (
+    PhaseContext,
+    PhaseResult,
+)
+from sc_linac_physics.applications.rf_commissioning.phases.ssa_char import (
+    SSACharPhase,
+)
+from sc_linac_physics.applications.rf_commissioning.session_manager import (
+    CommissioningSession,
+)
+from sc_linac_physics.applications.rf_commissioning.ui.controllers.piezo_pre_rf_pv import (
+    apply_pv_mapping,
+    format_pv_update_message,
+    resolve_cavity_selection,
+)
+from sc_linac_physics.utils.sc_linac.linac import Machine
+
+
+class SSACharController(QObject):
+    """Owns phase execution and PV wiring for the SSA Characterisation display."""
+
+    phase_completed = pyqtSignal(object)
+    phase_run_finished = pyqtSignal(bool, str)
+
+    def __init__(self, view, session: CommissioningSession) -> None:
+        super().__init__()
+        self.view = view
+        self.session = session
+
+        self.context: PhaseContext | None = None
+        self.phase: SSACharPhase | None = None
+        self.machine: Machine | None = None
+        self._cavity = None
+
+        self._paused = False
+        self._step_mode = False
+        self._step_executing = False
+        self._current_step_index = 0
+        self._total_steps = 0
+        self._steps: list[str] = []
+        self._active_phase_instance_id: int | None = None
+
+        self.phase_run_finished.connect(self._on_phase_run_finished)
+
+    # ------------------------------------------------------------------
+    # PV wiring
+    # ------------------------------------------------------------------
+
+    def setup_pv_connections(self) -> None:
+        if self.session.has_active_record():
+            self.update_pv_addresses()
+
+    def update_pv_addresses(
+        self,
+        cryomodule: str | None = None,
+        cavity_number: str | None = None,
+    ) -> None:
+        cryomodule, cavity_number = resolve_cavity_selection(
+            self.view, cryomodule, cavity_number
+        )
+        if cryomodule is None or cavity_number is None:
+            self.view.log_message("No cavity selected")
+            return
+
+        try:
+            cav_int = int(cavity_number)
+            cm_int = int(cryomodule)
+        except ValueError as exc:
+            self.view.log_message(f"Invalid cavity/CM value: {exc}")
+            return
+
+        try:
+            cavity = self._get_machine_cavity(cm_int, cav_int)
+            self._cavity = cavity
+            ssa = cavity.ssa
+            self._apply_ssa_pv_mapping(ssa, cavity)
+            self.view.log_message(
+                format_pv_update_message(
+                    cryomodule, cavity_number, cm_int, cav_int
+                )
+            )
+        except Exception as exc:
+            self.view.log_message(f"Error setting PVs: {exc}")
+
+    def _apply_ssa_pv_mapping(self, ssa, cavity) -> None:
+        pv_map = {}
+
+        optional = [
+            ("pydm_cal_status", ssa.calibration_status_pv),
+            ("pydm_max_fwd_pwr", ssa.max_fwd_pwr_pv),
+            ("pydm_slope_new", ssa.measured_slope_pv),
+            ("pydm_slope_current", ssa.current_slope_pv),
+            ("pydm_drive_max_req", ssa.drive_max_setpoint_pv),
+            ("pydm_drive_max_current", ssa.drive_max_setpoint_pv),
+        ]
+        for widget_name, pv_addr in optional:
+            if hasattr(self.view, widget_name):
+                pv_map[getattr(self.view, widget_name)] = pv_addr
+
+        apply_pv_mapping(pv_map)
+
+    def _get_machine_cavity(self, cm: int, cav: int):
+        if not self.machine:
+            self.machine = Machine()
+        return self.machine.cryomodules[f"{cm:02d}"].cavities[cav]
+
+    # ------------------------------------------------------------------
+    # Phase execution
+    # ------------------------------------------------------------------
+
+    def on_run_calibration(self) -> None:
+        operator = self._get_operator()
+        if not operator:
+            self.view.show_error(
+                "Please select an operator in the header before running."
+            )
+            return
+
+        if not self.session.has_active_record():
+            if not self._auto_create_record():
+                return
+
+        cavity_info = self.view.get_current_cavity()
+        if not cavity_info:
+            self.view.show_error(
+                "Unable to determine cavity. Select a cavity and try again."
+            )
+            return
+
+        cavity_name, cryomodule = cavity_info
+        try:
+            cm, cav = self._parse_cavity_from_record(cavity_name, cryomodule)
+        except (ValueError, IndexError):
+            self.view.show_error(f"Invalid cavity name format: {cavity_name}")
+            return
+
+        self.view.log_message(f"Starting SSA calibration for {cavity_name}")
+        self.view.clear_results()
+
+        try:
+            self.update_pv_addresses(f"{cm:02d}", str(cav))
+            cavity = self._get_machine_cavity(cm, cav)
+            self._cavity = cavity
+
+            drive_max = self._get_drive_max()
+            if not self._prepare_phase_context(cavity, operator, drive_max):
+                return
+
+            self._set_running_ui_state()
+            self._execute_phase_async()
+
+        except Exception as exc:
+            import traceback
+
+            self.view.show_error(f"Failed to start calibration: {exc}")
+            self.view.log_message(f"Traceback: {traceback.format_exc()}")
+
+    def _get_drive_max(self) -> float:
+        if hasattr(self.view, "drive_max_spinbox"):
+            return self.view.drive_max_spinbox.value()
+        return 0.670
+
+    def _prepare_phase_context(
+        self, cavity, operator: str, drive_max: float
+    ) -> bool:
+        record = self.session.get_active_record()
+        record_id = self.session.get_active_record_id()
+        self.view.log_message(f"Using record ID: {record_id}")
+
+        can_run, reason = self.session.can_run_phase(
+            CommissioningPhase.SSA_CHAR
+        )
+        if not can_run:
+            self.view.show_error(f"Cannot run SSA_CHAR phase: {reason}")
+            return False
+
+        if record_id is not None:
+            phase_start = self.session.start_active_phase_instance(
+                CommissioningPhase.SSA_CHAR, operator=operator
+            )
+            self._active_phase_instance_id = (
+                phase_start.phase_instance_id if phase_start else None
+            )
+
+        if self._active_phase_instance_id is not None:
+            self.view.log_message(
+                f"Tracking phase instance ID: {self._active_phase_instance_id}"
+            )
+
+        self.context = PhaseContext(
+            record=record,
+            operator=operator,
+            parameters={"cavity": cavity, "drive_max": drive_max},
+            phase_instance_id=self._active_phase_instance_id,
+            run_intent="commissioning",
+        )
+        self.phase = SSACharPhase(self.context)
+
+        is_valid, message = self.phase.validate_prerequisites()
+        if not is_valid:
+            self.view.show_error(f"Prerequisites not met: {message}")
+            return False
+
+        return True
+
+    def _set_running_ui_state(self) -> None:
+        self.view.run_button.setEnabled(False)
+        self.view.pause_button.setEnabled(True)
+        self.view.abort_button.setEnabled(True)
+        self.view.local_phase_status.setText("RUNNING")
+
+    def _execute_phase_async(self) -> None:
+        if not self.context or not self.phase:
+            return
+
+        self.context.progress_callback = (
+            lambda step, prog: self.view.step_progress_signal.emit(step, prog)
+        )
+        self._steps = self.phase.get_phase_steps()
+        self._total_steps = len(self._steps)
+        self._current_step_index = 0
+
+        QTimer.singleShot(100, self._run_phase_in_background)
+
+    def _run_phase_in_background(self) -> None:
+        def worker() -> None:
+            try:
+                self.phase._mark_phase_started()
+                for step_name in self.phase.get_phase_steps():
+                    if not self._check_pause_and_abort():
+                        return
+
+                    success = self._execute_single_step(step_name)
+                    if not success:
+                        self.phase_run_finished.emit(
+                            False, f"Step failed: {step_name}"
+                        )
+                        return
+
+                self._finalize_background_phase()
+            except Exception as exc:
+                self.phase_run_finished.emit(False, str(exc))
+
+        Thread(target=worker, daemon=True).start()
+
+    def _execute_single_step(self, step_name: str) -> bool:
+        import time
+
+        while self._paused:
+            time.sleep(0.1)
+            if self.context and self.context.is_abort_requested():
+                return False
+
+        if self.context and self.context.is_abort_requested():
+            return False
+
+        if self.context and self.context.progress_callback:
+            idx = (
+                self._steps.index(step_name) if step_name in self._steps else 0
+            )
+            self.context.progress_callback(
+                step_name, int((idx / len(self._steps)) * 100)
+            )
+
+        return self._execute_step_with_retries(step_name, max_retries=3)
+
+    def _execute_step_with_retries(
+        self, step_name: str, max_retries: int
+    ) -> bool:
+        import time
+
+        retry_count = 0
+        while retry_count < max_retries:
+            try:
+                result = self.phase.execute_step(step_name)
+                self._create_step_checkpoint(step_name, result)
+
+                if result.result in (PhaseResult.SUCCESS, PhaseResult.SKIP):
+                    self.view.log_message(f"✓ {step_name}")
+                    return True
+
+                if result.result == PhaseResult.RETRY:
+                    retry_count += 1
+                    if retry_count < max_retries:
+                        delay = max(0.0, float(result.retry_delay_seconds))
+                        self.view.log_message(
+                            f"Retrying {retry_count}/{max_retries} in {delay:.1f}s: "
+                            f"{result.message}"
+                        )
+                        time.sleep(delay)
+                        continue
+                    self.view.log_message(
+                        f"Failed after {max_retries} retries: {result.message}"
+                    )
+                    return False
+
+                self.view.log_message(f"✗ {step_name}: {result.message}")
+                return False
+
+            except Exception as exc:
+                retry_count += 1
+                if retry_count < max_retries:
+                    self.view.log_message(
+                        f"Exception on retry {retry_count}: {exc}"
+                    )
+                    continue
+                self.view.log_message(
+                    f"Exception after {max_retries} retries: {exc}"
+                )
+                return False
+
+        return False
+
+    def _create_step_checkpoint(self, step_name: str, result) -> None:
+        measurements = dict(result.data or {})
+        if self.context.phase_instance_id is not None:
+            measurements.setdefault(
+                "phase_instance_id", self.context.phase_instance_id
+            )
+
+        checkpoint = PhaseCheckpoint(
+            phase=self.phase.phase_type,
+            timestamp=datetime.now(),
+            operator=self.context.operator,
+            step_name=step_name,
+            success=result.result in (PhaseResult.SUCCESS, PhaseResult.SKIP),
+            notes=result.message,
+            measurements=measurements,
+        )
+        self.context.record.phase_history.append(checkpoint)
+
+    def _finalize_background_phase(self) -> None:
+        try:
+            self.phase.finalize_phase()
+            self.phase._mark_phase_completed()
+            self.phase_run_finished.emit(True, "")
+        except Exception as exc:
+            self.phase._handle_exception(exc)
+            self.phase_run_finished.emit(False, str(exc))
+
+    def _check_pause_and_abort(self) -> bool:
+        import time
+
+        while self._paused:
+            time.sleep(0.1)
+            if self.context and self.context.is_abort_requested():
+                self.phase_run_finished.emit(False, "Aborted")
+                return False
+
+        if self.context and self.context.is_abort_requested():
+            self.phase_run_finished.emit(False, "Aborted")
+            return False
+
+        return True
+
+    def _on_phase_run_finished(self, success: bool, error_msg: str) -> None:
+        if success:
+            self.on_phase_completed()
+        else:
+            self.on_phase_failed(error_msg or "Phase execution failed")
+
+    def on_phase_completed(self) -> None:
+        self._paused = False
+        self._step_mode = False
+
+        self.view.log_message("SSA calibration completed successfully")
+        self.view.local_phase_status.setText("COMPLETED")
+        self.view.local_progress_bar.setValue(100)
+        self._update_toolbar_state("complete")
+
+        try:
+            if self.context and self.context.record.ssa_char:
+                if self._active_phase_instance_id is not None:
+                    self.session.complete_active_phase_instance(
+                        phase_instance_id=self._active_phase_instance_id,
+                        phase=CommissioningPhase.SSA_CHAR,
+                        artifact_payload=self.context.record.ssa_char.to_dict(),
+                    )
+
+                if self.session.save_active_record():
+                    self.view.log_message(
+                        f"Results saved (ID: {self.session.get_active_record_id()})"
+                    )
+                    self.phase_completed.emit(self.session.get_active_record())
+                else:
+                    self.view.log_message("Warning: failed to save to database")
+
+                self._append_measurement_history()
+                self.view._update_local_results(self.context.record.ssa_char)
+                self.view._update_stored_readout(self.context.record.ssa_char)
+            else:
+                self.view.log_message("Warning: no ssa_char data to display")
+
+        except Exception as exc:
+            import traceback
+
+            self.view.log_message(f"Warning: failed to save results: {exc}")
+            self.view.log_message(f"Traceback: {traceback.format_exc()}")
+            if self._active_phase_instance_id is not None:
+                self.session.fail_active_phase_instance(
+                    phase_instance_id=self._active_phase_instance_id,
+                    phase=CommissioningPhase.SSA_CHAR,
+                    error_message=str(exc),
+                )
+        finally:
+            self._active_phase_instance_id = None
+
+        self.view.run_button.setEnabled(True)
+        self.view.pause_button.setEnabled(False)
+        self.view.abort_button.setEnabled(False)
+
+    def on_phase_failed(self, error_msg: str) -> None:
+        self._paused = False
+        self._step_mode = False
+
+        self.view.log_message(f"SSA calibration failed: {error_msg}")
+        self.view.local_phase_status.setText("FAILED")
+        self._update_toolbar_state("error")
+
+        try:
+            if self.phase:
+                self.phase.finalize_phase()
+
+            if self.session.save_active_record():
+                self.view.log_message("Partial results saved")
+
+            if self._active_phase_instance_id is not None:
+                snapshot = None
+                if self.context and self.context.record.ssa_char:
+                    snapshot = self.context.record.ssa_char.to_dict()
+                self.session.fail_active_phase_instance(
+                    phase_instance_id=self._active_phase_instance_id,
+                    phase=CommissioningPhase.SSA_CHAR,
+                    error_message=error_msg,
+                    artifact_payload=snapshot,
+                )
+
+            if self.context and self.context.record.ssa_char:
+                self._append_measurement_history(error_msg=error_msg)
+                self.view._update_local_results(self.context.record.ssa_char)
+                self.view._update_stored_readout(self.context.record.ssa_char)
+
+        except Exception as exc:
+            import traceback
+
+            self.view.log_message(
+                f"Warning: failed to save partial results: {exc}"
+            )
+            self.view.log_message(f"Traceback: {traceback.format_exc()}")
+            if self._active_phase_instance_id is not None:
+                self.session.fail_active_phase_instance(
+                    phase_instance_id=self._active_phase_instance_id,
+                    phase=CommissioningPhase.SSA_CHAR,
+                    error_message=str(exc),
+                )
+        finally:
+            self._active_phase_instance_id = None
+
+        self.view.run_button.setEnabled(True)
+        self.view.pause_button.setEnabled(False)
+        self.view.abort_button.setEnabled(False)
+        self.view.show_error(f"Calibration failed: {error_msg}")
+
+    # ------------------------------------------------------------------
+    # Manual Push / Save
+    # ------------------------------------------------------------------
+
+    def on_push_slope(self) -> None:
+        cavity = self._resolve_cavity()
+        if cavity is None:
+            return
+
+        def _push():
+            try:
+                cavity.push_ssa_slope()
+                self.view.log_message("✓ SSA slope pushed to cavity register")
+            except Exception as exc:
+                self.view.log_message(f"Push failed: {exc}")
+
+        Thread(target=_push, daemon=True).start()
+
+    def on_save_slope(self) -> None:
+        cavity = self._resolve_cavity()
+        if cavity is None:
+            return
+
+        def _save():
+            try:
+                cavity.save_ssa_slope()
+                self.view.log_message("✓ SSA slope saved to persistent storage")
+            except Exception as exc:
+                self.view.log_message(f"Save failed: {exc}")
+
+        Thread(target=_save, daemon=True).start()
+
+    def _resolve_cavity(self):
+        if self._cavity is not None:
+            return self._cavity
+
+        cavity_info = self.view.get_current_cavity()
+        if not cavity_info:
+            self.view.log_message("No cavity selected")
+            return None
+
+        cavity_name, cryomodule = cavity_info
+        try:
+            cm, cav = self._parse_cavity_from_record(cavity_name, cryomodule)
+            cavity = self._get_machine_cavity(cm, cav)
+            self._cavity = cavity
+            return cavity
+        except Exception as exc:
+            self.view.log_message(f"Could not resolve cavity: {exc}")
+            return None
+
+    # ------------------------------------------------------------------
+    # Pause / Abort
+    # ------------------------------------------------------------------
+
+    def on_abort(self) -> None:
+        if self.context:
+            self.context.request_abort()
+            self.view.log_message("Abort requested...")
+            self.view.abort_button.setEnabled(False)
+
+    def on_pause_test(self) -> None:
+        if self._paused:
+            self._paused = False
+            self.view.log_message("Test resumed...")
+            self.view.pause_button.setText("⏸ Pause")
+            self._update_toolbar_state("running")
+        else:
+            self._paused = True
+            self.view.log_message("Test paused...")
+            self.view.pause_button.setText("▶ Resume")
+            self._update_toolbar_state("paused")
+
+    # ------------------------------------------------------------------
+    # Misc helpers
+    # ------------------------------------------------------------------
+
+    def _get_operator(self) -> str:
+        if hasattr(self.view, "get_current_operator"):
+            return self.view.get_current_operator() or ""
+        return ""
+
+    def _parse_cavity_from_record(
+        self, cavity_name: str, cryomodule: str
+    ) -> tuple[int, int]:
+        parts = cavity_name.split("_")
+        cav_part = parts[2] if len(parts) >= 3 else "CAV1"
+        cav = int(cav_part.replace("CAV", ""))
+        cm = int(cryomodule)
+        return cm, cav
+
+    def _update_toolbar_state(self, state: str) -> None:
+        if hasattr(self.view, "ui") and hasattr(
+            self.view.ui, "update_toolbar_state"
+        ):
+            self.view.ui.update_toolbar_state(state)
+
+    def _append_measurement_history(self, error_msg: str | None = None) -> None:
+        if not (self.context and self.context.record.ssa_char):
+            return
+        notes = f"Phase failed: {error_msg}" if error_msg else None
+        self.session.add_measurement_to_history(
+            CommissioningPhase.SSA_CHAR,
+            self.context.record.ssa_char,
+            operator=self.context.operator or self._get_operator(),
+            notes=notes,
+            phase_instance_id=self._active_phase_instance_id,
+        )
+
+    def _auto_create_record(self) -> bool:
+        cryomodule, cavity_number = self._get_cavity_from_parent()
+        if not cryomodule or not cavity_number:
+            self.view.show_error(
+                "Please select a cavity in the header.\n\n"
+                "Use the CM and Cavity dropdowns, then try again."
+            )
+            return False
+
+        try:
+            record, record_id, created = self.session.start_new_record(
+                cryomodule=cryomodule, cavity_number=cavity_number
+            )
+            status = "Created" if created else "Loaded"
+            self.view.log_message(
+                f"✓ {status} record ID: {record_id} for CM{cryomodule} Cav{cavity_number}"
+            )
+            self.view._notify_parent_of_record_update(record, "Record created")
+            self.update_pv_addresses()
+            return True
+        except Exception as exc:
+            import traceback
+
+            self.view.show_error(f"Failed to create record:\n\n{exc}")
+            self.view.log_message(f"Traceback: {traceback.format_exc()}")
+            return False
+
+    def _get_cavity_from_parent(self) -> tuple[str | None, str | None]:
+        parent = self.view.parent()
+        while parent:
+            if hasattr(parent, "cryomodule_combo") and hasattr(
+                parent, "cavity_combo"
+            ):
+                try:
+                    cm = parent.cryomodule_combo.currentText()
+                    cav = parent.cavity_combo.currentText()
+                    if not cm or not cav:
+                        return None, None
+                    return cm, str(cav)
+                except Exception:
+                    return None, None
+            parent = parent.parent()
+        return None, None

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/displays/__init__.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/displays/__init__.py
@@ -3,6 +3,7 @@
 from .base_placeholder import BasePlaceholderDisplay
 from .piezo_pre_rf import PiezoPreRFDisplay
 from .registry import PHASE_DISPLAY_MAP, get_phase_display_class
+from .ssa_char import SSACharDisplay
 from .standard import (
     CavityCharDisplay,
     FrequencyTuningDisplay,
@@ -10,7 +11,6 @@ from .standard import (
     HighPowerOneHourRunDisplay,
     HighPowerRampDisplay,
     PiezoWithRFDisplay,
-    SSACharDisplay,
 )
 
 __all__ = [

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/displays/registry.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/displays/registry.py
@@ -11,6 +11,7 @@ from sc_linac_physics.applications.rf_commissioning.ui.builders import (
 
 from .base_placeholder import BasePlaceholderDisplay
 from .piezo_pre_rf import PiezoPreRFDisplay
+from .ssa_char import SSACharDisplay
 from .standard import (
     CavityCharDisplay,
     FrequencyTuningDisplay,
@@ -18,7 +19,6 @@ from .standard import (
     HighPowerOneHourRunDisplay,
     HighPowerRampDisplay,
     PiezoWithRFDisplay,
-    SSACharDisplay,
 )
 
 PHASE_DISPLAY_MAP: dict[CommissioningPhase, type[BasePlaceholderDisplay]] = {

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/displays/ssa_char.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/displays/ssa_char.py
@@ -1,4 +1,4 @@
-"""SSA Characterization commissioning display."""
+"""SSA Calibration commissioning display."""
 
 from PyQt5.QtCore import pyqtSlot
 
@@ -21,10 +21,10 @@ from .base_placeholder import BasePlaceholderDisplay
 
 
 class SSACharDisplay(BasePlaceholderDisplay):
-    """Display for SSA Characterization phase (fully implemented)."""
+    """Display for SSA Calibration phase (fully implemented)."""
 
     UI_CLASS = SSACharUI
-    PHASE_NAME = "SSA Characterization"
+    PHASE_NAME = "SSA Calibration"
     DATA_ATTR = "ssa_char"
     DATA_MODEL = SSACharacterization
 
@@ -32,7 +32,7 @@ class SSACharDisplay(BasePlaceholderDisplay):
         self, parent=None, session: CommissioningSession | None = None
     ):
         super().__init__(parent, session=session)
-        self.setWindowTitle("SSA Characterization - PyDM")
+        self.setWindowTitle("SSA Calibration - PyDM")
 
         self.controller = SSACharController(self, self.session)
         if hasattr(self.controller, "phase_completed"):
@@ -48,7 +48,6 @@ class SSACharDisplay(BasePlaceholderDisplay):
             "on_pause_test": self.on_pause_test,
             "on_abort_test": self.on_abort,
             "on_push_slope": self.on_push_slope,
-            "on_save_slope": self.on_save_slope,
             "on_plot": self.on_plot,
         }
         self.ui = self.UI_CLASS(self, callbacks)
@@ -136,9 +135,5 @@ class SSACharDisplay(BasePlaceholderDisplay):
         self.controller.on_push_slope()
 
     @pyqtSlot()
-    def on_save_slope(self):
-        self.controller.on_save_slope()
-
-    @pyqtSlot()
     def on_plot(self):
-        self.log_message("Plot not yet implemented")
+        self.controller.on_plot()

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/displays/ssa_char.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/displays/ssa_char.py
@@ -1,0 +1,144 @@
+"""SSA Characterization commissioning display."""
+
+from PyQt5.QtCore import pyqtSlot
+
+from sc_linac_physics.applications.rf_commissioning.models.data_models import (
+    CommissioningRecord,
+    SSACharacterization,
+)
+from sc_linac_physics.applications.rf_commissioning.session_manager import (
+    CommissioningSession,
+)
+from sc_linac_physics.applications.rf_commissioning.ui.builders import (
+    LOCAL_LABEL_STYLE,
+    SSACharUI,
+)
+from sc_linac_physics.applications.rf_commissioning.ui.controllers.ssa_char_controller import (
+    SSACharController,
+)
+
+from .base_placeholder import BasePlaceholderDisplay
+
+
+class SSACharDisplay(BasePlaceholderDisplay):
+    """Display for SSA Characterization phase (fully implemented)."""
+
+    UI_CLASS = SSACharUI
+    PHASE_NAME = "SSA Characterization"
+    DATA_ATTR = "ssa_char"
+    DATA_MODEL = SSACharacterization
+
+    def __init__(
+        self, parent=None, session: CommissioningSession | None = None
+    ):
+        super().__init__(parent, session=session)
+        self.setWindowTitle("SSA Characterization - PyDM")
+
+        self.controller = SSACharController(self, self.session)
+        if hasattr(self.controller, "phase_completed"):
+            self.controller.phase_completed.connect(
+                self._on_controller_phase_completed
+            )
+        if hasattr(self.controller, "setup_pv_connections"):
+            self.controller.setup_pv_connections()
+
+    def setup_ui(self):
+        callbacks = {
+            "on_run_automated_test": self.on_run_calibration,
+            "on_pause_test": self.on_pause_test,
+            "on_abort_test": self.on_abort,
+            "on_push_slope": self.on_push_slope,
+            "on_save_slope": self.on_save_slope,
+            "on_plot": self.on_plot,
+        }
+        self.ui = self.UI_CLASS(self, callbacks)
+        main_layout = self.ui.build()
+        self._bind_ui_widgets()
+        self.setLayout(main_layout)
+        self.update_timestamp()
+
+    def refresh_from_record(self, record: CommissioningRecord) -> None:
+        result = record.ssa_char
+        if result:
+            self._update_local_results(result)
+        else:
+            self.clear_results()
+        self._update_stored_readout(result)
+
+    def on_record_loaded(
+        self, record: CommissioningRecord, record_id: int
+    ) -> None:
+        if hasattr(self.controller, "update_pv_addresses"):
+            self.controller.update_pv_addresses(
+                record.cryomodule, str(record.cavity_number)
+            )
+        self.refresh_from_record(record)
+
+    def _on_controller_phase_completed(self, record):
+        parent = self.parent()
+        while parent:
+            if hasattr(parent, "on_phase_advanced"):
+                parent.on_phase_advanced(record)
+                break
+            parent = parent.parent()
+
+    def _update_local_results(self, result: SSACharacterization) -> None:
+        pass_style = (
+            LOCAL_LABEL_STYLE.replace("#2a2a1a", "#2d5016")
+            + "color: #90ee90; font-weight: bold;"
+        )
+        fail_style = (
+            LOCAL_LABEL_STYLE.replace("#2a2a1a", "#5c1a1a")
+            + "color: #ff6b6b; font-weight: bold;"
+        )
+
+        if hasattr(self, "local_phase_status"):
+            passed = result.calibration_passed
+            self.local_phase_status.setText("PASS" if passed else "FAIL")
+            self.local_phase_status.setStyleSheet(
+                pass_style if passed else fail_style
+            )
+
+    def _update_stored_readout(
+        self, result: SSACharacterization | None
+    ) -> None:
+        if result is None:
+            self._clear_phase_specific_readouts()
+            return
+        self._set_generic_stored_data(result)
+        self._apply_phase_specific_readouts(result)
+
+    def clear_results(self):
+        super().clear_results()
+        if hasattr(self, "local_phase_status"):
+            self.local_phase_status.setText("-")
+            self.local_phase_status.setStyleSheet(LOCAL_LABEL_STYLE)
+        self._clear_generic_stored_data()
+
+    # ------------------------------------------------------------------
+    # Slot handlers
+    # ------------------------------------------------------------------
+
+    @pyqtSlot()
+    def on_run_calibration(self):
+        self.controller.on_run_calibration()
+
+    @pyqtSlot()
+    def on_abort(self):
+        self.controller.on_abort()
+
+    @pyqtSlot()
+    def on_pause_test(self):
+        self.controller.on_pause_test()
+
+    @pyqtSlot()
+    def on_push_slope(self):
+        self.controller.on_push_slope()
+
+    @pyqtSlot()
+    def on_save_slope(self):
+        self.controller.on_save_slope()
+
+    @pyqtSlot()
+    def on_plot(self):
+        self.log_message("Plot not yet implemented")

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/displays/standard.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/displays/standard.py
@@ -7,7 +7,6 @@ from sc_linac_physics.applications.rf_commissioning.models.data_models import (
     MPProcessingData,
     OneHourRunData,
     PiezoWithRFTest,
-    SSACharacterization,
 )
 from sc_linac_physics.applications.rf_commissioning.ui.builders import (
     GenericPhaseUI,
@@ -23,15 +22,6 @@ class FrequencyTuningDisplay(BasePlaceholderDisplay):
     PHASE_NAME = "Frequency Tuning"
     DATA_ATTR = "frequency_tuning"
     DATA_MODEL = FrequencyTuningData
-
-
-class SSACharDisplay(BasePlaceholderDisplay):
-    """Display for SSA Characterization phase."""
-
-    UI_CLASS = GenericPhaseUI
-    PHASE_NAME = "SSA Characterization"
-    DATA_ATTR = "ssa_char"
-    DATA_MODEL = SSACharacterization
 
 
 class CavityCharDisplay(BasePlaceholderDisplay):

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/multi_phase_screen.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/multi_phase_screen.py
@@ -19,8 +19,14 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from pydm import Display as PyDMDisplay, PyDMApplication
+from pydm import Display, PyDMApplication
 
+from sc_linac_physics.applications.rf_commissioning.models.cryomodule_models import (
+    CryomoduleCheckoutRecord,
+    CryomodulePhase,
+    CryomodulePhaseStatus,
+    MagnetCheckoutData,
+)
 from sc_linac_physics.applications.rf_commissioning.models.data_models import (
     CommissioningPhase,
     CommissioningRecord,
@@ -28,17 +34,8 @@ from sc_linac_physics.applications.rf_commissioning.models.data_models import (
 from sc_linac_physics.applications.rf_commissioning.models.persistence.database import (
     RecordConflictError,
 )
-from sc_linac_physics.applications.rf_commissioning.models.cryomodule_models import (
-    CryomoduleCheckoutRecord,
-    CryomodulePhase,
-    CryomodulePhaseStatus,
-    MagnetCheckoutData,
-)
 from sc_linac_physics.applications.rf_commissioning.session_manager import (
     CommissioningSession,
-)
-from sc_linac_physics.utils.sc_linac.linac_utils import (
-    get_linac_for_cryomodule,
 )
 from sc_linac_physics.applications.rf_commissioning.ui.container import (
     PhaseTabSpec,
@@ -77,9 +74,12 @@ from sc_linac_physics.applications.rf_commissioning.ui.container import (
     update_sync_status,
     update_tab_states,
 )
+from sc_linac_physics.utils.sc_linac.linac_utils import (
+    get_linac_for_cryomodule,
+)
 
 
-class MultiPhaseCommissioningDisplay(PyDMDisplay):
+class MultiPhaseCommissioningDisplay(Display):
     """Container window that hosts multiple phase displays.
 
     This redesigned display keeps critical information always visible:

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/multi_phase_screen.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/multi_phase_screen.py
@@ -40,10 +40,6 @@ from sc_linac_physics.applications.rf_commissioning.session_manager import (
 from sc_linac_physics.utils.sc_linac.linac_utils import (
     get_linac_for_cryomodule,
 )
-from sc_linac_physics.applications.rf_commissioning.ui.phase_display_base import (
-    PhaseDisplayBase,
-)
-
 from sc_linac_physics.applications.rf_commissioning.ui.container import (
     PhaseTabSpec,
     build_note_dialog,
@@ -152,7 +148,7 @@ class MultiPhaseCommissioningDisplay(PyDMDisplay):
 
         self.setLayout(main_layout)
 
-        self._phase_displays: list[PhaseDisplayBase] = []
+        self._phase_displays: list = []
         self._init_tabs()
         self._update_tab_states()
         self._load_notes()
@@ -685,14 +681,6 @@ def main() -> int:
     window = MultiPhaseCommissioningDisplay()
     window.show()
     return app.exec_()
-
-
-class Display(MultiPhaseCommissioningDisplay):
-    """PyDM compatibility entrypoint class.
-
-    When launching this file directly via `pydm path/to/multi_phase_screen.py`,
-    PyDM expects a class named `Display` in the module.
-    """
 
 
 if __name__ == "__main__":

--- a/src/sc_linac_physics/utils/platform_paths.py
+++ b/src/sc_linac_physics/utils/platform_paths.py
@@ -64,3 +64,14 @@ def get_log_base_dir(
     if is_linux(system_name=system_name):
         return Path("/home/physics/srf/logfiles")
     return _current_home(home_dir) / "logfiles"
+
+
+def get_ssa_cal_base_dir(
+    *,
+    system_name: str | None = None,
+    home_dir: Path | None = None,
+) -> Path:
+    """Return the root directory where SSA calibration plots are stored."""
+    if is_linux(system_name=system_name):
+        return Path("/u1/lcls/physics/rf_lcls2/ssa_cal")
+    return _current_home(home_dir) / "ssa_cal"

--- a/src/sc_linac_physics/utils/sc_linac/ssa.py
+++ b/src/sc_linac_physics/utils/sc_linac/ssa.py
@@ -71,6 +71,7 @@ class SSA(linac_utils.SCLinacObject):
         self._cal_result_status_pv_obj: Optional[PV] = None
 
         self.current_slope_pv: str = self.pv_addr("SLOPE")
+        self._current_slope_pv_obj: Optional[PV] = None
         self.measured_slope_pv: str = self.pv_addr("SLOPE_NEW")
         self._measured_slope_pv_obj: Optional[PV] = None
         self.saved_slope_pv: str = self.pv_addr("SLOPE_SAVE")
@@ -548,6 +549,13 @@ class SSA(linac_utils.SCLinacObject):
                 }
             },
         )
+
+    @property
+    def current_slope(self):
+        """Currently active SSA slope (SLOPE PV), i.e. the value in use by the cavity."""
+        if not self._current_slope_pv_obj:
+            self._current_slope_pv_obj = PV(self.current_slope_pv)
+        return self._current_slope_pv_obj.get()
 
     @property
     def measured_slope(self):

--- a/src/sc_linac_physics/utils/sc_linac/ssa.py
+++ b/src/sc_linac_physics/utils/sc_linac/ssa.py
@@ -71,9 +71,9 @@ class SSA(linac_utils.SCLinacObject):
         self._cal_result_status_pv_obj: Optional[PV] = None
 
         self.current_slope_pv: str = self.pv_addr("SLOPE")
-
         self.measured_slope_pv: str = self.pv_addr("SLOPE_NEW")
         self._measured_slope_pv_obj: Optional[PV] = None
+        self.saved_slope_pv: str = self.pv_addr("SLOPE_SAVE")
 
         self.drive_max_setpoint_pv: str = self.pv_addr("DRV_MAX_REQ")
         self._drive_max_setpoint_pv_obj: Optional[PV] = None

--- a/src/sc_linac_physics/utils/sc_linac/ssa.py
+++ b/src/sc_linac_physics/utils/sc_linac/ssa.py
@@ -78,6 +78,9 @@ class SSA(linac_utils.SCLinacObject):
         self.drive_max_setpoint_pv: str = self.pv_addr("DRV_MAX_REQ")
         self._drive_max_setpoint_pv_obj: Optional[PV] = None
 
+        self.drive_max_new_pv: str = self.pv_addr("DRV_MAX_NEW")
+        self.drive_max_current_pv: str = self.pv_addr("DRV_MAX")
+
         self.saved_drive_max_pv: str = self.pv_addr("DRV_MAX_SAVE")
         self._saved_drive_max_pv_obj: Optional[PV] = None
 

--- a/src/sc_linac_physics/utils/simulation/cavity_service.py
+++ b/src/sc_linac_physics/utils/simulation/cavity_service.py
@@ -218,6 +218,13 @@ class CavityPVGroup(PVGroup):
     push_ssa_slope: PvpropertyInteger = pvproperty(
         value=0, name="PUSH_SSA_SLOPE.PROC", dtype=ChannelType.INT
     )
+
+    @push_ssa_slope.putter
+    async def push_ssa_slope(self, instance, value):
+        ssa = getattr(self, "ssa_group", None)
+        if ssa is not None:
+            await ssa.slope_old.write(ssa.slope_new.value)
+
     push_loaded_q: PvpropertyInteger = pvproperty(
         value=0, name="PUSH_QLOADED.PROC", dtype=ChannelType.INT
     )

--- a/src/sc_linac_physics/utils/simulation/cavity_service.py
+++ b/src/sc_linac_physics/utils/simulation/cavity_service.py
@@ -224,6 +224,7 @@ class CavityPVGroup(PVGroup):
         ssa = getattr(self, "ssa_group", None)
         if ssa is not None:
             await ssa.slope_old.write(ssa.slope_new.value)
+            await ssa.drive_max_current.write(ssa.drive_max_new.value)
 
     push_loaded_q: PvpropertyInteger = pvproperty(
         value=0, name="PUSH_QLOADED.PROC", dtype=ChannelType.INT

--- a/src/sc_linac_physics/utils/simulation/sc_linac_physics_service.py
+++ b/src/sc_linac_physics/utils/simulation/sc_linac_physics_service.py
@@ -442,9 +442,11 @@ class SCLinacPhysicsService(Service):
         )
 
         # Other cavity-related groups
-        self.add_pvs(
-            SSAPVGroup(prefix=f"{cav_prefix}SSA:", cavityGroup=cavity_group)
+        ssa_group = SSAPVGroup(
+            prefix=f"{cav_prefix}SSA:", cavityGroup=cavity_group
         )
+        cavity_group.ssa_group = ssa_group
+        self.add_pvs(ssa_group)
         self.add_pvs(CavFaultPVGroup(prefix=cav_prefix))
         jt_prefix = f"CLIC:CM{cm_name}:3001:PVJT:"
         jt_group = JTPVGroup(prefix=jt_prefix, cm_group=cm_group)

--- a/src/sc_linac_physics/utils/simulation/ssa_service.py
+++ b/src/sc_linac_physics/utils/simulation/ssa_service.py
@@ -88,6 +88,12 @@ class SSAPVGroup(PVGroup):
     drive_max: PvpropertyFloat = pvproperty(
         name="DRV_MAX_REQ", value=0.8, dtype=ChannelType.FLOAT
     )
+    drive_max_new: PvpropertyFloat = pvproperty(
+        name="DRV_MAX_NEW", value=0.8, dtype=ChannelType.FLOAT
+    )
+    drive_max_current: PvpropertyFloat = pvproperty(
+        name="DRV_MAX", value=0.8, dtype=ChannelType.FLOAT
+    )
     drive_max_save: PvpropertyFloat = pvproperty(
         name="DRV_MAX_SAVE", value=0.8, dtype=ChannelType.FLOAT
     )
@@ -123,6 +129,8 @@ class SSAPVGroup(PVGroup):
         print("Calibration Status: ", self.cal_status.value)
         await self.slope_new.write(uniform(0.5, 1.5))
         print("New Slope: ", self.slope_new.value)
+        await self.drive_max_new.write(self.drive_max.value)
+        print("New Drive Max: ", self.drive_max_new.value)
         if random() < 0.2:
             await self.cal_stat.write("Crash")
             print("Calibration Crashed")

--- a/tests/applications/rf_commissioning/models/persistence/test_database_helpers.py
+++ b/tests/applications/rf_commissioning/models/persistence/test_database_helpers.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from sc_linac_physics.applications.rf_commissioning.models.data_models import (
     CommissioningPhase,
     PhaseStatus,
@@ -71,12 +73,15 @@ def test_note_helpers_build_append_and_update_canonical_entries():
 
 def test_serialize_measurement_data_uses_model_to_dict():
     payload = serialize_measurement_data(
-        SSACharacterization(max_drive=0.25, initial_drive=0.5, num_attempts=2)
+        SSACharacterization(
+            max_drive=0.25,
+            slope_new=1.02345,
+        )
     )
 
     parsed = json.loads(payload)
     assert parsed["max_drive"] == 0.25
-    assert parsed["drive_reduction"] == 0.25
+    assert parsed["max_drive_percent"] == pytest.approx(25.0)
     assert parsed["is_complete"] is True
 
 

--- a/tests/applications/rf_commissioning/models/test_data_models.py
+++ b/tests/applications/rf_commissioning/models/test_data_models.py
@@ -95,14 +95,11 @@ class TestPhaseModels:
     def test_ssa_characterization_computed_properties(self):
         model = SSACharacterization(
             max_drive=0.60,
-            initial_drive=0.80,
-            num_attempts=1,
+            slope_new=1.02345,
+            calibration_passed=True,
         )
 
         assert model.max_drive_percent == pytest.approx(60.0)
-        assert model.initial_drive_percent == pytest.approx(80.0)
-        assert model.drive_reduction == pytest.approx(0.20)
-        assert model.succeeded_first_try is True
         assert model.is_complete is True
 
     def test_other_phase_completion_flags(self):
@@ -149,7 +146,12 @@ class TestPhaseModels:
         assert model.passed is False
 
     def test_stub_phases_passed_equals_is_complete(self):
-        assert SSACharacterization(max_drive=0.6).passed is True
+        assert (
+            SSACharacterization(
+                max_drive=0.6, slope_new=1.0, calibration_passed=True
+            ).passed
+            is True
+        )
         assert SSACharacterization().passed is False
         assert (
             CavityCharacterization(loaded_q=3e7, scale_factor=2.5).passed
@@ -316,21 +318,15 @@ class TestSerializationAndRegistry:
     def test_serialize_deserialize_round_trip_for_phase_model(self):
         original = SSACharacterization(
             max_drive=0.65,
-            initial_drive=0.85,
-            num_attempts=2,
+            slope_new=1.02345,
+            calibration_passed=True,
             timestamp=datetime(2026, 3, 21, 9, 0, 0),
             notes="round trip",
         )
 
         serialized = serialize_model(
             original,
-            computed_fields=(
-                "max_drive_percent",
-                "initial_drive_percent",
-                "drive_reduction",
-                "succeeded_first_try",
-                "is_complete",
-            ),
+            computed_fields=("max_drive_percent", "is_complete"),
         )
 
         restored = deserialize_model(SSACharacterization, serialized)

--- a/tests/applications/rf_commissioning/phases/test_ssa_char.py
+++ b/tests/applications/rf_commissioning/phases/test_ssa_char.py
@@ -178,7 +178,7 @@ def test_verify_initial_state_calibration_already_running(phase, mock_ssa):
 def test_verify_initial_state_read_exception_retries(phase, mock_ssa):
     phase.validate_prerequisites()
     mock_ssa.calibration_running = False
-    type(mock_ssa).measured_slope = PropertyMock(
+    type(mock_ssa).current_slope = PropertyMock(
         side_effect=RuntimeError("read fail")
     )
     result = phase._verify_initial_state()
@@ -189,7 +189,7 @@ def test_verify_initial_state_success(phase):
     phase.validate_prerequisites()
     result = phase._verify_initial_state()
     assert result.result == PhaseResult.SUCCESS
-    assert "initial_slope" in result.data
+    assert "initial_current_slope" in result.data
 
 
 # ------------------------------------------------------------------

--- a/tests/applications/rf_commissioning/phases/test_ssa_char.py
+++ b/tests/applications/rf_commissioning/phases/test_ssa_char.py
@@ -1,0 +1,450 @@
+"""Tests for SSA Calibration Phase."""
+
+import time
+from datetime import datetime
+from unittest.mock import Mock, PropertyMock
+
+import pytest
+
+from sc_linac_physics.applications.rf_commissioning.models.data_models import (
+    CommissioningPhase,
+    CommissioningRecord,
+    PhaseCheckpoint,
+)
+from sc_linac_physics.applications.rf_commissioning.phases.phase_base import (
+    PhaseContext,
+    PhaseResult,
+)
+from sc_linac_physics.applications.rf_commissioning.phases.ssa_char import (
+    SSACalLimits,
+    SSACharPhase,
+)
+from sc_linac_physics.utils.sc_linac.linac_utils import SSAFaultError
+
+
+@pytest.fixture(autouse=True)
+def no_sleep(monkeypatch):
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+
+
+@pytest.fixture
+def mock_ssa():
+    ssa = Mock()
+    ssa.calibration_running = False
+    ssa.calibration_crashed = False
+    ssa.calibration_result_good = True
+    ssa.measured_slope = 1.02345
+    ssa.measured_slope_in_tolerance = True
+    ssa.drive_max = 0.670
+    ssa.max_fwd_pwr = 4500.0
+    ssa.fwd_power_lower_limit = 4000.0
+    return ssa
+
+
+@pytest.fixture
+def mock_cavity(mock_ssa):
+    cavity = Mock()
+    cavity.ssa = mock_ssa
+    return cavity
+
+
+@pytest.fixture
+def record():
+    return CommissioningRecord(linac=1, cryomodule="02", cavity_number=1)
+
+
+@pytest.fixture
+def context(mock_cavity, record):
+    return PhaseContext(
+        record=record,
+        operator="test_op",
+        parameters={"cavity": mock_cavity, "drive_max": 0.670},
+    )
+
+
+@pytest.fixture
+def phase(context):
+    return SSACharPhase(
+        context,
+        limits=SSACalLimits(
+            cal_timeout=0.1, poll_interval=0.0, post_start_delay=0.0
+        ),
+    )
+
+
+# ------------------------------------------------------------------
+# Metadata
+# ------------------------------------------------------------------
+
+
+def test_phase_type(phase):
+    assert phase.phase_type == CommissioningPhase.SSA_CHAR
+
+
+def test_get_phase_steps(phase):
+    assert phase.get_phase_steps() == [
+        "verify_initial_state",
+        "set_drive_max",
+        "reset_and_power_on",
+        "start_calibration",
+        "wait_for_completion",
+        "validate_and_push",
+    ]
+
+
+# ------------------------------------------------------------------
+# validate_prerequisites
+# ------------------------------------------------------------------
+
+
+def test_validate_prerequisites_success(phase, mock_cavity):
+    ok, _ = phase.validate_prerequisites()
+    assert ok is True
+    assert phase.cavity is mock_cavity
+
+
+def test_validate_prerequisites_no_cavity(context):
+    context.parameters["cavity"] = None
+    ok, msg = SSACharPhase(context).validate_prerequisites()
+    assert ok is False
+    assert "cavity" in msg.lower()
+
+
+def test_validate_prerequisites_no_ssa(context):
+    context.parameters["cavity"].ssa = None
+    ok, _ = SSACharPhase(context).validate_prerequisites()
+    assert ok is False
+
+
+def test_validate_prerequisites_no_drive_max(context):
+    del context.parameters["drive_max"]
+    ok, _ = SSACharPhase(context).validate_prerequisites()
+    assert ok is False
+
+
+def test_validate_prerequisites_drive_max_out_of_range(context):
+    context.parameters["drive_max"] = 1.5
+    ok, msg = SSACharPhase(context).validate_prerequisites()
+    assert ok is False
+    assert "drive_max" in msg
+
+
+def test_validate_prerequisites_drive_max_zero(context):
+    context.parameters["drive_max"] = 0.0
+    ok, _ = SSACharPhase(context).validate_prerequisites()
+    assert ok is False
+
+
+# ------------------------------------------------------------------
+# execute_step dispatch
+# ------------------------------------------------------------------
+
+
+def test_execute_step_unknown_step(phase, mock_cavity):
+    phase.cavity = mock_cavity
+    result = phase.execute_step("nonexistent_step")
+    assert result.result == PhaseResult.FAILED
+    assert "Unknown step" in result.message
+
+
+def test_execute_step_without_cavity_raises(phase):
+    phase.cavity = None
+    with pytest.raises(Exception):
+        phase.execute_step("verify_initial_state")
+
+
+# ------------------------------------------------------------------
+# verify_initial_state
+# ------------------------------------------------------------------
+
+
+def test_verify_initial_state_dry_run(context):
+    context.dry_run = True
+    p = SSACharPhase(context)
+    p.validate_prerequisites()
+    result = p._verify_initial_state()
+    assert result.result == PhaseResult.SUCCESS
+    assert result.data["dry_run"] is True
+
+
+def test_verify_initial_state_calibration_already_running(phase, mock_ssa):
+    phase.validate_prerequisites()
+    mock_ssa.calibration_running = True
+    result = phase._verify_initial_state()
+    assert result.result == PhaseResult.FAILED
+    assert "already running" in result.message
+
+
+def test_verify_initial_state_read_exception_retries(phase, mock_ssa):
+    phase.validate_prerequisites()
+    mock_ssa.calibration_running = False
+    type(mock_ssa).measured_slope = PropertyMock(
+        side_effect=RuntimeError("read fail")
+    )
+    result = phase._verify_initial_state()
+    assert result.result == PhaseResult.RETRY
+
+
+def test_verify_initial_state_success(phase):
+    phase.validate_prerequisites()
+    result = phase._verify_initial_state()
+    assert result.result == PhaseResult.SUCCESS
+    assert "initial_slope" in result.data
+
+
+# ------------------------------------------------------------------
+# set_drive_max
+# ------------------------------------------------------------------
+
+
+def test_set_drive_max_dry_run(context):
+    context.dry_run = True
+    p = SSACharPhase(context)
+    p.validate_prerequisites()
+    result = p._set_drive_max()
+    assert result.result == PhaseResult.SUCCESS
+    assert result.data["dry_run"] is True
+
+
+def test_set_drive_max_success(phase, mock_ssa):
+    phase.validate_prerequisites()
+    result = phase._set_drive_max()
+    assert result.result == PhaseResult.SUCCESS
+    assert mock_ssa.drive_max == 0.670
+
+
+# ------------------------------------------------------------------
+# reset_and_power_on
+# ------------------------------------------------------------------
+
+
+def test_reset_and_power_on_dry_run(context):
+    context.dry_run = True
+    p = SSACharPhase(context)
+    p.validate_prerequisites()
+    assert p._reset_and_power_on().result == PhaseResult.SUCCESS
+
+
+def test_reset_and_power_on_success(phase, mock_cavity):
+    phase.validate_prerequisites()
+    result = phase._reset_and_power_on()
+    assert result.result == PhaseResult.SUCCESS
+    mock_cavity.ssa.reset.assert_called_once()
+    mock_cavity.ssa.turn_on.assert_called_once()
+    mock_cavity.reset_interlocks.assert_called_once()
+
+
+def test_reset_and_power_on_ssa_fault_error(phase, mock_cavity):
+    phase.validate_prerequisites()
+    mock_cavity.ssa.reset.side_effect = SSAFaultError("fault")
+    result = phase._reset_and_power_on()
+    assert result.result == PhaseResult.FAILED
+
+
+def test_reset_and_power_on_transient_error_retries(phase, mock_cavity):
+    phase.validate_prerequisites()
+    mock_cavity.ssa.reset.side_effect = RuntimeError("transient")
+    result = phase._reset_and_power_on()
+    assert result.result == PhaseResult.RETRY
+
+
+# ------------------------------------------------------------------
+# start_calibration
+# ------------------------------------------------------------------
+
+
+def test_start_calibration_dry_run(context):
+    context.dry_run = True
+    p = SSACharPhase(context)
+    p.validate_prerequisites()
+    assert p._start_calibration().result == PhaseResult.SUCCESS
+
+
+def test_start_calibration_crashes_immediately(phase, mock_ssa):
+    phase.validate_prerequisites()
+    mock_ssa.calibration_crashed = True
+    result = phase._start_calibration()
+    assert result.result == PhaseResult.FAILED
+    assert "crashed" in result.message.lower()
+
+
+def test_start_calibration_success(phase, mock_ssa):
+    phase.validate_prerequisites()
+    mock_ssa.calibration_crashed = False
+    result = phase._start_calibration()
+    assert result.result == PhaseResult.SUCCESS
+    mock_ssa.start_calibration.assert_called_once()
+
+
+# ------------------------------------------------------------------
+# wait_for_completion
+# ------------------------------------------------------------------
+
+
+def test_wait_for_completion_dry_run(context):
+    context.dry_run = True
+    p = SSACharPhase(context)
+    p.validate_prerequisites()
+    result = p._wait_for_completion()
+    assert result.result == PhaseResult.SUCCESS
+    assert result.data["dry_run"] is True
+    assert result.data["slope_new"] == 1.02345
+
+
+def test_wait_for_completion_already_done(phase, mock_ssa):
+    phase.validate_prerequisites()
+    mock_ssa.calibration_running = False
+    result = phase._wait_for_completion()
+    assert result.result == PhaseResult.SUCCESS
+    assert result.data["slope_new"] == mock_ssa.measured_slope
+
+
+def test_wait_for_completion_timeout(context, mock_ssa):
+    p = SSACharPhase(
+        context,
+        limits=SSACalLimits(
+            cal_timeout=0.1, poll_interval=0.1, post_start_delay=0.0
+        ),
+    )
+    p.validate_prerequisites()
+    mock_ssa.calibration_running = True
+    result = p._wait_for_completion()
+    assert result.result == PhaseResult.FAILED
+    assert "timed out" in result.message.lower()
+
+
+def test_wait_for_completion_abort_while_running(context, mock_ssa):
+    p = SSACharPhase(
+        context,
+        limits=SSACalLimits(
+            cal_timeout=100.0, poll_interval=0.0, post_start_delay=0.0
+        ),
+    )
+    p.validate_prerequisites()
+    mock_ssa.calibration_running = True
+    context.request_abort()
+    result = p._wait_for_completion()
+    assert result.result == PhaseResult.FAILED
+    assert "Abort" in result.message
+
+
+def test_wait_for_completion_slope_read_error(phase, mock_ssa):
+    phase.validate_prerequisites()
+    mock_ssa.calibration_running = False
+    type(mock_ssa).measured_slope = PropertyMock(
+        side_effect=RuntimeError("read error")
+    )
+    result = phase._wait_for_completion()
+    assert result.result == PhaseResult.SUCCESS
+    assert result.data["slope_new"] is None
+
+
+# ------------------------------------------------------------------
+# validate_and_push
+# ------------------------------------------------------------------
+
+
+def test_validate_and_push_dry_run(context):
+    context.dry_run = True
+    p = SSACharPhase(context)
+    p.validate_prerequisites()
+    result = p._validate_and_push()
+    assert result.result == PhaseResult.SUCCESS
+    assert result.data["calibration_passed"] is True
+
+
+def test_validate_and_push_crashed(phase, mock_ssa):
+    phase.validate_prerequisites()
+    mock_ssa.calibration_crashed = True
+    result = phase._validate_and_push()
+    assert result.result == PhaseResult.FAILED
+
+
+def test_validate_and_push_bad_calstat(phase, mock_ssa):
+    phase.validate_prerequisites()
+    mock_ssa.calibration_result_good = False
+    result = phase._validate_and_push()
+    assert result.result == PhaseResult.FAILED
+
+
+def test_validate_and_push_low_forward_power(phase, mock_ssa):
+    phase.validate_prerequisites()
+    mock_ssa.max_fwd_pwr = 100.0
+    result = phase._validate_and_push()
+    assert result.result == PhaseResult.FAILED
+    assert "power" in result.message.lower()
+
+
+def test_validate_and_push_slope_out_of_tolerance(phase, mock_ssa):
+    phase.validate_prerequisites()
+    mock_ssa.measured_slope_in_tolerance = False
+    result = phase._validate_and_push()
+    assert result.result == PhaseResult.FAILED
+    assert "tolerance" in result.message.lower()
+
+
+def test_validate_and_push_success(phase, mock_ssa, mock_cavity):
+    phase.validate_prerequisites()
+    result = phase._validate_and_push()
+    assert result.result == PhaseResult.SUCCESS
+    assert result.data["calibration_passed"] is True
+    mock_cavity.push_ssa_slope.assert_called_once()
+    assert result.data["slope_new"] == mock_ssa.measured_slope
+
+
+def test_validate_and_push_post_push_readback_error(phase, mock_ssa):
+    phase.validate_prerequisites()
+    call_count = {"n": 0}
+    original_value = mock_ssa.measured_slope
+
+    def _slope():
+        call_count["n"] += 1
+        if call_count["n"] > 1:
+            raise RuntimeError("readback fail")
+        return original_value
+
+    type(mock_ssa).measured_slope = PropertyMock(side_effect=_slope)
+    result = phase._validate_and_push()
+    assert result.result == PhaseResult.SUCCESS
+
+
+# ------------------------------------------------------------------
+# finalize_phase
+# ------------------------------------------------------------------
+
+
+def test_finalize_phase_uses_validate_and_push_checkpoint(phase, record):
+    phase.validate_prerequisites()
+    phase._history_start = 0
+
+    checkpoint = PhaseCheckpoint(
+        phase=CommissioningPhase.SSA_CHAR,
+        timestamp=datetime.now(),
+        operator="op",
+        step_name="validate_and_push",
+        success=True,
+        measurements={
+            "slope_new": 1.05,
+            "max_fwd_pwr": 4500.0,
+            "max_drive": 0.670,
+            "calibration_passed": True,
+        },
+    )
+    record.phase_history.append(checkpoint)
+
+    phase.finalize_phase()
+
+    assert record.ssa_char is not None
+    assert record.ssa_char.slope_new == 1.05
+    assert record.ssa_char.calibration_passed is True
+    assert record.ssa_char.max_drive == 0.670
+
+
+def test_finalize_phase_no_checkpoint_creates_default(phase, record):
+    phase.validate_prerequisites()
+    phase._history_start = 0
+
+    phase.finalize_phase()
+
+    assert record.ssa_char is not None
+    assert record.ssa_char.calibration_passed is False

--- a/tests/applications/rf_commissioning/test_phase_specs.py
+++ b/tests/applications/rf_commissioning/test_phase_specs.py
@@ -11,8 +11,14 @@ from sc_linac_physics.applications.rf_commissioning.ui.container.phase_specs imp
 def test_default_phase_specs_hide_placeholder_tabs_for_beta() -> None:
     specs = build_default_phase_specs()
 
-    assert [spec.phase for spec in specs] == [CommissioningPhase.PIEZO_PRE_RF]
-    assert [spec.title for spec in specs] == ["Piezo Pre-RF"]
+    assert [spec.phase for spec in specs] == [
+        CommissioningPhase.PIEZO_PRE_RF,
+        CommissioningPhase.SSA_CHAR,
+    ]
+    assert [spec.title for spec in specs] == [
+        "Piezo Pre-RF",
+        "SSA Characterization",
+    ]
 
 
 def test_default_phase_specs_can_include_all_placeholder_tabs() -> None:

--- a/tests/applications/rf_commissioning/test_phase_specs.py
+++ b/tests/applications/rf_commissioning/test_phase_specs.py
@@ -17,7 +17,7 @@ def test_default_phase_specs_hide_placeholder_tabs_for_beta() -> None:
     ]
     assert [spec.title for spec in specs] == [
         "Piezo Pre-RF",
-        "SSA Characterization",
+        "SSA Calibration",
     ]
 
 

--- a/tests/applications/rf_commissioning/test_ssa_char_controller.py
+++ b/tests/applications/rf_commissioning/test_ssa_char_controller.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from unittest.mock import Mock
 
 import sc_linac_physics.applications.rf_commissioning.ui.controllers.ssa_char_controller as controller_module
+from pydm.widgets import PyDMSpinbox
 from sc_linac_physics.applications.rf_commissioning.models.data_models import (
     CommissioningRecord,
     SSACharacterization,
@@ -49,7 +50,10 @@ class _ViewStub:
         self.local_progress_bar = Mock()
         self.ui = SimpleNamespace(update_toolbar_state=Mock())
         self.step_progress_signal = SimpleNamespace(emit=Mock())
-        self.drive_max_spinbox = SimpleNamespace(value=Mock(return_value=0.670))
+        self.drive_max_spinbox = PyDMSpinbox()
+        self.drive_max_spinbox.setRange(0.01, 1.0)
+        self.drive_max_spinbox.setDecimals(3)
+        self.drive_max_spinbox.setValue(0.82)
         self._update_local_results = Mock()
         self._update_stored_readout = Mock()
 
@@ -84,7 +88,7 @@ def _record_with_result() -> CommissioningRecord:
     record.ssa_char = SSACharacterization(
         max_drive=0.670,
         slope_new=1.02345,
-        max_fwd_pwr_w=4500.0,
+        max_fwd_pwr=4500.0,
         calibration_passed=True,
     )
     return record
@@ -191,6 +195,32 @@ def test_update_pv_addresses_exception_logs_error() -> None:
     controller.update_pv_addresses("02", "1")
 
     assert any("Error setting PVs" in msg for msg in view.logs)
+
+
+def test_update_pv_addresses_binds_drive_max_spinbox_to_request_pv() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    ssa = SimpleNamespace(
+        calibration_status_pv="PV:CALSTAT",
+        max_fwd_pwr_pv="PV:CALPWR",
+        measured_slope_pv="PV:SLOPE_NEW",
+        current_slope_pv="PV:SLOPE",
+        drive_max_setpoint_pv="PV:DRV_MAX_REQ",
+        drive_max_new_pv="PV:DRV_MAX_NEW",
+        drive_max_current_pv="PV:DRV_MAX",
+    )
+    controller._get_machine_cavity = Mock(return_value=SimpleNamespace(ssa=ssa))
+
+    controller.update_pv_addresses("02", "1")
+
+    assert view.drive_max_spinbox.channel == "ca://PV:DRV_MAX_REQ"
+
+
+def test_get_drive_max_reads_pydm_spinbox_value() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+
+    assert controller._get_drive_max() == 0.82
 
 
 # ------------------------------------------------------------------

--- a/tests/applications/rf_commissioning/test_ssa_char_controller.py
+++ b/tests/applications/rf_commissioning/test_ssa_char_controller.py
@@ -1,0 +1,981 @@
+"""Tests for SSA Calibration controller."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import sc_linac_physics.applications.rf_commissioning.ui.controllers.ssa_char_controller as controller_module
+from sc_linac_physics.applications.rf_commissioning.models.data_models import (
+    CommissioningRecord,
+    SSACharacterization,
+)
+from sc_linac_physics.applications.rf_commissioning.phases.phase_base import (
+    PhaseContext,
+    PhaseResult,
+    PhaseStepResult,
+)
+from sc_linac_physics.applications.rf_commissioning.ui.controllers.ssa_char_controller import (
+    SSACharController,
+)
+
+
+class _ButtonStub:
+    def __init__(self):
+        self.enabled = True
+        self.text = ""
+
+    def setEnabled(self, enabled: bool) -> None:
+        self.enabled = enabled
+
+    def setText(self, text: str) -> None:
+        self.text = text
+
+
+class _ViewStub:
+    def __init__(
+        self,
+        *,
+        current_operator: str = "Test Operator",
+        cavity: tuple[str, str] | None = ("L1B_CM02_CAV1", "02"),
+    ):
+        self._current_operator = current_operator
+        self._cavity = cavity
+        self.logs: list[str] = []
+        self.errors: list[str] = []
+
+        self.run_button = _ButtonStub()
+        self.pause_button = _ButtonStub()
+        self.abort_button = _ButtonStub()
+        self.local_phase_status = Mock()
+        self.local_progress_bar = Mock()
+        self.ui = SimpleNamespace(update_toolbar_state=Mock())
+        self.step_progress_signal = SimpleNamespace(emit=Mock())
+        self.drive_max_spinbox = SimpleNamespace(value=Mock(return_value=0.670))
+        self._update_local_results = Mock()
+        self._update_stored_readout = Mock()
+
+    def get_current_operator(self) -> str:
+        return self._current_operator
+
+    def get_current_cavity(self):
+        return self._cavity
+
+    def log_message(self, message: str) -> None:
+        self.logs.append(message)
+
+    def show_error(self, message: str) -> None:
+        self.errors.append(message)
+
+    def clear_results(self) -> None:
+        return None
+
+    def parent(self):
+        return None
+
+    def _notify_parent_of_record_update(self, record, message: str) -> None:
+        return None
+
+
+def _make_controller(view=None, session=None):
+    return SSACharController(view or _ViewStub(), session or Mock())
+
+
+def _record_with_result() -> CommissioningRecord:
+    record = CommissioningRecord(linac=1, cryomodule="02", cavity_number=1)
+    record.ssa_char = SSACharacterization(
+        max_drive=0.670,
+        slope_new=1.02345,
+        max_fwd_pwr_w=4500.0,
+        calibration_passed=True,
+    )
+    return record
+
+
+class _ThreadStub:
+    def __init__(self, target, daemon):
+        self.target = target
+
+    def start(self):
+        self.target()
+
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+
+def test_get_operator_returns_value() -> None:
+    view = _ViewStub(current_operator="Alice")
+    assert _make_controller(view=view)._get_operator() == "Alice"
+
+
+def test_get_operator_empty_when_no_method() -> None:
+    assert SSACharController(SimpleNamespace(), Mock())._get_operator() == ""
+
+
+def test_parse_cavity_from_record_full_name() -> None:
+    controller = _make_controller()
+    assert controller._parse_cavity_from_record("L1B_CM02_CAV8", "02") == (2, 8)
+
+
+def test_parse_cavity_from_record_short_name_defaults_to_cav1() -> None:
+    controller = _make_controller()
+    assert controller._parse_cavity_from_record("SHORT", "02") == (2, 1)
+
+
+def test_update_toolbar_state_delegates_to_ui() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller._update_toolbar_state("running")
+    view.ui.update_toolbar_state.assert_called_once_with("running")
+
+
+def test_update_toolbar_state_without_ui_is_safe() -> None:
+    SSACharController(SimpleNamespace(), Mock())._update_toolbar_state(
+        "running"
+    )
+
+
+# ------------------------------------------------------------------
+# PV wiring
+# ------------------------------------------------------------------
+
+
+def test_setup_pv_connections_calls_update_when_active() -> None:
+    session = Mock()
+    session.has_active_record.return_value = True
+    controller = _make_controller(session=session)
+    controller.update_pv_addresses = Mock()
+
+    controller.setup_pv_connections()
+
+    controller.update_pv_addresses.assert_called_once()
+
+
+def test_setup_pv_connections_skips_when_no_active_record() -> None:
+    session = Mock()
+    session.has_active_record.return_value = False
+    controller = _make_controller(session=session)
+    controller.update_pv_addresses = Mock()
+
+    controller.setup_pv_connections()
+
+    controller.update_pv_addresses.assert_not_called()
+
+
+def test_update_pv_addresses_no_selection_logs_message() -> None:
+    view = _ViewStub(cavity=None)
+    controller = _make_controller(view=view)
+
+    controller.update_pv_addresses()
+
+    assert "No cavity selected" in view.logs
+
+
+def test_update_pv_addresses_invalid_int_logs_message(monkeypatch) -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    monkeypatch.setattr(
+        controller_module, "resolve_cavity_selection", lambda *_: ("02", "bad")
+    )
+
+    controller.update_pv_addresses()
+
+    assert any("Invalid cavity/CM value" in msg for msg in view.logs)
+
+
+def test_update_pv_addresses_exception_logs_error() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller._get_machine_cavity = Mock(side_effect=RuntimeError("oops"))
+
+    controller.update_pv_addresses("02", "1")
+
+    assert any("Error setting PVs" in msg for msg in view.logs)
+
+
+# ------------------------------------------------------------------
+# on_run_calibration
+# ------------------------------------------------------------------
+
+
+def test_on_run_calibration_no_operator_shows_error() -> None:
+    view = _ViewStub(current_operator="")
+    _make_controller(view=view).on_run_calibration()
+    assert any("operator" in msg.lower() for msg in view.errors)
+
+
+def test_on_run_calibration_auto_create_fails_stops() -> None:
+    session = Mock()
+    session.has_active_record.return_value = False
+    controller = _make_controller(session=session)
+    controller._auto_create_record = Mock(return_value=False)
+
+    controller.on_run_calibration()
+
+    controller._auto_create_record.assert_called_once()
+
+
+def test_on_run_calibration_no_cavity_shows_error() -> None:
+    session = Mock()
+    session.has_active_record.return_value = True
+    view = _ViewStub(cavity=None)
+    _make_controller(view=view, session=session).on_run_calibration()
+    assert any("cavity" in msg.lower() for msg in view.errors)
+
+
+def test_on_run_calibration_success_path() -> None:
+    view = _ViewStub()
+    session = Mock()
+    session.has_active_record.return_value = True
+    controller = _make_controller(view=view, session=session)
+    controller.update_pv_addresses = Mock()
+    controller._get_machine_cavity = Mock(return_value=Mock())
+    controller._prepare_phase_context = Mock(return_value=True)
+    controller._set_running_ui_state = Mock()
+    controller._execute_phase_async = Mock()
+
+    controller.on_run_calibration()
+
+    controller._set_running_ui_state.assert_called_once()
+    controller._execute_phase_async.assert_called_once()
+
+
+def test_on_run_calibration_prepare_context_fails_stops() -> None:
+    session = Mock()
+    session.has_active_record.return_value = True
+    controller = _make_controller(session=session)
+    controller.update_pv_addresses = Mock()
+    controller._get_machine_cavity = Mock(return_value=Mock())
+    controller._prepare_phase_context = Mock(return_value=False)
+    controller._execute_phase_async = Mock()
+
+    controller.on_run_calibration()
+
+    controller._execute_phase_async.assert_not_called()
+
+
+def test_on_run_calibration_exception_is_logged() -> None:
+    view = _ViewStub()
+    session = Mock()
+    session.has_active_record.return_value = True
+    controller = _make_controller(view=view, session=session)
+    controller.update_pv_addresses = Mock(side_effect=RuntimeError("boom"))
+
+    controller.on_run_calibration()
+
+    assert any("Failed to start calibration" in msg for msg in view.errors)
+
+
+# ------------------------------------------------------------------
+# _prepare_phase_context
+# ------------------------------------------------------------------
+
+
+def test_prepare_phase_context_can_run_false() -> None:
+    session = Mock()
+    session.get_active_record.return_value = _record_with_result()
+    session.get_active_record_id.return_value = 7
+    session.can_run_phase.return_value = (False, "blocked")
+    view = _ViewStub()
+    controller = _make_controller(view=view, session=session)
+
+    assert controller._prepare_phase_context(Mock(), "op", 0.670) is False
+    assert any("blocked" in msg for msg in view.errors)
+
+
+def test_prepare_phase_context_prerequisites_fail(monkeypatch) -> None:
+    session = Mock()
+    session.get_active_record.return_value = _record_with_result()
+    session.get_active_record_id.return_value = 7
+    session.can_run_phase.return_value = (True, "")
+    session.start_active_phase_instance.return_value = SimpleNamespace(
+        phase_instance_id=99
+    )
+
+    class _PhaseStub:
+        def __init__(self, ctx):
+            pass
+
+        def validate_prerequisites(self):
+            return (False, "no SSA")
+
+    monkeypatch.setattr(controller_module, "SSACharPhase", _PhaseStub)
+    view = _ViewStub()
+    controller = _make_controller(view=view, session=session)
+
+    assert controller._prepare_phase_context(Mock(), "op", 0.670) is False
+    assert any("no SSA" in msg for msg in view.errors)
+
+
+def test_prepare_phase_context_success_no_record_id(monkeypatch) -> None:
+    session = Mock()
+    session.get_active_record.return_value = _record_with_result()
+    session.get_active_record_id.return_value = None
+    session.can_run_phase.return_value = (True, "")
+
+    class _PhaseStub:
+        def __init__(self, ctx):
+            pass
+
+        def validate_prerequisites(self):
+            return (True, "ok")
+
+    monkeypatch.setattr(controller_module, "SSACharPhase", _PhaseStub)
+    controller = _make_controller(session=session)
+
+    assert controller._prepare_phase_context(Mock(), "op", 0.670) is True
+    assert controller._active_phase_instance_id is None
+
+
+# ------------------------------------------------------------------
+# UI state
+# ------------------------------------------------------------------
+
+
+def test_set_running_ui_state() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+
+    controller._set_running_ui_state()
+
+    assert view.run_button.enabled is False
+    assert view.pause_button.enabled is True
+    assert view.abort_button.enabled is True
+    view.local_phase_status.setText.assert_called_once_with("RUNNING")
+
+
+# ------------------------------------------------------------------
+# Pause / abort
+# ------------------------------------------------------------------
+
+
+def test_on_abort_requests_abort_and_disables_button() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+
+    controller.on_abort()
+
+    assert controller.context.abort_requested is True
+    assert view.abort_button.enabled is False
+    assert "Abort requested..." in view.logs
+
+
+def test_on_abort_without_context_is_noop() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller.context = None
+
+    controller.on_abort()
+
+    assert view.abort_button.enabled is True
+
+
+def test_on_pause_test_toggles_state_and_button_text() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+
+    controller.on_pause_test()
+    assert controller._paused is True
+    assert view.pause_button.text == "▶ Resume"
+
+    controller.on_pause_test()
+    assert controller._paused is False
+    assert view.pause_button.text == "⏸ Pause"
+
+
+# ------------------------------------------------------------------
+# _check_pause_and_abort
+# ------------------------------------------------------------------
+
+
+def test_check_pause_and_abort_normal_proceeds() -> None:
+    assert _make_controller()._check_pause_and_abort() is True
+
+
+def test_check_pause_and_abort_aborted() -> None:
+    controller = _make_controller()
+    controller.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+    controller.context.request_abort()
+    emitted = []
+    controller.phase_run_finished.connect(
+        lambda ok, msg: emitted.append((ok, msg))
+    )
+
+    assert controller._check_pause_and_abort() is False
+    assert emitted[-1] == (False, "Aborted")
+
+
+def test_check_pause_and_abort_paused_then_abort(monkeypatch) -> None:
+    controller = _make_controller()
+    controller.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+    controller._paused = True
+
+    def _sleep(_):
+        controller.context.request_abort()
+
+    monkeypatch.setitem(
+        __import__("sys").modules, "time", SimpleNamespace(sleep=_sleep)
+    )
+    emitted = []
+    controller.phase_run_finished.connect(
+        lambda ok, msg: emitted.append((ok, msg))
+    )
+
+    assert controller._check_pause_and_abort() is False
+    assert emitted[-1] == (False, "Aborted")
+
+
+# ------------------------------------------------------------------
+# Step execution
+# ------------------------------------------------------------------
+
+
+def test_execute_step_with_retries_success() -> None:
+    controller = _make_controller()
+    controller.phase = Mock()
+    controller.phase.execute_step.return_value = PhaseStepResult(
+        result=PhaseResult.SUCCESS, message="ok"
+    )
+    controller._create_step_checkpoint = Mock()
+
+    assert controller._execute_step_with_retries("step", max_retries=3) is True
+    assert any("✓" in msg for msg in controller.view.logs)
+
+
+def test_execute_step_with_retries_skip() -> None:
+    controller = _make_controller()
+    controller.phase = Mock()
+    controller.phase.execute_step.return_value = PhaseStepResult(
+        result=PhaseResult.SKIP, message="skip"
+    )
+    controller._create_step_checkpoint = Mock()
+
+    assert controller._execute_step_with_retries("step", max_retries=3) is True
+
+
+def test_execute_step_with_retries_failed() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller.phase = Mock()
+    controller.phase.execute_step.return_value = PhaseStepResult(
+        result=PhaseResult.FAILED, message="bad"
+    )
+    controller._create_step_checkpoint = Mock()
+
+    assert controller._execute_step_with_retries("step", max_retries=3) is False
+    assert any("✗" in msg for msg in view.logs)
+
+
+def test_execute_step_with_retries_retry_exhausted() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller.phase = Mock()
+    controller.phase.execute_step.return_value = PhaseStepResult(
+        result=PhaseResult.RETRY, message="again", retry_delay_seconds=0.0
+    )
+    controller._create_step_checkpoint = Mock()
+
+    assert controller._execute_step_with_retries("step", max_retries=2) is False
+    assert any("Failed after 2 retries" in msg for msg in view.logs)
+
+
+def test_execute_step_with_retries_exception_exhausted() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller.phase = Mock()
+    controller.phase.execute_step.side_effect = RuntimeError("rpc down")
+
+    assert controller._execute_step_with_retries("step", max_retries=2) is False
+    assert any("Exception after 2 retries" in msg for msg in view.logs)
+
+
+def test_create_step_checkpoint_appends_to_history() -> None:
+    controller = _make_controller()
+    record = _record_with_result()
+    record.phase_history = []
+    controller.context = PhaseContext(record=record, operator="op")
+    controller.phase = Mock()
+    controller.phase.phase_type = "SSA_CHAR"
+
+    controller._create_step_checkpoint(
+        "verify_initial_state",
+        PhaseStepResult(
+            result=PhaseResult.SUCCESS, message="ok", data={"a": 1}
+        ),
+    )
+
+    assert len(record.phase_history) == 1
+    assert record.phase_history[0].step_name == "verify_initial_state"
+    assert record.phase_history[0].success is True
+
+
+# ------------------------------------------------------------------
+# Background phase finalization
+# ------------------------------------------------------------------
+
+
+def test_finalize_background_phase_emits_success() -> None:
+    controller = _make_controller()
+    controller.phase = Mock()
+    emitted = []
+    controller.phase_run_finished.connect(
+        lambda ok, msg: emitted.append((ok, msg))
+    )
+
+    controller._finalize_background_phase()
+
+    assert emitted[-1] == (True, "")
+
+
+def test_finalize_background_phase_emits_failure_on_exception() -> None:
+    controller = _make_controller()
+    controller.phase = Mock()
+    controller.phase.finalize_phase.side_effect = RuntimeError("fail")
+    emitted = []
+    controller.phase_run_finished.connect(
+        lambda ok, msg: emitted.append((ok, msg))
+    )
+
+    controller._finalize_background_phase()
+
+    assert emitted[-1] == (False, "fail")
+
+
+def test_on_phase_run_finished_routes_to_completed() -> None:
+    controller = _make_controller()
+    controller.on_phase_completed = Mock()
+    controller.on_phase_failed = Mock()
+
+    controller._on_phase_run_finished(True, "")
+
+    controller.on_phase_completed.assert_called_once()
+    controller.on_phase_failed.assert_not_called()
+
+
+def test_on_phase_run_finished_routes_to_failed_with_message() -> None:
+    controller = _make_controller()
+    controller.on_phase_completed = Mock()
+    controller.on_phase_failed = Mock()
+
+    controller._on_phase_run_finished(False, "boom")
+
+    controller.on_phase_failed.assert_called_once_with("boom")
+
+
+def test_on_phase_run_finished_uses_default_error_message() -> None:
+    controller = _make_controller()
+    controller.on_phase_completed = Mock()
+    controller.on_phase_failed = Mock()
+
+    controller._on_phase_run_finished(False, "")
+
+    controller.on_phase_failed.assert_called_once_with("Phase execution failed")
+
+
+# ------------------------------------------------------------------
+# _run_phase_in_background
+# ------------------------------------------------------------------
+
+
+def test_run_phase_in_background_abort_path(monkeypatch) -> None:
+    controller = _make_controller()
+    controller.phase = Mock()
+    controller.phase.get_phase_steps.return_value = ["step"]
+    controller._check_pause_and_abort = Mock(return_value=False)
+    monkeypatch.setattr(controller_module, "Thread", _ThreadStub)
+
+    controller._run_phase_in_background()
+
+
+def test_run_phase_in_background_step_fails_emits_signal(monkeypatch) -> None:
+    controller = _make_controller()
+    controller.phase = Mock()
+    controller.phase.get_phase_steps.return_value = ["step"]
+    controller._check_pause_and_abort = Mock(return_value=True)
+    controller._execute_single_step = Mock(return_value=False)
+    emitted = []
+    controller.phase_run_finished.connect(
+        lambda ok, msg: emitted.append((ok, msg))
+    )
+    monkeypatch.setattr(controller_module, "Thread", _ThreadStub)
+
+    controller._run_phase_in_background()
+
+    assert emitted[-1] == (False, "Step failed: step")
+
+
+def test_run_phase_in_background_exception_emits_signal(monkeypatch) -> None:
+    controller = _make_controller()
+    controller.phase = Mock()
+    controller.phase.get_phase_steps.side_effect = RuntimeError("worker fail")
+    emitted = []
+    controller.phase_run_finished.connect(
+        lambda ok, msg: emitted.append((ok, msg))
+    )
+    monkeypatch.setattr(controller_module, "Thread", _ThreadStub)
+
+    controller._run_phase_in_background()
+
+    assert emitted[-1] == (False, "worker fail")
+
+
+# ------------------------------------------------------------------
+# on_phase_completed
+# ------------------------------------------------------------------
+
+
+def test_on_phase_completed_success_resets_buttons() -> None:
+    view = _ViewStub()
+    session = Mock()
+    session.save_active_record.return_value = True
+    session.get_active_record_id.return_value = 42
+    controller = _make_controller(view=view, session=session)
+    controller.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+    controller._active_phase_instance_id = 3
+    controller._append_measurement_history = Mock()
+    captured = []
+    controller.phase_completed.connect(lambda rec: captured.append(rec))
+
+    controller.on_phase_completed()
+
+    assert view.run_button.enabled is True
+    assert view.pause_button.enabled is False
+    assert controller._active_phase_instance_id is None
+    assert captured
+
+
+def test_on_phase_completed_save_fails_logs_warning() -> None:
+    view = _ViewStub()
+    session = Mock()
+    session.save_active_record.return_value = False
+    controller = _make_controller(view=view, session=session)
+    controller.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+    controller._append_measurement_history = Mock()
+
+    controller.on_phase_completed()
+
+    assert any("failed to save" in msg.lower() for msg in view.logs)
+
+
+def test_on_phase_completed_no_ssa_char_data_logs_warning() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view, session=Mock())
+    record = CommissioningRecord(linac=1, cryomodule="02", cavity_number=1)
+    record.ssa_char = None
+    controller.context = PhaseContext(record=record, operator="op")
+
+    controller.on_phase_completed()
+
+    assert any("no ssa_char data" in msg.lower() for msg in view.logs)
+
+
+def test_on_phase_completed_exception_calls_fail_instance() -> None:
+    session = Mock()
+    session.save_active_record.side_effect = RuntimeError("db down")
+    controller = _make_controller(session=session)
+    controller.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+    controller._active_phase_instance_id = 5
+
+    controller.on_phase_completed()
+
+    session.fail_active_phase_instance.assert_called_once()
+
+
+# ------------------------------------------------------------------
+# on_phase_failed
+# ------------------------------------------------------------------
+
+
+def test_on_phase_failed_resets_buttons_and_shows_error() -> None:
+    view = _ViewStub()
+    session = Mock()
+    session.save_active_record.return_value = True
+    controller = _make_controller(view=view, session=session)
+    controller.phase = Mock()
+    controller.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+    controller._active_phase_instance_id = 9
+    controller._append_measurement_history = Mock()
+
+    controller.on_phase_failed("bad")
+
+    assert view.run_button.enabled is True
+    assert view.pause_button.enabled is False
+    assert view.abort_button.enabled is False
+    assert any("bad" in msg for msg in view.errors)
+    session.fail_active_phase_instance.assert_called_once()
+
+
+def test_on_phase_failed_exception_still_calls_fail_instance() -> None:
+    session = Mock()
+    session.save_active_record.side_effect = RuntimeError("db exploded")
+    controller = _make_controller(session=session)
+    controller.phase = Mock()
+    controller.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+    controller._active_phase_instance_id = 10
+
+    controller.on_phase_failed("orig")
+
+    session.fail_active_phase_instance.assert_called_once()
+
+
+# ------------------------------------------------------------------
+# on_push_slope
+# ------------------------------------------------------------------
+
+
+def test_on_push_slope_calls_cavity_push(monkeypatch) -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    cavity = Mock()
+    controller._cavity = cavity
+    monkeypatch.setattr(controller_module, "Thread", _ThreadStub)
+
+    controller.on_push_slope()
+
+    cavity.push_ssa_slope.assert_called_once()
+    assert any("SSA slope pushed" in msg for msg in view.logs)
+
+
+def test_on_push_slope_logs_exception(monkeypatch) -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    cavity = Mock()
+    cavity.push_ssa_slope.side_effect = RuntimeError("push fail")
+    controller._cavity = cavity
+    monkeypatch.setattr(controller_module, "Thread", _ThreadStub)
+
+    controller.on_push_slope()
+
+    assert any("Push failed" in msg for msg in view.logs)
+
+
+def test_on_push_slope_no_cavity_logs_message() -> None:
+    view = _ViewStub(cavity=None)
+    _make_controller(view=view).on_push_slope()
+    assert any("No cavity selected" in msg for msg in view.logs)
+
+
+# ------------------------------------------------------------------
+# on_plot
+# ------------------------------------------------------------------
+
+
+def test_on_plot_no_directory_logs_message(monkeypatch, tmp_path) -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller._cavity = Mock()
+    controller._cavity.pv_prefix = "ACCL:L0B:0110:"
+    monkeypatch.setattr(
+        controller_module, "get_ssa_cal_base_dir", lambda: tmp_path
+    )
+
+    controller.on_plot()
+
+    assert any("No SSA cal directory" in msg for msg in view.logs)
+
+
+def test_on_plot_no_png_found(monkeypatch, tmp_path) -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller._cavity = Mock()
+    controller._cavity.pv_prefix = "ACCL:L0B:0110:"
+    monkeypatch.setattr(
+        controller_module, "get_ssa_cal_base_dir", lambda: tmp_path
+    )
+    (tmp_path / "ACCL_L0B_0110" / "ACCL_L0B_0110_20251203_081722").mkdir(
+        parents=True
+    )
+
+    controller.on_plot()
+
+    assert any("No ssa_cal.png" in msg for msg in view.logs)
+
+
+def test_on_plot_finds_most_recent_png_and_shows(monkeypatch, tmp_path) -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller._cavity = Mock()
+    controller._cavity.pv_prefix = "ACCL:L0B:0110:"
+    monkeypatch.setattr(
+        controller_module, "get_ssa_cal_base_dir", lambda: tmp_path
+    )
+    subdir = tmp_path / "ACCL_L0B_0110" / "ACCL_L0B_0110_20251203_081722"
+    subdir.mkdir(parents=True)
+    png = subdir / "ssa_cal.png"
+    png.write_bytes(b"")
+    controller._show_plot = Mock()
+
+    controller.on_plot()
+
+    controller._show_plot.assert_called_once_with(png)
+
+
+# ------------------------------------------------------------------
+# _resolve_cavity
+# ------------------------------------------------------------------
+
+
+def test_resolve_cavity_returns_cached() -> None:
+    controller = _make_controller()
+    cavity = Mock()
+    controller._cavity = cavity
+
+    assert controller._resolve_cavity() is cavity
+
+
+def test_resolve_cavity_looks_up_from_view() -> None:
+    controller = _make_controller()
+    mock_cavity = Mock()
+    controller._parse_cavity_from_record = Mock(return_value=(2, 1))
+    controller._get_machine_cavity = Mock(return_value=mock_cavity)
+
+    result = controller._resolve_cavity()
+
+    assert result is mock_cavity
+
+
+def test_resolve_cavity_no_info_logs_and_returns_none() -> None:
+    view = _ViewStub(cavity=None)
+    controller = _make_controller(view=view)
+
+    assert controller._resolve_cavity() is None
+    assert "No cavity selected" in view.logs
+
+
+# ------------------------------------------------------------------
+# _append_measurement_history
+# ------------------------------------------------------------------
+
+
+def test_append_measurement_history_no_context_is_noop() -> None:
+    session = Mock()
+    controller = _make_controller(session=session)
+    controller.context = None
+
+    controller._append_measurement_history()
+
+    session.add_measurement_to_history.assert_not_called()
+
+
+def test_append_measurement_history_calls_session_with_instance_id() -> None:
+    session = Mock()
+    controller = _make_controller(session=session)
+    controller.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+    controller._active_phase_instance_id = 42
+
+    controller._append_measurement_history()
+
+    kwargs = session.add_measurement_to_history.call_args[1]
+    assert kwargs["phase_instance_id"] == 42
+    assert kwargs["operator"] == "op"
+
+
+def test_append_measurement_history_adds_error_note() -> None:
+    session = Mock()
+    controller = _make_controller(session=session)
+    controller.context = PhaseContext(
+        record=_record_with_result(), operator="op"
+    )
+
+    controller._append_measurement_history(error_msg="boom")
+
+    kwargs = session.add_measurement_to_history.call_args[1]
+    assert kwargs["notes"] == "Phase failed: boom"
+
+
+# ------------------------------------------------------------------
+# _auto_create_record
+# ------------------------------------------------------------------
+
+
+def test_auto_create_record_no_cavity_shows_error() -> None:
+    view = _ViewStub()
+    controller = _make_controller(view=view)
+    controller._get_cavity_from_parent = Mock(return_value=(None, None))
+
+    assert controller._auto_create_record() is False
+    assert view.errors
+
+
+def test_auto_create_record_success() -> None:
+    session = Mock()
+    session.start_new_record.return_value = (_record_with_result(), 10, True)
+    view = _ViewStub()
+    controller = _make_controller(view=view, session=session)
+    controller._get_cavity_from_parent = Mock(return_value=("02", "1"))
+    controller.update_pv_addresses = Mock()
+
+    assert controller._auto_create_record() is True
+
+
+def test_auto_create_record_exception_shows_error() -> None:
+    session = Mock()
+    session.start_new_record.side_effect = RuntimeError("db down")
+    view = _ViewStub()
+    controller = _make_controller(view=view, session=session)
+    controller._get_cavity_from_parent = Mock(return_value=("02", "1"))
+
+    assert controller._auto_create_record() is False
+    assert view.errors
+
+
+# ------------------------------------------------------------------
+# _get_cavity_from_parent
+# ------------------------------------------------------------------
+
+
+class _Combo:
+    def __init__(self, text):
+        self._text = text
+
+    def currentText(self):
+        return self._text
+
+
+class _ParentWithCombos:
+    def __init__(self, cm="02", cav="1"):
+        self.cryomodule_combo = _Combo(cm)
+        self.cavity_combo = _Combo(cav)
+
+    def parent(self):
+        return None
+
+
+def test_get_cavity_from_parent_returns_selection() -> None:
+    controller = _make_controller()
+    controller.view.parent = lambda: _ParentWithCombos(cm="02", cav="1")
+
+    assert controller._get_cavity_from_parent() == ("02", "1")
+
+
+def test_get_cavity_from_parent_empty_returns_none() -> None:
+    controller = _make_controller()
+    controller.view.parent = lambda: _ParentWithCombos(cm="", cav="")
+
+    assert controller._get_cavity_from_parent() == (None, None)
+
+
+def test_get_cavity_from_parent_no_parent_returns_none() -> None:
+    controller = _make_controller()
+    controller.view.parent = lambda: None
+
+    assert controller._get_cavity_from_parent() == (None, None)

--- a/tests/applications/rf_commissioning/ui/builders/test_phase_builders.py
+++ b/tests/applications/rf_commissioning/ui/builders/test_phase_builders.py
@@ -8,6 +8,7 @@ from PyQt5.QtWidgets import QGroupBox, QHBoxLayout, QWidget
 from sc_linac_physics.applications.rf_commissioning.ui.builders.phase_builders import (
     GenericPhaseUI,
     PiezoPreRFUI,
+    SSACharUI,
 )
 
 
@@ -127,3 +128,83 @@ def test_generic_phase_title_falls_back_to_default():
     ui = GenericPhaseUI(parent=_ParentWidget())
 
     assert ui.PHASE_TITLE == "Phase"
+
+
+# ------------------------------------------------------------------
+# SSACharUI
+# ------------------------------------------------------------------
+
+
+def test_ssa_char_build_creates_two_panel_layout():
+    parent = _ParentWidget(
+        specs=[SimpleNamespace(label="Operator", widget_name="stored_operator")]
+    )
+    ui = SSACharUI(parent=parent)
+
+    layout = ui.build()
+    host = _mount(layout)
+
+    assert layout.count() == 2
+    titles = {group.title() for group in host.findChildren(QGroupBox)}
+    assert "SSA Calibration Inputs" in titles
+    assert "Phase History" in titles
+    assert "SSA Calibration — Status && Results" in titles
+    assert "Stored Data" in titles
+
+
+def test_ssa_char_build_registers_input_widgets():
+    ui = SSACharUI(parent=_ParentWidget())
+
+    group = ui._build_ssa_inputs()  # noqa: F841
+
+    spinbox = ui.widgets["drive_max_spinbox"]
+    assert spinbox.minimum() == pytest.approx(0.01)
+    assert spinbox.maximum() == pytest.approx(1.0)
+    assert spinbox.value() == pytest.approx(0.670)
+    assert "plot_btn" in ui.widgets
+
+
+def test_ssa_char_build_registers_result_widgets():
+    ui = SSACharUI(parent=_ParentWidget())
+
+    group = ui._build_ssa_results()  # noqa: F841
+
+    for name in (
+        "pydm_slope_new",
+        "pydm_slope_current",
+        "pydm_drive_max_req",
+        "pydm_drive_max_current",
+        "pydm_max_fwd_pwr",
+        "pydm_cal_status",
+        "local_phase_status",
+        "local_current_step",
+        "push_btn",
+    ):
+        assert name in ui.widgets, f"Missing widget: {name}"
+
+
+def test_ssa_char_push_button_label():
+    ui = SSACharUI(parent=_ParentWidget())
+    group = ui._build_ssa_results()  # noqa: F841
+    assert "Push New Slope to Cavity" in ui.widgets["push_btn"].text()
+
+
+def test_ssa_char_pv_labels_default_text():
+    ui = SSACharUI(parent=_ParentWidget())
+    group = ui._build_ssa_results()  # noqa: F841
+    assert ui.widgets["local_phase_status"].text() == "-"
+    assert ui.widgets["local_current_step"].text() == "-"
+
+
+def test_ssa_char_build_registers_stored_fields_from_parent():
+    parent = _ParentWidget(
+        specs=[
+            SimpleNamespace(label="Operator", widget_name="stored_operator"),
+            SimpleNamespace(label="Slope", widget_name="stored_slope"),
+        ]
+    )
+    ui = SSACharUI(parent=parent)
+    _mount(ui.build())
+
+    assert "stored_operator" in ui.widgets
+    assert "stored_slope" in ui.widgets

--- a/tests/applications/rf_commissioning/ui/builders/test_phase_builders.py
+++ b/tests/applications/rf_commissioning/ui/builders/test_phase_builders.py
@@ -98,9 +98,7 @@ def test_piezo_build_registers_stored_fields_from_parent_specs():
     assert "stored_amp" in ui.widgets
 
 
-@pytest.mark.parametrize(
-    "phase_title", ["Frequency Tuning", "SSA Characterization"]
-)
+@pytest.mark.parametrize("phase_title", ["Frequency Tuning", "SSA Calibration"])
 def test_generic_phase_ui_builds_standard_layout(phase_title):
     parent = _ParentWidget(
         specs=[SimpleNamespace(label="Tag", widget_name="stored_tag")],

--- a/tests/applications/rf_commissioning/ui/builders/test_phase_builders.py
+++ b/tests/applications/rf_commissioning/ui/builders/test_phase_builders.py
@@ -172,7 +172,7 @@ def test_ssa_char_build_registers_result_widgets():
     for name in (
         "pydm_slope_new",
         "pydm_slope_current",
-        "pydm_drive_max_req",
+        "pydm_drive_max_new",
         "pydm_drive_max_current",
         "pydm_max_fwd_pwr",
         "pydm_cal_status",

--- a/tests/applications/rf_commissioning/ui/builders/test_phase_builders.py
+++ b/tests/applications/rf_commissioning/ui/builders/test_phase_builders.py
@@ -3,7 +3,8 @@
 from types import SimpleNamespace
 
 import pytest
-from PyQt5.QtWidgets import QGroupBox, QHBoxLayout, QWidget
+from PyQt5.QtWidgets import QDoubleSpinBox, QGroupBox, QHBoxLayout, QWidget
+from pydm.widgets import PyDMSpinbox
 
 from sc_linac_physics.applications.rf_commissioning.ui.builders.phase_builders import (
     GenericPhaseUI,
@@ -158,9 +159,17 @@ def test_ssa_char_build_registers_input_widgets():
     group = ui._build_ssa_inputs()  # noqa: F841
 
     spinbox = ui.widgets["drive_max_spinbox"]
+    assert isinstance(spinbox, PyDMSpinbox)
     assert spinbox.minimum() == pytest.approx(0.01)
     assert spinbox.maximum() == pytest.approx(1.0)
-    assert spinbox.value() == pytest.approx(0.670)
+    assert spinbox.userDefinedLimits is True
+    assert spinbox.userMinimum == pytest.approx(0.01)
+    assert spinbox.userMaximum == pytest.approx(1.0)
+    assert spinbox.precisionFromPV is False
+    assert spinbox.precision == 3
+    assert spinbox.writeOnPress is True
+    spinbox.setValue(0.8)
+    assert QDoubleSpinBox.value(spinbox) == pytest.approx(0.8)
     assert "plot_btn" in ui.widgets
 
 

--- a/tests/applications/rf_commissioning/ui/test_displays.py
+++ b/tests/applications/rf_commissioning/ui/test_displays.py
@@ -27,6 +27,8 @@ from sc_linac_physics.applications.rf_commissioning.ui.displays.registry import 
 )
 from sc_linac_physics.applications.rf_commissioning.ui.displays.standard import (
     FrequencyTuningDisplay,
+)
+from sc_linac_physics.applications.rf_commissioning.ui.displays.ssa_char import (
     SSACharDisplay,
 )
 from sc_linac_physics.applications.rf_commissioning.ui.phase_display_base import (

--- a/tests/applications/tuning/conftest.py
+++ b/tests/applications/tuning/conftest.py
@@ -214,6 +214,10 @@ def cavity_section_patches():
             "sc_linac_physics.applications.tuning.tuning_gui.CollapsibleGroupBox",
             MockCollapsibleGroupBox,
         ),
+        patch(
+            "sc_linac_physics.applications.tuning.tuning_gui.PyDMSpinbox",
+            MockPyDMSpinbox,
+        ),
     ):
         yield
 


### PR DESCRIPTION

### Summary
This PR implements a fully functional SSA Calibration phase for the RF commissioning application, replacing the previous placeholder with a complete workflow that includes phase execution logic, UI controls, PV integration, and automated validation.

### Changes Overview

#### 1. **Data Model Updates** (`data_models.py`)
- **Replaced** legacy fields (`initial_drive`, `num_attempts`) with new fields:
  - `slope_new`: New calibration slope value (5 decimal precision)
  - `max_fwd_pwr_w`: Maximum forward power in Watts
  - `calibration_passed`: Boolean pass/fail status with custom display text
- **Removed** computed properties: `initial_drive_percent`, `drive_reduction`, `succeeded_first_try`
- **Retained** `max_drive_percent` and updated `is_complete` to check for `slope_new`
- **Updated** `passed` property to return `calibration_passed` value
- Updated display label from "SSA Characterization" to "SSA Calibration"

#### 2. **Phase Logic** (`phases/ssa_char.py`) - **NEW**
Implements `SSACharPhase` with a 6-step automated workflow:

1. **`verify_initial_state`**: Checks SSA is not mid-calibration and reads initial values
2. **`set_drive_max`**: Writes requested drive max to SSA
3. **`reset_and_power_on`**: Resets faults, powers on SSA, clears cavity interlocks
4. **`start_calibration`**: Triggers calibration scan via EPICS PV
5. **`wait_for_completion`**: Polls calibration status with timeout protection
6. **`validate_and_push`**: Validates results (forward power, slope tolerance) and auto-pushes new slope to cavity register

**Features:**
- Configurable limits via `SSACalLimits` dataclass
- Automatic retry logic for transient errors
- Pause/abort support throughout execution
- Dry-run mode for testing
- Comprehensive error handling with specific failure messages

#### 3. **Controller** (`ui/controllers/ssa_char_controller.py`) - **NEW**
Manages display logic, phase execution orchestration, and PV connections:

- **PV Management**: Auto-wires SSA PVs (slope, drive max, cal status, forward power)
- **Phase Execution**: 
  - Validates prerequisites before execution
  - Runs phase asynchronously in background thread
  - Tracks phase instance ID for database persistence
  - Auto-creates records if none active
- **User Actions**:
  - Manual "Push Slope" button to re-apply calibration
  - "Plot" button to display most recent calibration plot from filesystem
- **State Management**: Updates UI state (buttons, progress, status labels) throughout execution

#### 4. **UI Builder** (`ui/builders/phase_builders.py`)
Implements `SSACharUI` with two-panel layout:

**Left Panel:**
- Input controls (drive max spinbox, plot button)
- Phase history log
- Main toolbar (run/pause/abort)

**Right Panel:**
- Live PV readouts with 3-column grid:
  - **New** (calibration results)
  - **Current** (active values)
  - Labels: SSA Slope, Drive Max, Max Fwd Pwr, Cal Status
- Local phase status indicators
- Manual "Push New Slope to Cavity" button
- Stored data section (operator, timestamp, etc.)

**Styling:** Unified grid layout with color-coded headers, improved spacing/alignment

#### 5. **Display** (`ui/displays/ssa_char.py`) - **NEW**
`SSACharDisplay` integrates controller and UI:

- Connects controller signals (`phase_completed`, PV updates)
- Implements slot handlers for user actions
- Updates local result indicators (PASS/FAIL with color coding)
- Refreshes stored data readouts from record
- Notifies parent container on phase completion

#### 6. **SSA Utilities** (`utils/sc_linac/ssa.py`)
Added new PV addresses:
- `drive_max_new_pv`: New drive max from calibration
- `drive_max_current_pv`: Currently active drive max
- `saved_slope_pv`: Saved slope value

#### 7. **Platform Paths** (`utils/platform_paths.py`)
Added `get_ssa_cal_base_dir()` to locate calibration plot storage:
- Linux: `/u1/lcls/physics/rf_lcls2/ssa_cal`
- Dev: `~/ssa_cal`

#### 8. **Simulation Updates**
- `CavityPVGroup`: Implemented `push_ssa_slope` logic to copy `slope_new` → `slope_old`
- `SSAPVGroup`: Added `drive_max_new` and `drive_max_current` PVs, auto-populated during calibration

#### 9. **Testing**
Added comprehensive test coverage:
- **`test_ssa_char.py`**: 450+ lines covering all phase steps, edge cases, error paths
- **`test_ssa_char_controller.py`**: 981 lines covering controller logic, PV wiring, UI state, async execution
- **`test_phase_builders.py`**: UI widget registration and layout validation
- Updated existing tests for data model changes

#### 10. **Registration & Visibility**
- Added `SSACharPhase` to `phases/__init__.py`
- Added `SSACharUI` to `ui/builders/__init__.py`
- Updated `DEFAULT_BETA_VISIBLE_PHASES` to include `SSA_CHAR`
- Registered display in `ui/displays/registry.py`

### Migration Notes

**Breaking Changes:**
- `SSACharacterization` fields renamed/removed:
  - ❌ `initial_drive`, `num_attempts` → ✅ `slope_new`, `max_fwd_pwr_w`, `calibration_passed`
  - Computed properties `drive_reduction`, `succeeded_first_try` removed

**Database:** Existing records will need migration to populate new fields or handle `None` values gracefully.

### Testing Instructions

1. **Unit Tests**: Run `pytest tests/applications/rf_commissioning/phases/test_ssa_char.py -v`
2. **Simulation Mode**:
   ```bash
   # Terminal 1: Start IOC simulator
   python -m sc_linac_physics.utils.simulation.sc_linac_physics_service
   
   # Terminal 2: Launch UI
   pydm path/to/multi_phase_screen.py
   ```
3. **Workflow Validation**:
   - Select CM02, Cavity 1
   - Navigate to "SSA Calibration" tab
   - Set drive max (default 0.670)
   - Click "Run Calibration"
   - Verify all 6 steps execute
   - Check stored data updates with calibration results
   - Test pause/abort mid-execution
   - Click "Push New Slope to Cavity" to manually apply
   - Click "Plot" to view calibration curve (requires filesystem data)

### Screenshots/Demo

https://github.com/user-attachments/assets/5b26a5d1-b759-4817-b439-74b46060aa75



### Related Issues
- Closes #XXX (if applicable)
- Related to SSA calibration automation initiative

---

**Checklist:**
- [x] Unit tests added/updated
- [x] Integration with existing phase workflow
- [x] Documentation comments in code
- [x] Backward compatibility considered (migration notes provided)
- [x] Simulation service updated for testing