### PR TITLE
refactor(rf-commissioning): enforce session facade, extract dialog, convert container to mixins

### DIFF
--- a/src/sc_linac_physics/applications/rf_commissioning/session_manager.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/session_manager.py
@@ -5,6 +5,9 @@ Coordinates database access and record management across all commissioning phase
 
 import logging
 
+from sc_linac_physics.applications.rf_commissioning.models.cryomodule_models import (
+    CryomoduleCheckoutRecord,
+)
 from sc_linac_physics.applications.rf_commissioning.models.data_models import (
     CommissioningRecord,
     CommissioningPhase,
@@ -600,3 +603,65 @@ class CommissioningSession:
         except Exception as e:
             logger.exception("Failed to update general note: %s", e)
             return False
+
+    # ==================== RECORD QUERY METHODS ====================
+
+    def get_record_with_version(
+        self, record_id: int
+    ) -> tuple[CommissioningRecord, int] | None:
+        return self.db.get_record_with_version(record_id)
+
+    def save_record(
+        self,
+        record: CommissioningRecord,
+        record_id: int | None = None,
+        expected_version: int | None = None,
+    ) -> int:
+        return self.db.save_record(record, record_id, expected_version)
+
+    def find_records_for_cavity(
+        self, linac: int, cryomodule: str, cavity_number: str
+    ) -> list[dict]:
+        return self.db.find_records_for_cavity(linac, cryomodule, cavity_number)
+
+    def get_record_id_for_cavity(
+        self, linac: int, cryomodule: str, cavity_number: str
+    ) -> int | None:
+        return self.db.get_record_id_for_cavity(
+            linac, cryomodule, cavity_number
+        )
+
+    def get_active_record_version(self) -> int | None:
+        return self._active_record_version
+
+    # ==================== CRYOMODULE METHODS ====================
+
+    def get_cryomodule_record(
+        self, linac: str, cryomodule: str
+    ) -> CryomoduleCheckoutRecord | None:
+        return self.db.get_cryomodule_record(linac, cryomodule)
+
+    def get_cryomodule_record_with_version(
+        self, linac: str, cryomodule: str
+    ) -> tuple[CryomoduleCheckoutRecord, int] | None:
+        return self.db.get_cryomodule_record_with_version(linac, cryomodule)
+
+    def get_cryomodule_record_id(
+        self, linac: str, cryomodule: str
+    ) -> int | None:
+        return self.db.get_cryomodule_record_id(linac, cryomodule)
+
+    def save_cryomodule_record(
+        self,
+        record: CryomoduleCheckoutRecord,
+        record_id: int | None = None,
+        expected_version: int | None = None,
+    ) -> int:
+        return self.db.save_cryomodule_record(
+            record, record_id, expected_version
+        )
+
+    def get_records_by_cryomodule(
+        self, linac: int, cryomodule: str, active_only: bool = False
+    ) -> list[CommissioningRecord]:
+        return self.db.get_records_by_cryomodule(linac, cryomodule, active_only)

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/container/__init__.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/container/__init__.py
@@ -3,12 +3,14 @@
 from .phase_specs import PhaseTabSpec, build_default_phase_specs
 from .progress import build_progress_phases
 from .progress_panel import (
+    _ProgressMixin,
     build_compact_progress_bar,
     update_progress_indicator,
 )
-from .header import build_header_panel
-from .notes import build_enhanced_notes_panel, load_notes
+from .header import _HeaderMixin, build_header_panel
+from .notes import _NotesPanelMixin, build_enhanced_notes_panel, load_notes
 from .note_actions import (
+    _NoteActionsMixin,
     build_note_dialog,
     get_selected_note_ref,
     on_edit_note,
@@ -16,6 +18,7 @@ from .note_actions import (
     show_notes_context_menu,
 )
 from .records import (
+    _RecordSelectorMixin,
     confirm_and_start_new,
     load_selected_record,
     on_load_or_start,
@@ -23,6 +26,7 @@ from .records import (
     start_new_from_dialog,
 )
 from .sync import (
+    _SyncMixin,
     check_for_external_changes,
     dismiss_banner,
     handle_note_conflict,
@@ -31,18 +35,21 @@ from .sync import (
     update_sync_status,
 )
 from .persistence import (
+    _PersistenceMixin,
     handle_save_conflict,
     save_active_record,
     show_database_browser,
     show_measurement_history,
 )
 from .record_lifecycle import (
+    _RecordLifecycleMixin,
     load_record,
     on_phase_advanced,
     start_new_record,
     sync_cavity_selection_from_record,
 )
 from .tab_state import (
+    _TabsMixin,
     get_phase_icon,
     init_tabs,
     on_tab_changed,
@@ -53,6 +60,17 @@ __all__ = [
     "PhaseTabSpec",
     "build_default_phase_specs",
     "build_progress_phases",
+    # Mixin classes
+    "_HeaderMixin",
+    "_ProgressMixin",
+    "_NotesPanelMixin",
+    "_NoteActionsMixin",
+    "_RecordSelectorMixin",
+    "_SyncMixin",
+    "_PersistenceMixin",
+    "_RecordLifecycleMixin",
+    "_TabsMixin",
+    # Backward-compat function aliases
     "build_compact_progress_bar",
     "update_progress_indicator",
     "build_header_panel",

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/container/header.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/container/header.py
@@ -17,144 +17,147 @@ from sc_linac_physics.applications.rf_commissioning.ui.magnet_status_badge impor
 )
 
 
-def build_header_panel(host) -> QWidget:
-    """Build persistent header with operator and cavity selection."""
-    header = QWidget()
-    header.setStyleSheet("""
-            QWidget {
-                background-color: #2b2b2b;
-                border-bottom: 2px solid #4a4a4a;
-            }
-            QGroupBox {
-                font-weight: bold;
-                border: 1px solid #555;
-                border-radius: 5px;
-                margin-top: 6px;
-                padding-top: 10px;
-            }
-            QGroupBox::title {
-                subcontrol-origin: margin;
-                left: 10px;
-                padding: 0 5px;
-            }
-        """)
-    layout = QHBoxLayout()
-    layout.setContentsMargins(10, 10, 10, 10)
+class _HeaderMixin:
+    def _build_header_panel(self) -> QWidget:
+        """Build persistent header with operator and cavity selection."""
+        header = QWidget()
+        header.setStyleSheet("""
+                QWidget {
+                    background-color: #2b2b2b;
+                    border-bottom: 2px solid #4a4a4a;
+                }
+                QGroupBox {
+                    font-weight: bold;
+                    border: 1px solid #555;
+                    border-radius: 5px;
+                    margin-top: 6px;
+                    padding-top: 10px;
+                }
+                QGroupBox::title {
+                    subcontrol-origin: margin;
+                    left: 10px;
+                    padding: 0 5px;
+                }
+            """)
+        layout = QHBoxLayout()
+        layout.setContentsMargins(10, 10, 10, 10)
 
-    # Cavity section - comes FIRST (don't need operator to browse)
-    cavity_group = QGroupBox("Cavity Selection")
-    cavity_layout = QHBoxLayout()
+        cavity_group = QGroupBox("Cavity Selection")
+        cavity_layout = QHBoxLayout()
 
-    host.cryomodule_combo = QComboBox()
-    host.cryomodule_combo.setMinimumWidth(80)
-    host.cryomodule_combo.addItem("Select CM...", "")
-    host.cryomodule_combo.addItems(sorted(ALL_CRYOMODULES))
-    cavity_layout.addWidget(QLabel("CM:"))
-    cavity_layout.addWidget(host.cryomodule_combo)
+        self.cryomodule_combo = QComboBox()
+        self.cryomodule_combo.setMinimumWidth(80)
+        self.cryomodule_combo.addItem("Select CM...", "")
+        self.cryomodule_combo.addItems(sorted(ALL_CRYOMODULES))
+        cavity_layout.addWidget(QLabel("CM:"))
+        cavity_layout.addWidget(self.cryomodule_combo)
 
-    host.cavity_combo = QComboBox()
-    host.cavity_combo.setMinimumWidth(60)
-    host.cavity_combo.addItem("Select Cav...", "")
-    host.cavity_combo.addItems([str(i) for i in range(1, 9)])
-    cavity_layout.addWidget(QLabel("Cav:"))
-    cavity_layout.addWidget(host.cavity_combo)
+        self.cavity_combo = QComboBox()
+        self.cavity_combo.setMinimumWidth(60)
+        self.cavity_combo.addItem("Select Cav...", "")
+        self.cavity_combo.addItems([str(i) for i in range(1, 9)])
+        cavity_layout.addWidget(QLabel("Cav:"))
+        cavity_layout.addWidget(self.cavity_combo)
 
-    cavity_group.setLayout(cavity_layout)
-    layout.addWidget(cavity_group)
+        cavity_group.setLayout(cavity_layout)
+        layout.addWidget(cavity_group)
 
-    # Cavity completion counter
-    host.cavity_completion_label = QLabel("0/8 Complete")
-    host.cavity_completion_label.setStyleSheet("""
-            QLabel {
-                color: #aaa;
-                font-weight: bold;
-                padding: 5px 10px;
-                background-color: rgba(100, 100, 100, 0.2);
-                border-radius: 3px;
-                font-size: 9px;
-            }
-        """)
-    host.cavity_completion_label.setMaximumWidth(100)
-    layout.addWidget(host.cavity_completion_label)
+        self.cavity_completion_label = QLabel("0/8 Complete")
+        self.cavity_completion_label.setStyleSheet("""
+                QLabel {
+                    color: #aaa;
+                    font-weight: bold;
+                    padding: 5px 10px;
+                    background-color: rgba(100, 100, 100, 0.2);
+                    border-radius: 3px;
+                    font-size: 9px;
+                }
+            """)
+        self.cavity_completion_label.setMaximumWidth(100)
+        layout.addWidget(self.cavity_completion_label)
 
-    # Update PVs and load record when cavity selection changes
-    host.cryomodule_combo.currentIndexChanged.connect(
-        host._on_cavity_selection_changed
-    )
-    host.cavity_combo.currentIndexChanged.connect(
-        host._on_cavity_selection_changed
-    )
+        self.cryomodule_combo.currentIndexChanged.connect(
+            self._on_cavity_selection_changed
+        )
+        self.cavity_combo.currentIndexChanged.connect(
+            self._on_cavity_selection_changed
+        )
 
-    # Separator
-    separator = QFrame()
-    separator.setFrameShape(QFrame.VLine)
-    separator.setFrameShadow(QFrame.Sunken)
-    separator.setStyleSheet("color: #555;")
-    layout.addWidget(separator)
+        separator = QFrame()
+        separator.setFrameShape(QFrame.VLine)
+        separator.setFrameShadow(QFrame.Sunken)
+        separator.setStyleSheet("color: #555;")
+        layout.addWidget(separator)
 
-    # Operator section - needed for running tests
-    op_group = QGroupBox("Operator (Required for Tests)")
-    op_layout = QHBoxLayout()
-    host.operator_combo = QComboBox()
-    host.operator_combo.setMinimumWidth(200)
-    host.operator_combo.currentIndexChanged.connect(host._on_operator_changed)
-    host._populate_operator_combo()
-    op_layout.addWidget(host.operator_combo)
-    op_group.setLayout(op_layout)
-    layout.addWidget(op_group)
+        op_group = QGroupBox("Operator (Required for Tests)")
+        op_layout = QHBoxLayout()
+        self.operator_combo = QComboBox()
+        self.operator_combo.setMinimumWidth(200)
+        self.operator_combo.currentIndexChanged.connect(
+            self._on_operator_changed
+        )
+        self._populate_operator_combo()
+        op_layout.addWidget(self.operator_combo)
+        op_group.setLayout(op_layout)
+        layout.addWidget(op_group)
 
-    # Sync status indicator
-    host.sync_status = QLabel("○ No Record Loaded")
-    host.sync_status.setStyleSheet("""
-            QLabel {
-                color: #888;
-                font-weight: bold;
-                padding: 5px 10px;
-                background-color: rgba(100, 100, 100, 0.2);
-                border-radius: 3px;
-            }
-        """)
-    layout.addWidget(host.sync_status)
+        self.sync_status = QLabel("○ No Record Loaded")
+        self.sync_status.setStyleSheet("""
+                QLabel {
+                    color: #888;
+                    font-weight: bold;
+                    padding: 5px 10px;
+                    background-color: rgba(100, 100, 100, 0.2);
+                    border-radius: 3px;
+                }
+            """)
+        layout.addWidget(self.sync_status)
 
-    # Magnet checkout section (prominent status + open action)
-    magnet_group = QGroupBox("Magnet Checkout")
-    magnet_layout = QVBoxLayout()
-    magnet_layout.setSpacing(6)
+        magnet_group = QGroupBox("Magnet Checkout")
+        magnet_layout = QVBoxLayout()
+        magnet_layout.setSpacing(6)
 
-    host.magnet_status_badge = MagnetStatusBadge()
-    host.magnet_status_badge.setToolTip("Cryomodule magnet checkout status")
-    host.magnet_status_badge.setMinimumWidth(120)
-    magnet_layout.addWidget(host.magnet_status_badge)
+        self.magnet_status_badge = MagnetStatusBadge()
+        self.magnet_status_badge.setToolTip("Cryomodule magnet checkout status")
+        self.magnet_status_badge.setMinimumWidth(120)
+        magnet_layout.addWidget(self.magnet_status_badge)
 
-    host.open_magnet_checkout_btn = QPushButton("Open Magnet Checkout")
-    host.open_magnet_checkout_btn.setToolTip(
-        "Open the cryomodule magnet checkout screen"
-    )
-    host.open_magnet_checkout_btn.clicked.connect(
-        host._open_magnet_checkout_screen
-    )
-    magnet_layout.addWidget(host.open_magnet_checkout_btn)
+        self.open_magnet_checkout_btn = QPushButton("Open Magnet Checkout")
+        self.open_magnet_checkout_btn.setToolTip(
+            "Open the cryomodule magnet checkout screen"
+        )
+        self.open_magnet_checkout_btn.clicked.connect(
+            self._open_magnet_checkout_screen
+        )
+        magnet_layout.addWidget(self.open_magnet_checkout_btn)
 
-    magnet_group.setLayout(magnet_layout)
-    layout.addWidget(magnet_group)
+        magnet_group.setLayout(magnet_layout)
+        layout.addWidget(magnet_group)
 
-    layout.addStretch()
+        layout.addStretch()
 
-    # Quick actions
-    batch_btn = QPushButton("Batch Pre-RF")
-    batch_btn.setToolTip("Run Piezo Pre-RF test on multiple cavities at once")
-    batch_btn.clicked.connect(host._open_batch_pre_rf_window)
-    layout.addWidget(batch_btn)
+        batch_btn = QPushButton("Batch Pre-RF")
+        batch_btn.setToolTip(
+            "Run Piezo Pre-RF test on multiple cavities at once"
+        )
+        batch_btn.clicked.connect(self._open_batch_pre_rf_window)
+        layout.addWidget(batch_btn)
 
-    history_btn = QPushButton("📊 Measurements")
-    history_btn.setToolTip("View all measurement attempts and filter by phase")
-    history_btn.clicked.connect(host._show_measurement_history)
-    layout.addWidget(history_btn)
+        history_btn = QPushButton("📊 Measurements")
+        history_btn.setToolTip(
+            "View all measurement attempts and filter by phase"
+        )
+        history_btn.clicked.connect(self._show_measurement_history)
+        layout.addWidget(history_btn)
 
-    database_btn = QPushButton("🗄️ Database")
-    database_btn.setToolTip("Browse and load commissioning records")
-    database_btn.clicked.connect(host._show_database_browser)
-    layout.addWidget(database_btn)
+        database_btn = QPushButton("🗄️ Database")
+        database_btn.setToolTip("Browse and load commissioning records")
+        database_btn.clicked.connect(self._show_database_browser)
+        layout.addWidget(database_btn)
 
-    header.setLayout(layout)
-    return header
+        header.setLayout(layout)
+        return header
+
+
+# Backward-compat alias so existing tests continue to work.
+build_header_panel = _HeaderMixin._build_header_panel

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/container/note_actions.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/container/note_actions.py
@@ -19,162 +19,169 @@ from sc_linac_physics.applications.rf_commissioning.models.persistence.database 
 )
 
 
-def quick_add_note(host) -> None:
-    """Quick note entry without complex dialog."""
-    if not host.session.has_active_record():
-        QMessageBox.warning(
-            host,
-            "No Record",
-            "Please load or create a commissioning record first.",
-        )
-        return
-
-    operator = host.operator_combo.currentData()
-    if not operator:
-        QMessageBox.warning(
-            host, "Operator Required", "Please select an operator first."
-        )
-        host.operator_combo.setFocus()
-        return
-
-    note, ok = QInputDialog.getMultiLineText(
-        host,
-        "Quick Note",
-        f"Operator: {host.operator_combo.currentText()}\n\nEnter note:",
-    )
-
-    if ok and note.strip():
-        try:
-            if host.session.append_general_note(operator, note.strip()):
-                host._load_notes()
-                host.notes_table.scrollToTop()
-        except RecordConflictError as conflict:
-            host._handle_note_conflict(conflict)
-
-
-def show_notes_context_menu(host, position) -> None:
-    """Show context menu for notes table."""
-    if host.notes_table.rowCount() == 0:
-        return
-
-    menu = QMenu(host)
-    edit_action = menu.addAction("✏️ Edit Note")
-
-    action = menu.exec_(host.notes_table.viewport().mapToGlobal(position))
-
-    if action == edit_action:
-        host._on_edit_note()
-
-
-def on_edit_note(host) -> None:
-    """Edit selected note."""
-    note_ref = get_selected_note_ref(host)
-    if not note_ref:
-        return
-
-    row = host.notes_table.currentRow()
-    current_operator = host.notes_table.item(row, 2).text()
-    current_note = host.notes_table.item(row, 3).text()
-
-    operator, note = build_note_dialog(
-        host, "Edit Note", current_operator, current_note
-    )
-    if not note:
-        return
-
-    note_type, ref_data = note_ref
-
-    if note_type == "general":
-        note_index = ref_data
-        try:
-            if host.session.update_general_note(note_index, operator, note):
-                host._load_notes()
-        except RecordConflictError as conflict:
-            host._handle_note_conflict(conflict)
-    elif note_type == "measurement":
-        entry_id, note_index = ref_data
-        if host.session.update_measurement_note(
-            entry_id, note_index, operator, note
-        ):
-            host._load_notes()
-
-
-def get_selected_note_ref(host):
-    """Get reference to selected note."""
-    selected = host.notes_table.selectedItems()
-    if not selected:
-        return None
-
-    row = selected[0].row()
-    return host.notes_table.item(row, 0).data(Qt.UserRole)
-
-
-def build_note_dialog(
-    host,
-    title: str,
-    operator_default: str,
-    note_default: str = "",
-) -> tuple[str | None, str | None]:
-    """Build note editing dialog."""
-    dialog = QDialog(host)
-    dialog.setWindowTitle(title)
-    dialog.setMinimumWidth(500)
-    layout = QVBoxLayout(dialog)
-
-    op_row = QHBoxLayout()
-    op_row.addWidget(QLabel("Operator:"))
-    operator_combo = QComboBox()
-    op_row.addWidget(operator_combo)
-    layout.addLayout(op_row)
-
-    layout.addWidget(QLabel("Note:"))
-    note_input = QTextEdit()
-    note_input.setPlainText(note_default)
-    note_input.setMinimumHeight(100)
-    layout.addWidget(note_input)
-
-    def populate_operator_combo(selected: str | None) -> None:
-        operator_combo.blockSignals(True)
-        operator_combo.clear()
-        operator_combo.addItem("Select operator...", "")
-        for name in host.session.get_operators():
-            operator_combo.addItem(name, name)
-        if selected and operator_combo.findData(selected) == -1:
-            operator_combo.addItem(selected, selected)
-        operator_combo.addItem("Add operator...", "__add__")
-        if selected:
-            idx = operator_combo.findData(selected)
-            if idx >= 0:
-                operator_combo.setCurrentIndex(idx)
-        operator_combo.blockSignals(False)
-
-    def on_operator_selected() -> None:
-        selection = operator_combo.currentData()
-        if selection != "__add__":
+class _NoteActionsMixin:
+    def _quick_add_note(self) -> None:
+        """Quick note entry without complex dialog."""
+        if not self.session.has_active_record():
+            QMessageBox.warning(
+                self,
+                "No Record",
+                "Please load or create a commissioning record first.",
+            )
             return
 
-        name, ok = QInputDialog.getText(
-            host, "Add Operator", "Enter your name:"
-        )
-        clean_name = name.strip()
-        if not ok or not clean_name:
-            operator_combo.setCurrentIndex(0)
+        operator = self.operator_combo.currentData()
+        if not operator:
+            QMessageBox.warning(
+                self, "Operator Required", "Please select an operator first."
+            )
+            self.operator_combo.setFocus()
             return
 
-        host.session.add_operator(clean_name)
-        populate_operator_combo(clean_name)
+        note, ok = QInputDialog.getMultiLineText(
+            self,
+            "Quick Note",
+            f"Operator: {self.operator_combo.currentText()}\n\nEnter note:",
+        )
 
-    operator_combo.currentIndexChanged.connect(on_operator_selected)
-    populate_operator_combo(operator_default)
+        if ok and note.strip():
+            try:
+                if self.session.append_general_note(operator, note.strip()):
+                    self._load_notes()
+                    self.notes_table.scrollToTop()
+            except RecordConflictError as conflict:
+                self._handle_note_conflict(conflict)
 
-    buttons = QDialogButtonBox(QDialogButtonBox.Save | QDialogButtonBox.Cancel)
-    buttons.accepted.connect(dialog.accept)
-    buttons.rejected.connect(dialog.reject)
-    layout.addWidget(buttons)
+    def _show_notes_context_menu(self, position) -> None:
+        """Show context menu for notes table."""
+        if self.notes_table.rowCount() == 0:
+            return
 
-    if dialog.exec_() != QDialog.Accepted:
-        return None, None
+        menu = QMenu(self)
+        edit_action = menu.addAction("✏️ Edit Note")
 
-    operator = operator_combo.currentData() or None
-    note_text = note_input.toPlainText().strip() or None
-    return operator, note_text
+        action = menu.exec_(self.notes_table.viewport().mapToGlobal(position))
+
+        if action == edit_action:
+            self._on_edit_note()
+
+    def _on_edit_note(self) -> None:
+        """Edit selected note."""
+        note_ref = self._get_selected_note_ref()
+        if not note_ref:
+            return
+
+        row = self.notes_table.currentRow()
+        current_operator = self.notes_table.item(row, 2).text()
+        current_note = self.notes_table.item(row, 3).text()
+
+        operator, note = self._build_note_dialog(
+            "Edit Note", current_operator, current_note
+        )
+        if not note:
+            return
+
+        note_type, ref_data = note_ref
+
+        if note_type == "general":
+            note_index = ref_data
+            try:
+                if self.session.update_general_note(note_index, operator, note):
+                    self._load_notes()
+            except RecordConflictError as conflict:
+                self._handle_note_conflict(conflict)
+        elif note_type == "measurement":
+            entry_id, note_index = ref_data
+            if self.session.update_measurement_note(
+                entry_id, note_index, operator, note
+            ):
+                self._load_notes()
+
+    def _get_selected_note_ref(self):
+        """Get reference to selected note."""
+        selected = self.notes_table.selectedItems()
+        if not selected:
+            return None
+
+        row = selected[0].row()
+        return self.notes_table.item(row, 0).data(Qt.UserRole)
+
+    def _build_note_dialog(
+        self,
+        title: str,
+        operator_default: str,
+        note_default: str = "",
+    ) -> tuple[str | None, str | None]:
+        """Build note editing dialog."""
+        dialog = QDialog(self)
+        dialog.setWindowTitle(title)
+        dialog.setMinimumWidth(500)
+        layout = QVBoxLayout(dialog)
+
+        op_row = QHBoxLayout()
+        op_row.addWidget(QLabel("Operator:"))
+        operator_combo = QComboBox()
+        op_row.addWidget(operator_combo)
+        layout.addLayout(op_row)
+
+        layout.addWidget(QLabel("Note:"))
+        note_input = QTextEdit()
+        note_input.setPlainText(note_default)
+        note_input.setMinimumHeight(100)
+        layout.addWidget(note_input)
+
+        def populate_operator_combo(selected: str | None) -> None:
+            operator_combo.blockSignals(True)
+            operator_combo.clear()
+            operator_combo.addItem("Select operator...", "")
+            for name in self.session.get_operators():
+                operator_combo.addItem(name, name)
+            if selected and operator_combo.findData(selected) == -1:
+                operator_combo.addItem(selected, selected)
+            operator_combo.addItem("Add operator...", "__add__")
+            if selected:
+                idx = operator_combo.findData(selected)
+                if idx >= 0:
+                    operator_combo.setCurrentIndex(idx)
+            operator_combo.blockSignals(False)
+
+        def on_operator_selected() -> None:
+            selection = operator_combo.currentData()
+            if selection != "__add__":
+                return
+
+            name, ok = QInputDialog.getText(
+                self, "Add Operator", "Enter your name:"
+            )
+            clean_name = name.strip()
+            if not ok or not clean_name:
+                operator_combo.setCurrentIndex(0)
+                return
+
+            self.session.add_operator(clean_name)
+            populate_operator_combo(clean_name)
+
+        operator_combo.currentIndexChanged.connect(on_operator_selected)
+        populate_operator_combo(operator_default)
+
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.Save | QDialogButtonBox.Cancel
+        )
+        buttons.accepted.connect(dialog.accept)
+        buttons.rejected.connect(dialog.reject)
+        layout.addWidget(buttons)
+
+        if dialog.exec_() != QDialog.Accepted:
+            return None, None
+
+        operator = operator_combo.currentData() or None
+        note_text = note_input.toPlainText().strip() or None
+        return operator, note_text
+
+
+# Backward-compat aliases so existing tests continue to work.
+quick_add_note = _NoteActionsMixin._quick_add_note
+show_notes_context_menu = _NoteActionsMixin._show_notes_context_menu
+on_edit_note = _NoteActionsMixin._on_edit_note
+get_selected_note_ref = _NoteActionsMixin._get_selected_note_ref
+build_note_dialog = _NoteActionsMixin._build_note_dialog

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/container/notes.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/container/notes.py
@@ -19,167 +19,160 @@ from sc_linac_physics.applications.rf_commissioning.models.data_models import (
 )
 
 
-def build_enhanced_notes_panel(host) -> QWidget:
-    """Build always-accessible notes panel with better UX."""
-    widget = QWidget()
-    widget.setStyleSheet("""
-                            QWidget {
-                                background-color: #2a2a2a;
-                                border-top: 1px solid #444;
-                            }
-                        """)
+class _NotesPanelMixin:
+    def _build_enhanced_notes_panel(self) -> QWidget:
+        """Build always-accessible notes panel with better UX."""
+        widget = QWidget()
+        widget.setStyleSheet("""
+                                QWidget {
+                                    background-color: #2a2a2a;
+                                    border-top: 1px solid #444;
+                                }
+                            """)
 
-    layout = QVBoxLayout()
-    layout.setContentsMargins(10, 10, 10, 10)
+        layout = QVBoxLayout()
+        layout.setContentsMargins(10, 10, 10, 10)
 
-    # Header with add button
-    header = QHBoxLayout()
-    title = QLabel("📝 Notes")
-    title.setStyleSheet("font-weight: bold; font-size: 14px; color: #ddd;")
-    header.addWidget(title)
-    header.addStretch()
+        header = QHBoxLayout()
+        title = QLabel("📝 Notes")
+        title.setStyleSheet("font-weight: bold; font-size: 14px; color: #ddd;")
+        header.addWidget(title)
+        header.addStretch()
 
-    quick_add = QPushButton("+ Quick Note")
-    quick_add.setStyleSheet("""
-                            QPushButton {
-                                background-color: #4CAF50;
-                                color: white;
-                                border-radius: 3px;
-                                padding: 5px 15px;
-                                font-weight: bold;
-                            }
-                            QPushButton:hover {
-                                background-color: #45a049;
-                            }
-                        """)
-    quick_add.clicked.connect(host._quick_add_note)
-    header.addWidget(quick_add)
+        quick_add = QPushButton("+ Quick Note")
+        quick_add.setStyleSheet("""
+                                QPushButton {
+                                    background-color: #4CAF50;
+                                    color: white;
+                                    border-radius: 3px;
+                                    padding: 5px 15px;
+                                    font-weight: bold;
+                                }
+                                QPushButton:hover {
+                                    background-color: #45a049;
+                                }
+                            """)
+        quick_add.clicked.connect(self._quick_add_note)
+        header.addWidget(quick_add)
 
-    layout.addLayout(header)
+        layout.addLayout(header)
 
-    # Filter row
-    filter_row = QHBoxLayout()
-    filter_row.addWidget(QLabel("Filter:"))
-    host.notes_phase_filter = QComboBox()
-    host.notes_phase_filter.addItem("All", None)
-    host.notes_phase_filter.addItem("Current Phase", "current")
-    for phase in CommissioningPhase:
-        host.notes_phase_filter.addItem(phase.value, phase)
-    host.notes_phase_filter.currentIndexChanged.connect(host._load_notes)
-    filter_row.addWidget(host.notes_phase_filter)
-    filter_row.addStretch()
+        filter_row = QHBoxLayout()
+        filter_row.addWidget(QLabel("Filter:"))
+        self.notes_phase_filter = QComboBox()
+        self.notes_phase_filter.addItem("All", None)
+        self.notes_phase_filter.addItem("Current Phase", "current")
+        for phase in CommissioningPhase:
+            self.notes_phase_filter.addItem(phase.value, phase)
+        self.notes_phase_filter.currentIndexChanged.connect(self._load_notes)
+        filter_row.addWidget(self.notes_phase_filter)
+        filter_row.addStretch()
 
-    refresh_btn = QPushButton("🔄")
-    refresh_btn.setToolTip("Refresh notes")
-    refresh_btn.setFixedWidth(30)
-    refresh_btn.clicked.connect(host._load_notes)
-    filter_row.addWidget(refresh_btn)
+        refresh_btn = QPushButton("🔄")
+        refresh_btn.setToolTip("Refresh notes")
+        refresh_btn.setFixedWidth(30)
+        refresh_btn.clicked.connect(self._load_notes)
+        filter_row.addWidget(refresh_btn)
 
-    layout.addLayout(filter_row)
+        layout.addLayout(filter_row)
 
-    # Notes table
-    host.notes_table = QTableWidget()
-    host.notes_table.setColumnCount(4)
-    host.notes_table.setHorizontalHeaderLabels(
-        ["Time", "Phase", "Operator", "Note"]
-    )
-    host.notes_table.horizontalHeader().setStretchLastSection(True)
-    host.notes_table.setSelectionBehavior(QTableWidget.SelectRows)
-    host.notes_table.setAlternatingRowColors(True)
-    host.notes_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self.notes_table = QTableWidget()
+        self.notes_table.setColumnCount(4)
+        self.notes_table.setHorizontalHeaderLabels(
+            ["Time", "Phase", "Operator", "Note"]
+        )
+        self.notes_table.horizontalHeader().setStretchLastSection(True)
+        self.notes_table.setSelectionBehavior(QTableWidget.SelectRows)
+        self.notes_table.setAlternatingRowColors(True)
+        self.notes_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
 
-    # Column widths
-    host.notes_table.setColumnWidth(0, 130)
-    host.notes_table.setColumnWidth(1, 100)
-    host.notes_table.setColumnWidth(2, 100)
-    host.notes_table.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
-
-    # Enable right-click context menu
-    host.notes_table.setContextMenuPolicy(Qt.CustomContextMenu)
-    host.notes_table.customContextMenuRequested.connect(
-        host._show_notes_context_menu
-    )
-
-    layout.addWidget(host.notes_table)
-
-    widget.setLayout(layout)
-    return widget
-
-
-def load_notes(host) -> None:
-    """Load and display all notes for the active record."""
-    if not host.session.has_active_record():
-        host.notes_table.setRowCount(0)
-        return
-
-    phase_filter = host.notes_phase_filter.currentData()
-
-    # Handle "current phase" filter
-    if phase_filter == "current":
-        record = host.session.get_active_record()
-        phase_filter = record.current_phase
-
-    # Get both general notes and measurement notes
-    measurement_notes = host.session.get_measurement_notes(phase_filter)
-    general_notes = host.session.get_general_notes()
-
-    # Combine all notes
-    all_notes = []
-
-    # General notes don't have phase or measurement time
-    for note_index, note in enumerate(general_notes):
-        all_notes.append(
-            {
-                "type": "General",
-                "phase": "",
-                "measurement_timestamp": "",
-                "timestamp": note.get("timestamp"),
-                "operator": note.get("operator"),
-                "note": note.get("note"),
-                "note_ref": ("general", note_index),
-            }
+        self.notes_table.setColumnWidth(0, 130)
+        self.notes_table.setColumnWidth(1, 100)
+        self.notes_table.setColumnWidth(2, 100)
+        self.notes_table.setSizePolicy(
+            QSizePolicy.Expanding, QSizePolicy.Expanding
         )
 
-    # Measurement notes have phase and measurement time
-    for note in measurement_notes:
-        if phase_filter and note.get("phase") != phase_filter.value:
-            continue
-        all_notes.append(
-            {
-                "type": "Measurement",
-                "phase": note.get("phase", ""),
-                "measurement_timestamp": note.get("measurement_timestamp", ""),
-                "timestamp": note.get("timestamp"),
-                "operator": note.get("operator"),
-                "note": note.get("note"),
-                "note_ref": (
-                    "measurement",
-                    (note.get("entry_id"), note.get("note_index")),
-                ),
-            }
+        self.notes_table.setContextMenuPolicy(Qt.CustomContextMenu)
+        self.notes_table.customContextMenuRequested.connect(
+            self._show_notes_context_menu
         )
 
-    # Sort by timestamp (most recent first)
-    all_notes.sort(key=lambda x: x.get("timestamp") or "", reverse=True)
+        layout.addWidget(self.notes_table)
 
-    host.notes_table.setRowCount(len(all_notes))
+        widget.setLayout(layout)
+        return widget
 
-    for row, item in enumerate(all_notes):
-        # Time column
-        time_str = item["timestamp"] or item["measurement_timestamp"] or "-"
-        time_item = QTableWidgetItem(time_str)
-        time_item.setData(Qt.UserRole, item["note_ref"])
-        host.notes_table.setItem(row, 0, time_item)
+    def _load_notes(self) -> None:
+        """Load and display all notes for the active record."""
+        if not self.session.has_active_record():
+            self.notes_table.setRowCount(0)
+            return
 
-        # Phase column
-        phase_str = item["phase"] or "General"
-        phase_item = QTableWidgetItem(phase_str)
-        host.notes_table.setItem(row, 1, phase_item)
+        phase_filter = self.notes_phase_filter.currentData()
 
-        # Operator column
-        operator_item = QTableWidgetItem(item["operator"] or "Unknown")
-        host.notes_table.setItem(row, 2, operator_item)
+        if phase_filter == "current":
+            record = self.session.get_active_record()
+            phase_filter = record.current_phase
 
-        # Note column
-        note_item = QTableWidgetItem(item["note"] or "")
-        host.notes_table.setItem(row, 3, note_item)
+        measurement_notes = self.session.get_measurement_notes(phase_filter)
+        general_notes = self.session.get_general_notes()
+
+        all_notes = []
+
+        for note_index, note in enumerate(general_notes):
+            all_notes.append(
+                {
+                    "type": "General",
+                    "phase": "",
+                    "measurement_timestamp": "",
+                    "timestamp": note.get("timestamp"),
+                    "operator": note.get("operator"),
+                    "note": note.get("note"),
+                    "note_ref": ("general", note_index),
+                }
+            )
+
+        for note in measurement_notes:
+            if phase_filter and note.get("phase") != phase_filter.value:
+                continue
+            all_notes.append(
+                {
+                    "type": "Measurement",
+                    "phase": note.get("phase", ""),
+                    "measurement_timestamp": note.get(
+                        "measurement_timestamp", ""
+                    ),
+                    "timestamp": note.get("timestamp"),
+                    "operator": note.get("operator"),
+                    "note": note.get("note"),
+                    "note_ref": (
+                        "measurement",
+                        (note.get("entry_id"), note.get("note_index")),
+                    ),
+                }
+            )
+
+        all_notes.sort(key=lambda x: x.get("timestamp") or "", reverse=True)
+
+        self.notes_table.setRowCount(len(all_notes))
+
+        for row, item in enumerate(all_notes):
+            time_str = item["timestamp"] or item["measurement_timestamp"] or "-"
+            time_item = QTableWidgetItem(time_str)
+            time_item.setData(Qt.UserRole, item["note_ref"])
+            self.notes_table.setItem(row, 0, time_item)
+
+            phase_str = item["phase"] or "General"
+            self.notes_table.setItem(row, 1, QTableWidgetItem(phase_str))
+            self.notes_table.setItem(
+                row, 2, QTableWidgetItem(item["operator"] or "Unknown")
+            )
+            self.notes_table.setItem(
+                row, 3, QTableWidgetItem(item["note"] or "")
+            )
+
+
+# Backward-compat aliases so existing tests continue to work.
+build_enhanced_notes_panel = _NotesPanelMixin._build_enhanced_notes_panel
+load_notes = _NotesPanelMixin._load_notes

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/container/persistence.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/container/persistence.py
@@ -17,26 +17,9 @@ from sc_linac_physics.applications.rf_commissioning.ui.merge_dialog import (
 )
 
 
-def save_active_record(host) -> bool:
-    """Save the active record with conflict detection."""
-    if not host.session.has_active_record():
-        return False
-
-    try:
-        success = host.session.save_active_record()
-        if success:
-            host._update_sync_status(True, "Saved")
-            host.update_progress_indicator(host.session.get_active_record())
-            host._update_tab_states()
-
-        return success
-    except RecordConflictError as error:
-        return host._handle_save_conflict(error)
-
-
 def _fetch_merge_target(host, record_id: int):
     """Fetch the latest database record/version for merge resolution."""
-    result = host.session.db.get_record_with_version(record_id)
+    result = host.session.get_record_with_version(record_id)
     if not result:
         QMessageBox.critical(
             host, "Error", "Failed to load database version for merge."
@@ -75,115 +58,139 @@ def _handle_merge_save_error(host, error: Exception) -> bool:
     return False
 
 
-def handle_save_conflict(host, conflict: RecordConflictError) -> bool:
-    """Handle optimistic locking conflict via merge dialog."""
-    if not host.session.has_active_record():
-        return False
-
-    record_id = host.session.get_active_record_id()
-    if not record_id:
-        return False
-
-    latest_conflict = conflict
-
-    while True:
-        result = _fetch_merge_target(host, record_id)
-        if result is None:
-            return False
-
-        db_record, db_version = result
-        expected_version = _get_expected_version(db_version, latest_conflict)
-        merged_record = _get_merged_record(host, db_record)
-        if not merged_record:
+class _PersistenceMixin:
+    def save_active_record(self) -> bool:
+        """Save the active record with conflict detection."""
+        if not self.session.has_active_record():
             return False
 
         try:
-            host.session.db.save_record(
-                merged_record,
-                record_id,
-                expected_version=expected_version,
-            )
-            host.load_record(record_id)
+            success = self.session.save_active_record()
+            if success:
+                self._update_sync_status(True, "Saved")
+                self.update_progress_indicator(self.session.get_active_record())
+                self._update_tab_states()
 
-            QMessageBox.information(
-                host,
-                "Merge Successful",
-                "Your changes have been merged and saved.",
-            )
-            host._update_sync_status(True, "Merged and saved")
-            return True
+            return success
+        except RecordConflictError as error:
+            return self._handle_save_conflict(error)
 
-        except Exception as error:
-            if not _handle_merge_save_error(host, error):
+    def _handle_save_conflict(self, conflict: RecordConflictError) -> bool:
+        """Handle optimistic locking conflict via merge dialog."""
+        if not self.session.has_active_record():
+            return False
+
+        record_id = self.session.get_active_record_id()
+        if not record_id:
+            return False
+
+        latest_conflict = conflict
+
+        while True:
+            result = _fetch_merge_target(self, record_id)
+            if result is None:
                 return False
-            latest_conflict = error
 
-    return False
+            db_record, db_version = result
+            expected_version = _get_expected_version(
+                db_version, latest_conflict
+            )
+            merged_record = _get_merged_record(self, db_record)
+            if not merged_record:
+                return False
 
+            try:
+                self.session.save_record(
+                    merged_record,
+                    record_id,
+                    expected_version=expected_version,
+                )
+                self.load_record(record_id)
 
-def show_measurement_history(host) -> None:
-    """Open dialog showing all measurement attempts."""
-    if not host.session.has_active_record():
-        QMessageBox.information(
-            host,
-            "No Active Record",
-            "Please load or create a commissioning record first.",
+                QMessageBox.information(
+                    self,
+                    "Merge Successful",
+                    "Your changes have been merged and saved.",
+                )
+                self._update_sync_status(True, "Merged and saved")
+                return True
+
+            except Exception as error:
+                if not _handle_merge_save_error(self, error):
+                    return False
+                latest_conflict = error
+
+        return False
+
+    def _show_measurement_history(self) -> None:
+        """Open dialog showing all measurement attempts."""
+        if not self.session.has_active_record():
+            QMessageBox.information(
+                self,
+                "No Active Record",
+                "Please load or create a commissioning record first.",
+            )
+            return
+
+        existing_dialog = getattr(self, "_measurement_history_dialog", None)
+        if existing_dialog and existing_dialog.isVisible():
+            existing_dialog.raise_()
+            existing_dialog.activateWindow()
+            return
+
+        dialog = MeasurementHistoryDialog(self.session, parent=self)
+        self._measurement_history_dialog = dialog
+        dialog.setAttribute(Qt.WA_DeleteOnClose, True)
+        dialog.destroyed.connect(
+            lambda _obj=None: setattr(self, "_measurement_history_dialog", None)
         )
-        return
+        dialog.show()
+        dialog.raise_()
+        dialog.activateWindow()
 
-    existing_dialog = getattr(host, "_measurement_history_dialog", None)
-    if existing_dialog and existing_dialog.isVisible():
-        existing_dialog.raise_()
-        existing_dialog.activateWindow()
-        return
+    def _show_database_browser(self) -> None:
+        """Open database browser to select and load a record."""
+        cryomodule = self.cryomodule_combo.currentText()
+        cavity = self.cavity_combo.currentText()
 
-    dialog = MeasurementHistoryDialog(host.session, parent=host)
-    host._measurement_history_dialog = dialog
-    dialog.setAttribute(Qt.WA_DeleteOnClose, True)
-    dialog.destroyed.connect(
-        lambda _obj=None: setattr(host, "_measurement_history_dialog", None)
-    )
-    dialog.show()
-    dialog.raise_()
-    dialog.activateWindow()
+        if cryomodule == "Select CM..." or not cryomodule:
+            cryomodule = None
 
+        if cavity == "Select Cav..." or not cavity:
+            cavity = None
 
-def show_database_browser(host) -> None:
-    """Open database browser to select and load a record."""
-    cryomodule = host.cryomodule_combo.currentText()
-    cavity = host.cavity_combo.currentText()
+        linac = None
+        if cryomodule:
+            from sc_linac_physics.utils.sc_linac.linac_utils import (
+                get_linac_for_cryomodule,
+            )
 
-    if cryomodule == "Select CM..." or not cryomodule:
-        cryomodule = None
+            linac = get_linac_for_cryomodule(cryomodule)
 
-    if cavity == "Select Cav..." or not cavity:
-        cavity = None
-
-    linac = None
-    if cryomodule:
-        from sc_linac_physics.utils.sc_linac.linac_utils import (
-            get_linac_for_cryomodule,
+        dialog = DatabaseBrowserDialog(
+            self.session.database,
+            self,
+            cryomodule_filter=cryomodule,
+            cavity_filter=cavity,
+            linac_filter=linac,
         )
 
-        linac = get_linac_for_cryomodule(cryomodule)
+        if dialog.exec_() != QDialog.Accepted:
+            return
 
-    dialog = DatabaseBrowserDialog(
-        host.session.database,
-        host,
-        cryomodule_filter=cryomodule,
-        cavity_filter=cavity,
-        linac_filter=linac,
-    )
+        record_id, record_data = dialog.get_selected_record()
 
-    if dialog.exec_() != QDialog.Accepted:
-        return
+        if not record_id or not record_data:
+            return
 
-    record_id, record_data = dialog.get_selected_record()
+        if not self.load_record(record_id):
+            QMessageBox.critical(
+                self, "Load Failed", f"Failed to load record {record_id}"
+            )
 
-    if not record_id or not record_data:
-        return
 
-    if not host.load_record(record_id):
-        QMessageBox.critical(
-            host, "Load Failed", f"Failed to load record {record_id}"
-        )
+# Backward-compat aliases so existing tests continue to work.
+save_active_record = _PersistenceMixin.save_active_record
+handle_save_conflict = _PersistenceMixin._handle_save_conflict
+show_measurement_history = _PersistenceMixin._show_measurement_history
+show_database_browser = _PersistenceMixin._show_database_browser

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/container/progress_panel.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/container/progress_panel.py
@@ -11,156 +11,161 @@ from sc_linac_physics.applications.rf_commissioning.ui.container.progress import
 )
 
 
-def build_compact_progress_bar(host) -> QWidget:
-    """Build a compact horizontal progress indicator."""
-    widget = QWidget()
-    widget.setMaximumHeight(100)
-    widget.setStyleSheet("""
-        QWidget {
-            background-color: #1e1e1e;
-            border-bottom: 1px solid #333;
-        }
-    """)
-
-    main_layout = QVBoxLayout()
-    main_layout.setContentsMargins(10, 8, 10, 8)
-    main_layout.setSpacing(8)
-
-    title = QLabel("Commissioning Progress")
-    title.setStyleSheet("color: #aaa; font-size: 11px; font-weight: bold;")
-    main_layout.addWidget(title)
-
-    progress_container = QWidget()
-    progress_layout = QHBoxLayout()
-    progress_layout.setSpacing(0)
-    progress_layout.setContentsMargins(20, 0, 20, 0)
-
-    phases = build_progress_phases()
-
-    host.phase_indicators = {}
-    host.phase_connectors = []
-
-    for i, (label, phase) in enumerate(phases):
-        node_container = QWidget()
-        node_layout = QVBoxLayout()
-        node_layout.setSpacing(4)
-        node_layout.setContentsMargins(0, 0, 0, 0)
-        node_layout.setAlignment(Qt.AlignCenter)
-
-        circle = QLabel("●")
-        circle.setAlignment(Qt.AlignCenter)
-        circle.setMinimumSize(32, 32)
-        circle.setStyleSheet("""
-            font-size: 28px;
-            color: #444;
-            background-color: transparent;
+class _ProgressMixin:
+    def _build_compact_progress_bar(self) -> QWidget:
+        """Build a compact horizontal progress indicator."""
+        widget = QWidget()
+        widget.setMaximumHeight(100)
+        widget.setStyleSheet("""
+            QWidget {
+                background-color: #1e1e1e;
+                border-bottom: 1px solid #333;
+            }
         """)
-        host.phase_indicators[phase] = circle
 
-        text = QLabel(label)
-        text.setAlignment(Qt.AlignCenter)
-        text.setStyleSheet(
-            "font-size: 9px; color: #888; background-color: transparent;"
-        )
-        text.setWordWrap(True)
-        text.setFixedWidth(60)
+        main_layout = QVBoxLayout()
+        main_layout.setContentsMargins(10, 8, 10, 8)
+        main_layout.setSpacing(8)
 
-        node_layout.addWidget(circle)
-        node_layout.addWidget(text)
-        node_container.setLayout(node_layout)
+        title = QLabel("Commissioning Progress")
+        title.setStyleSheet("color: #aaa; font-size: 11px; font-weight: bold;")
+        main_layout.addWidget(title)
 
-        progress_layout.addWidget(node_container)
+        progress_container = QWidget()
+        progress_layout = QHBoxLayout()
+        progress_layout.setSpacing(0)
+        progress_layout.setContentsMargins(20, 0, 20, 0)
 
-        if i < len(phases) - 1:
-            connector = QLabel("━━━━")
-            connector.setAlignment(Qt.AlignCenter)
-            connector.setStyleSheet("""
-                color: #444;
-                font-size: 16px;
-                padding: 0px;
-                margin: 0px 4px 24px 4px;
-                background-color: transparent;
-            """)
-            connector.setFixedHeight(32)
-            host.phase_connectors.append(connector)
-            progress_layout.addWidget(connector)
+        phases = build_progress_phases()
 
-    progress_container.setLayout(progress_layout)
-    main_layout.addWidget(progress_container)
+        self.phase_indicators = {}
+        self.phase_connectors = []
 
-    widget.setLayout(main_layout)
-    return widget
+        for i, (label, phase) in enumerate(phases):
+            node_container = QWidget()
+            node_layout = QVBoxLayout()
+            node_layout.setSpacing(4)
+            node_layout.setContentsMargins(0, 0, 0, 0)
+            node_layout.setAlignment(Qt.AlignCenter)
 
-
-def update_progress_indicator(host, record) -> None:
-    """Update status icons/colors for the compact progress bar."""
-    projection = host.session.get_active_phase_projection()
-    if projection is None:
-        return
-
-    current_phase = projection.get("current_phase")
-    phase_status = projection.get("phase_status", {})
-
-    phase_order = CommissioningPhase.get_phase_order()
-    current_idx = phase_order.index(current_phase)
-
-    for phase, indicator in host.phase_indicators.items():
-        idx = phase_order.index(phase)
-        status = phase_status.get(phase)
-        if status is not None and status.value in {"complete", "skipped"}:
-            indicator.setText("✔")
-            indicator.setStyleSheet("""
-                font-size: 28px;
-                color: #4CAF50;
-                font-weight: bold;
-                background-color: rgba(76, 175, 80, 0.2);
-                border-radius: 16px;
-                border: 2px solid #4CAF50;
-            """)
-        elif status is not None and status.value == "failed":
-            indicator.setText("✖")
-            indicator.setStyleSheet("""
-                font-size: 24px;
-                color: #ef5350;
-                font-weight: bold;
-                background-color: rgba(239, 83, 80, 0.2);
-                border-radius: 16px;
-                border: 2px solid #ef5350;
-            """)
-        elif idx == current_idx:
-            indicator.setText("▶")
-            indicator.setStyleSheet("""
-                font-size: 24px;
-                color: #2196F3;
-                font-weight: bold;
-                background-color: rgba(33, 150, 243, 0.3);
-                border-radius: 16px;
-                border: 2px solid #2196F3;
-            """)
-        else:
-            indicator.setText("○")
-            indicator.setStyleSheet("""
+            circle = QLabel("●")
+            circle.setAlignment(Qt.AlignCenter)
+            circle.setMinimumSize(32, 32)
+            circle.setStyleSheet("""
                 font-size: 28px;
                 color: #444;
                 background-color: transparent;
-                border-radius: 16px;
             """)
+            self.phase_indicators[phase] = circle
 
-    for i, connector in enumerate(host.phase_connectors):
-        if i < current_idx:
-            connector.setStyleSheet("""
-                color: #4CAF50;
-                font-size: 16px;
-                font-weight: bold;
-                padding: 0px;
-                margin: 0px 4px 24px 4px;
-                background-color: transparent;
-            """)
-        else:
-            connector.setStyleSheet("""
-                color: #444;
-                font-size: 16px;
-                padding: 0px;
-                margin: 0px 4px 24px 4px;
-                background-color: transparent;
-            """)
+            text = QLabel(label)
+            text.setAlignment(Qt.AlignCenter)
+            text.setStyleSheet(
+                "font-size: 9px; color: #888; background-color: transparent;"
+            )
+            text.setWordWrap(True)
+            text.setFixedWidth(60)
+
+            node_layout.addWidget(circle)
+            node_layout.addWidget(text)
+            node_container.setLayout(node_layout)
+
+            progress_layout.addWidget(node_container)
+
+            if i < len(phases) - 1:
+                connector = QLabel("━━━━")
+                connector.setAlignment(Qt.AlignCenter)
+                connector.setStyleSheet("""
+                    color: #444;
+                    font-size: 16px;
+                    padding: 0px;
+                    margin: 0px 4px 24px 4px;
+                    background-color: transparent;
+                """)
+                connector.setFixedHeight(32)
+                self.phase_connectors.append(connector)
+                progress_layout.addWidget(connector)
+
+        progress_container.setLayout(progress_layout)
+        main_layout.addWidget(progress_container)
+
+        widget.setLayout(main_layout)
+        return widget
+
+    def update_progress_indicator(self, record) -> None:
+        """Update status icons/colors for the compact progress bar."""
+        projection = self.session.get_active_phase_projection()
+        if projection is None:
+            return
+
+        current_phase = projection.get("current_phase")
+        phase_status = projection.get("phase_status", {})
+
+        phase_order = CommissioningPhase.get_phase_order()
+        current_idx = phase_order.index(current_phase)
+
+        for phase, indicator in self.phase_indicators.items():
+            idx = phase_order.index(phase)
+            status = phase_status.get(phase)
+            if status is not None and status.value in {"complete", "skipped"}:
+                indicator.setText("✔")
+                indicator.setStyleSheet("""
+                    font-size: 28px;
+                    color: #4CAF50;
+                    font-weight: bold;
+                    background-color: rgba(76, 175, 80, 0.2);
+                    border-radius: 16px;
+                    border: 2px solid #4CAF50;
+                """)
+            elif status is not None and status.value == "failed":
+                indicator.setText("✖")
+                indicator.setStyleSheet("""
+                    font-size: 24px;
+                    color: #ef5350;
+                    font-weight: bold;
+                    background-color: rgba(239, 83, 80, 0.2);
+                    border-radius: 16px;
+                    border: 2px solid #ef5350;
+                """)
+            elif idx == current_idx:
+                indicator.setText("▶")
+                indicator.setStyleSheet("""
+                    font-size: 24px;
+                    color: #2196F3;
+                    font-weight: bold;
+                    background-color: rgba(33, 150, 243, 0.3);
+                    border-radius: 16px;
+                    border: 2px solid #2196F3;
+                """)
+            else:
+                indicator.setText("○")
+                indicator.setStyleSheet("""
+                    font-size: 28px;
+                    color: #444;
+                    background-color: transparent;
+                    border-radius: 16px;
+                """)
+
+        for i, connector in enumerate(self.phase_connectors):
+            if i < current_idx:
+                connector.setStyleSheet("""
+                    color: #4CAF50;
+                    font-size: 16px;
+                    font-weight: bold;
+                    padding: 0px;
+                    margin: 0px 4px 24px 4px;
+                    background-color: transparent;
+                """)
+            else:
+                connector.setStyleSheet("""
+                    color: #444;
+                    font-size: 16px;
+                    padding: 0px;
+                    margin: 0px 4px 24px 4px;
+                    background-color: transparent;
+                """)
+
+
+# Backward-compat aliases so existing tests continue to work.
+build_compact_progress_bar = _ProgressMixin._build_compact_progress_bar
+update_progress_indicator = _ProgressMixin.update_progress_indicator

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/container/record_lifecycle.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/container/record_lifecycle.py
@@ -1,90 +1,86 @@
 """Record lifecycle helpers for multi-phase commissioning container."""
 
 
-def _select_tab_for_record_phase(host, record) -> None:
-    """Select the tab that matches the record's current phase."""
-    for i, spec in enumerate(host.phase_specs):
-        if spec.phase == record.current_phase:
-            host.tabs.setCurrentIndex(i)
-            break
+class _RecordLifecycleMixin:
+    def start_new_record(self, cryomodule: str, cavity_number: str) -> bool:
+        """Start a new commissioning record."""
+        record, _record_id, created = self.session.start_new_record(
+            cryomodule, cavity_number
+        )
+
+        for display in self._phase_displays:
+            if hasattr(display, "controller") and hasattr(
+                display.controller, "update_pv_addresses"
+            ):
+                display.controller.update_pv_addresses(
+                    cryomodule, cavity_number
+                )
+
+        self.update_progress_indicator(record)
+        self._update_tab_states()
+        self._update_cm_status_panel(record)
+        self._load_notes()
+
+        for display in self._phase_displays:
+            display.refresh_from_record(record)
+
+        if created:
+            self.tabs.setCurrentIndex(0)
+        else:
+            self._select_tab_for_record_phase(record)
+
+        return created
+
+    def load_record(self, record_id: int) -> bool:
+        """Load an existing commissioning record."""
+        record = self.session.load_record(record_id)
+        if not record:
+            return False
+
+        self._sync_cavity_selection_from_record(record)
+        self.update_progress_indicator(record)
+
+        for display in self._phase_displays:
+            display.on_record_loaded(record, record_id)
+
+        self._update_tab_states()
+        self._select_tab_for_record_phase(record)
+        self._update_cm_status_panel(record)
+        self._load_notes()
+        self._update_sync_status(True, "Record loaded")
+
+        return True
+
+    def _sync_cavity_selection_from_record(self, record) -> None:
+        """Sync header cavity selection to a loaded record."""
+        cm_index = self.cryomodule_combo.findText(record.cryomodule)
+        if cm_index >= 0:
+            self.cryomodule_combo.setCurrentIndex(cm_index)
+
+        cav_index = self.cavity_combo.findText(str(record.cavity_number))
+        if cav_index >= 0:
+            self.cavity_combo.setCurrentIndex(cav_index)
+
+    def on_phase_advanced(self, record) -> None:
+        """Handle notification that a phase has advanced."""
+        self.update_progress_indicator(record)
+        self._update_tab_states()
+        self._update_sync_status(True, "Phase completed")
+        self._update_cm_status_panel(record)
+        self._select_tab_for_record_phase(record)
+
+    def _select_tab_for_record_phase(self, record) -> None:
+        """Select the tab that matches the record's current phase."""
+        for i, spec in enumerate(self.phase_specs):
+            if spec.phase == record.current_phase:
+                self.tabs.setCurrentIndex(i)
+                break
 
 
-def start_new_record(host, cryomodule: str, cavity_number: str) -> bool:
-    """Start a new commissioning record."""
-    record, _record_id, created = host.session.start_new_record(
-        cryomodule, cavity_number
-    )
-
-    for display in host._phase_displays:
-        if hasattr(display, "controller") and hasattr(
-            display.controller, "update_pv_addresses"
-        ):
-            display.controller.update_pv_addresses(cryomodule, cavity_number)
-
-    host.update_progress_indicator(record)
-    host._update_tab_states()
-
-    # Keep CM-level tracker in sync for cavity-selection driven workflows
-    if hasattr(host, "_update_cm_status_panel"):
-        host._update_cm_status_panel(record)
-
-    host._load_notes()
-
-    for display in host._phase_displays:
-        display.refresh_from_record(record)
-
-    if created:
-        host.tabs.setCurrentIndex(0)
-    else:
-        _select_tab_for_record_phase(host, record)
-
-    return created
-
-
-def load_record(host, record_id: int) -> bool:
-    """Load an existing commissioning record."""
-    record = host.session.load_record(record_id)
-    if not record:
-        return False
-
-    sync_cavity_selection_from_record(host, record)
-
-    host.update_progress_indicator(record)
-
-    for display in host._phase_displays:
-        display.on_record_loaded(record, record_id)
-
-    host._update_tab_states()
-    _select_tab_for_record_phase(host, record)
-
-    # Update CM status panel with current record
-    if hasattr(host, "_update_cm_status_panel"):
-        host._update_cm_status_panel(record)
-
-    host._load_notes()
-    host._update_sync_status(True, "Record loaded")
-
-    return True
-
-
-def sync_cavity_selection_from_record(host, record) -> None:
-    """Sync header cavity selection to a loaded record."""
-    cm_index = host.cryomodule_combo.findText(record.cryomodule)
-    if cm_index >= 0:
-        host.cryomodule_combo.setCurrentIndex(cm_index)
-
-    cav_index = host.cavity_combo.findText(str(record.cavity_number))
-    if cav_index >= 0:
-        host.cavity_combo.setCurrentIndex(cav_index)
-
-
-def on_phase_advanced(host, record) -> None:
-    """Handle notification that a phase has advanced."""
-    host.update_progress_indicator(record)
-    host._update_tab_states()
-    host._update_sync_status(True, "Phase completed")
-
-    # Update CM status panel to reflect changed cavity completion count
-    if hasattr(host, "_update_cm_status_panel"):
-        host._update_cm_status_panel(record)
-    _select_tab_for_record_phase(host, record)
+# Backward-compat aliases so existing tests continue to work.
+start_new_record = _RecordLifecycleMixin.start_new_record
+load_record = _RecordLifecycleMixin.load_record
+sync_cavity_selection_from_record = (
+    _RecordLifecycleMixin._sync_cavity_selection_from_record
+)
+on_phase_advanced = _RecordLifecycleMixin.on_phase_advanced

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/container/records.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/container/records.py
@@ -19,268 +19,266 @@ from sc_linac_physics.applications.rf_commissioning.models.persistence.database 
 from sc_linac_physics.utils.sc_linac.linac_utils import get_linac_for_cryomodule
 
 
-def on_load_or_start(host) -> None:
-    """Intelligent load/start with validation and recent records."""
-    operator = host.operator_combo.currentData()
-    if not operator:
-        QMessageBox.warning(
-            host,
-            "Operator Required",
-            "Please select an operator before loading/starting a record.",
-        )
-        host.operator_combo.setFocus()
-        return
-
-    cryomodule = host.cryomodule_combo.currentText()
-    cavity = host.cavity_combo.currentText()
-
-    # Validate selections (check if placeholder still selected)
-    if cryomodule == "Select CM..." or not cryomodule:
-        QMessageBox.warning(
-            host, "Cryomodule Required", "Please select a cryomodule."
-        )
-        host.cryomodule_combo.setFocus()
-        return
-
-    if cavity == "Select Cav..." or not cavity:
-        QMessageBox.warning(
-            host, "Cavity Required", "Please select a cavity number."
-        )
-        host.cavity_combo.setFocus()
-        return
-
-    cavity_number = cavity
-
-    linac_name = get_linac_for_cryomodule(cryomodule)
-    if not linac_name:
-        QMessageBox.warning(
-            host, "Invalid Cryomodule", f"Unknown cryomodule: {cryomodule}"
-        )
-        return
-
-    try:
-        linac = int(linac_name[1])
-    except (IndexError, ValueError):
-        QMessageBox.warning(
-            host,
-            "Invalid Linac",
-            f"Could not parse linac index from '{linac_name}'",
-        )
-        return
-
-    existing_records = host.session.db.find_records_for_cavity(
-        linac, cryomodule, cavity_number
-    )
-
-    cavity_display_name = f"{cryomodule}-{cavity}"
-
-    if existing_records:
-        show_record_selector(
-            host,
-            cavity_display_name,
-            linac,
-            cryomodule,
-            cavity_number,
-            existing_records,
-        )
-    else:
-        confirm_and_start_new(
-            host, cavity_display_name, linac, cryomodule, cavity_number
-        )
-
-
-def show_record_selector(
-    host,
-    cavity_display_name: str,
-    linac: str,
-    cryomodule: str,
-    cavity_number: str,
-    records: list,
-) -> None:
-    """Show dialog to select existing record or start new."""
-    dialog = QDialog(host)
-    dialog.setWindowTitle(f"Records for {cavity_display_name}")
-    dialog.setMinimumWidth(700)
-    dialog.setMinimumHeight(400)
-
-    layout = QVBoxLayout()
-
-    header_label = QLabel(
-        f"<b>Found {len(records)} existing record(s) for {cavity_display_name}</b><br>"
-        f"<small>Select a record to view or continue working on it</small>"
-    )
-    header_label.setStyleSheet("font-size: 13px; padding: 5px;")
-    layout.addWidget(header_label)
-
-    # Table of existing records
-    table = QTableWidget()
-    table.setColumnCount(5)
-    table.setHorizontalHeaderLabels(
-        ["ID", "Started", "Status", "Current Phase", "Last Modified"]
-    )
-    table.setRowCount(len(records))
-    table.setSelectionBehavior(QTableWidget.SelectRows)
-    table.setEditTriggers(QAbstractItemView.NoEditTriggers)
-    table.setAlternatingRowColors(True)
-
-    for row, record_data in enumerate(records):
-        table.setItem(row, 0, QTableWidgetItem(str(record_data["id"])))
-        table.setItem(
-            row, 1, QTableWidgetItem(record_data.get("start_time", "")[:16])
-        )
-
-        # Status with color
-        status = record_data.get("overall_status", "in_progress")
-        status_item = QTableWidgetItem(status.replace("_", " ").title())
-        if status == "complete":
-            status_item.setForeground(Qt.darkGreen)
-        elif status == "in_progress":
-            status_item.setForeground(Qt.blue)
-        table.setItem(row, 2, status_item)
-
-        table.setItem(
-            row,
-            3,
-            QTableWidgetItem(record_data.get("current_phase", "Unknown")),
-        )
-        table.setItem(
-            row,
-            4,
-            QTableWidgetItem(record_data.get("updated_at", "Unknown")[:16]),
-        )
-
-    table.resizeColumnsToContents()
-    table.horizontalHeader().setStretchLastSection(True)
-    layout.addWidget(table)
-
-    # Instructions
-    info = QLabel(
-        "💡 <i>Double-click a record to load it.<br>"
-        "Select an operator before loading or starting a record.</i>"
-    )
-    info.setStyleSheet("color: #888; padding: 5px;")
-    info.setWordWrap(True)
-    layout.addWidget(info)
-
-    # Buttons
-    button_layout = QHBoxLayout()
-
-    load_btn = QPushButton("📂 Load Selected")
-    load_btn.setStyleSheet("""
-            QPushButton {
-                background-color: #2196F3;
-                color: white;
-                padding: 8px 16px;
-                font-weight: bold;
-                border-radius: 4px;
-            }
-            QPushButton:hover {
-                background-color: #1976D2;
-            }
-            QPushButton:disabled {
-                background-color: #ccc;
-                color: #666;
-            }
-        """)
-    load_btn.clicked.connect(lambda: load_selected_record(host, table, dialog))
-    load_btn.setEnabled(False)
-
-    cancel_btn = QPushButton("Cancel")
-    cancel_btn.clicked.connect(dialog.reject)
-
-    button_layout.addWidget(load_btn)
-    button_layout.addStretch()
-    button_layout.addWidget(cancel_btn)
-
-    layout.addLayout(button_layout)
-
-    # Enable load button when row selected
-    table.itemSelectionChanged.connect(
-        lambda: load_btn.setEnabled(len(table.selectedItems()) > 0)
-    )
-
-    # Double-click to load
-    table.cellDoubleClicked.connect(
-        lambda: load_selected_record(host, table, dialog)
-    )
-
-    dialog.setLayout(layout)
-    dialog.exec_()
-
-
-def load_selected_record(host, table: QTableWidget, dialog: QDialog) -> None:
-    """Load the selected record from the table."""
-    selected_rows = set(item.row() for item in table.selectedItems())
-    if not selected_rows:
-        return
-
-    row = list(selected_rows)[0]
-    record_id = int(table.item(row, 0).text())
-
-    if host.load_record(record_id):
-        dialog.accept()
-        host._update_sync_status(True, "Record loaded")
-
-        # Save to settings for next launch
-        settings = QSettings("SLAC", "RFCommissioning")
-        settings.setValue("last_record_id", record_id)
-    else:
-        QMessageBox.critical(
-            dialog, "Load Failed", f"Failed to load record {record_id}"
-        )
-
-
-def start_new_from_dialog(
-    host,
-    cavity_display_name: str,
-    linac: str,
-    cryomodule: str,
-    cavity_number: str,
-    dialog: QDialog,
-) -> None:
-    """Start new record from the selection dialog."""
-    dialog.accept()
-    confirm_and_start_new(
-        host, cavity_display_name, linac, cryomodule, cavity_number
-    )
-
-
-def confirm_and_start_new(
-    host,
-    cavity_display_name: str,
-    linac: str,
-    cryomodule: str,
-    cavity_number: str,
-) -> None:
-    """Confirm and start a new commissioning record."""
-    reply = QMessageBox.question(
-        host,
-        "Start New Record",
-        f"Start new commissioning record for {cavity_display_name}?",
-        QMessageBox.Yes | QMessageBox.No,
-        QMessageBox.Yes,
-    )
-
-    if reply == QMessageBox.Yes:
-        try:
-            created = host.start_new_record(cryomodule, cavity_number)
-            if created:
-                host._update_sync_status(True, "New record started")
-            else:
-                host._update_sync_status(True, "Record loaded")
-
-            if created:
-                # Log the start
-                operator = host.operator_combo.currentText()
-                try:
-                    host.session.append_general_note(
-                        operator,
-                        f"Started commissioning for {cavity_display_name}",
-                    )
-                except RecordConflictError as conflict:
-                    host._handle_note_conflict(conflict)
-
-        except Exception as e:
-            QMessageBox.critical(
-                host, "Error", f"Failed to start new record: {e}"
+class _RecordSelectorMixin:
+    def _on_load_or_start(self) -> None:
+        """Intelligent load/start with validation and recent records."""
+        operator = self.operator_combo.currentData()
+        if not operator:
+            QMessageBox.warning(
+                self,
+                "Operator Required",
+                "Please select an operator before loading/starting a record.",
             )
+            self.operator_combo.setFocus()
+            return
+
+        cryomodule = self.cryomodule_combo.currentText()
+        cavity = self.cavity_combo.currentText()
+
+        if cryomodule == "Select CM..." or not cryomodule:
+            QMessageBox.warning(
+                self, "Cryomodule Required", "Please select a cryomodule."
+            )
+            self.cryomodule_combo.setFocus()
+            return
+
+        if cavity == "Select Cav..." or not cavity:
+            QMessageBox.warning(
+                self, "Cavity Required", "Please select a cavity number."
+            )
+            self.cavity_combo.setFocus()
+            return
+
+        cavity_number = cavity
+
+        linac_name = get_linac_for_cryomodule(cryomodule)
+        if not linac_name:
+            QMessageBox.warning(
+                self, "Invalid Cryomodule", f"Unknown cryomodule: {cryomodule}"
+            )
+            return
+
+        try:
+            linac = int(linac_name[1])
+        except (IndexError, ValueError):
+            QMessageBox.warning(
+                self,
+                "Invalid Linac",
+                f"Could not parse linac index from '{linac_name}'",
+            )
+            return
+
+        existing_records = self.session.find_records_for_cavity(
+            linac, cryomodule, cavity_number
+        )
+
+        cavity_display_name = f"{cryomodule}-{cavity}"
+
+        if existing_records:
+            self._show_record_selector(
+                cavity_display_name,
+                linac,
+                cryomodule,
+                cavity_number,
+                existing_records,
+            )
+        else:
+            self._confirm_and_start_new(
+                cavity_display_name, linac, cryomodule, cavity_number
+            )
+
+    def _show_record_selector(
+        self,
+        cavity_display_name: str,
+        linac: str,
+        cryomodule: str,
+        cavity_number: str,
+        records: list,
+    ) -> None:
+        """Show dialog to select existing record or start new."""
+        dialog = QDialog(self)
+        dialog.setWindowTitle(f"Records for {cavity_display_name}")
+        dialog.setMinimumWidth(700)
+        dialog.setMinimumHeight(400)
+
+        layout = QVBoxLayout()
+
+        header_label = QLabel(
+            f"<b>Found {len(records)} existing record(s) for {cavity_display_name}</b><br>"
+            f"<small>Select a record to view or continue working on it</small>"
+        )
+        header_label.setStyleSheet("font-size: 13px; padding: 5px;")
+        layout.addWidget(header_label)
+
+        table = QTableWidget()
+        table.setColumnCount(5)
+        table.setHorizontalHeaderLabels(
+            ["ID", "Started", "Status", "Current Phase", "Last Modified"]
+        )
+        table.setRowCount(len(records))
+        table.setSelectionBehavior(QTableWidget.SelectRows)
+        table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        table.setAlternatingRowColors(True)
+
+        for row, record_data in enumerate(records):
+            table.setItem(row, 0, QTableWidgetItem(str(record_data["id"])))
+            table.setItem(
+                row, 1, QTableWidgetItem(record_data.get("start_time", "")[:16])
+            )
+
+            status = record_data.get("overall_status", "in_progress")
+            status_item = QTableWidgetItem(status.replace("_", " ").title())
+            if status == "complete":
+                status_item.setForeground(Qt.darkGreen)
+            elif status == "in_progress":
+                status_item.setForeground(Qt.blue)
+            table.setItem(row, 2, status_item)
+
+            table.setItem(
+                row,
+                3,
+                QTableWidgetItem(record_data.get("current_phase", "Unknown")),
+            )
+            table.setItem(
+                row,
+                4,
+                QTableWidgetItem(record_data.get("updated_at", "Unknown")[:16]),
+            )
+
+        table.resizeColumnsToContents()
+        table.horizontalHeader().setStretchLastSection(True)
+        layout.addWidget(table)
+
+        info = QLabel(
+            "💡 <i>Double-click a record to load it.<br>"
+            "Select an operator before loading or starting a record.</i>"
+        )
+        info.setStyleSheet("color: #888; padding: 5px;")
+        info.setWordWrap(True)
+        layout.addWidget(info)
+
+        button_layout = QHBoxLayout()
+
+        load_btn = QPushButton("📂 Load Selected")
+        load_btn.setStyleSheet("""
+                QPushButton {
+                    background-color: #2196F3;
+                    color: white;
+                    padding: 8px 16px;
+                    font-weight: bold;
+                    border-radius: 4px;
+                }
+                QPushButton:hover {
+                    background-color: #1976D2;
+                }
+                QPushButton:disabled {
+                    background-color: #ccc;
+                    color: #666;
+                }
+            """)
+        load_btn.clicked.connect(
+            lambda: self._load_selected_record(table, dialog)
+        )
+        load_btn.setEnabled(False)
+
+        cancel_btn = QPushButton("Cancel")
+        cancel_btn.clicked.connect(dialog.reject)
+
+        button_layout.addWidget(load_btn)
+        button_layout.addStretch()
+        button_layout.addWidget(cancel_btn)
+
+        layout.addLayout(button_layout)
+
+        table.itemSelectionChanged.connect(
+            lambda: load_btn.setEnabled(len(table.selectedItems()) > 0)
+        )
+        table.cellDoubleClicked.connect(
+            lambda: self._load_selected_record(table, dialog)
+        )
+
+        dialog.setLayout(layout)
+        dialog.exec_()
+
+    def _load_selected_record(
+        self, table: QTableWidget, dialog: QDialog
+    ) -> None:
+        """Load the selected record from the table."""
+        selected_rows = set(item.row() for item in table.selectedItems())
+        if not selected_rows:
+            return
+
+        row = list(selected_rows)[0]
+        record_id = int(table.item(row, 0).text())
+
+        if self.load_record(record_id):
+            dialog.accept()
+            self._update_sync_status(True, "Record loaded")
+
+            settings = QSettings("SLAC", "RFCommissioning")
+            settings.setValue("last_record_id", record_id)
+        else:
+            QMessageBox.critical(
+                dialog, "Load Failed", f"Failed to load record {record_id}"
+            )
+
+    def _start_new_from_dialog(
+        self,
+        cavity_display_name: str,
+        linac: str,
+        cryomodule: str,
+        cavity_number: str,
+        dialog: QDialog,
+    ) -> None:
+        """Start new record from the selection dialog."""
+        dialog.accept()
+        self._confirm_and_start_new(
+            cavity_display_name, linac, cryomodule, cavity_number
+        )
+
+    def _confirm_and_start_new(
+        self,
+        cavity_display_name: str,
+        linac: str,
+        cryomodule: str,
+        cavity_number: str,
+    ) -> None:
+        """Confirm and start a new commissioning record."""
+        reply = QMessageBox.question(
+            self,
+            "Start New Record",
+            f"Start new commissioning record for {cavity_display_name}?",
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.Yes,
+        )
+
+        if reply == QMessageBox.Yes:
+            try:
+                created = self.start_new_record(cryomodule, cavity_number)
+                if created:
+                    self._update_sync_status(True, "New record started")
+                else:
+                    self._update_sync_status(True, "Record loaded")
+
+                if created:
+                    operator = self.operator_combo.currentText()
+                    try:
+                        self.session.append_general_note(
+                            operator,
+                            f"Started commissioning for {cavity_display_name}",
+                        )
+                    except RecordConflictError as conflict:
+                        self._handle_note_conflict(conflict)
+
+            except Exception as e:
+                QMessageBox.critical(
+                    self, "Error", f"Failed to start new record: {e}"
+                )
+
+
+# Backward-compat aliases so existing tests continue to work.
+on_load_or_start = _RecordSelectorMixin._on_load_or_start
+show_record_selector = _RecordSelectorMixin._show_record_selector
+load_selected_record = _RecordSelectorMixin._load_selected_record
+start_new_from_dialog = _RecordSelectorMixin._start_new_from_dialog
+confirm_and_start_new = _RecordSelectorMixin._confirm_and_start_new

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/container/sync.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/container/sync.py
@@ -13,149 +13,155 @@ from PyQt5.QtWidgets import (
 logger = logging.getLogger(__name__)
 
 
-def update_sync_status(host, is_synced: bool, message: str = "") -> None:
-    """Update the global sync status indicator."""
-    if is_synced:
-        host.sync_status.setText("● Synced")
-        host.sync_status.setStyleSheet("""
-                        QLabel {
-                            color: #4CAF50;
-                            font-weight: bold;
-                            padding: 5px 10px;
-                            background-color: rgba(76, 175, 80, 0.15);
-                            border-radius: 3px;
-                        }
-                    """)
-    else:
-        host.sync_status.setText(f"⚠ {message or 'Out of Sync'}")
-        host.sync_status.setStyleSheet("""
-                        QLabel {
-                            color: #FF9800;
-                            font-weight: bold;
-                            padding: 5px 10px;
-                            background-color: rgba(255, 152, 0, 0.15);
-                            border-radius: 3px;
-                            border: 1px solid #FF9800;
-                        }
-                    """)
+class _SyncMixin:
+    def _update_sync_status(self, is_synced: bool, message: str = "") -> None:
+        """Update the global sync status indicator."""
+        if is_synced:
+            self.sync_status.setText("● Synced")
+            self.sync_status.setStyleSheet("""
+                            QLabel {
+                                color: #4CAF50;
+                                font-weight: bold;
+                                padding: 5px 10px;
+                                background-color: rgba(76, 175, 80, 0.15);
+                                border-radius: 3px;
+                            }
+                        """)
+        else:
+            self.sync_status.setText(f"⚠ {message or 'Out of Sync'}")
+            self.sync_status.setStyleSheet("""
+                            QLabel {
+                                color: #FF9800;
+                                font-weight: bold;
+                                padding: 5px 10px;
+                                background-color: rgba(255, 152, 0, 0.15);
+                                border-radius: 3px;
+                                border: 1px solid #FF9800;
+                            }
+                        """)
 
-
-def check_for_external_changes(host) -> None:
-    """Enhanced change detection with visible notification."""
-    if not host.session.has_active_record():
-        return
-
-    record_id = host.session.get_active_record_id()
-    if not record_id:
-        return
-
-    try:
-        result = host.session.db.get_record_with_version(record_id)
-        if not result:
+    def _check_for_external_changes(self) -> None:
+        """Enhanced change detection with visible notification."""
+        if not self.session.has_active_record():
             return
 
-        _, db_version = result
-        local_version = host.session._active_record_version
+        record_id = self.session.get_active_record_id()
+        if not record_id:
+            return
 
-        if local_version is not None and db_version > local_version:
-            show_update_banner(host, db_version, local_version)
+        try:
+            result = self.session.get_record_with_version(record_id)
+            if not result:
+                return
 
-    except Exception as e:
-        logger.exception("Error checking for external changes: %s", e)
+            _, db_version = result
+            local_version = self.session.get_active_record_version()
 
+            if local_version is not None and db_version > local_version:
+                self._show_update_banner(db_version, local_version)
 
-def show_update_banner(host, db_version: int, local_version: int) -> None:
-    """Show a prominent banner when external updates are detected."""
-    if hasattr(host, "_update_banner") and host._update_banner:
-        return
+        except Exception as e:
+            logger.exception("Error checking for external changes: %s", e)
 
-    host._update_banner = QWidget()
-    host._update_banner.setStyleSheet("""
-                    QWidget {
-                        background-color: #FF9800;
-                        border: 2px solid #F57C00;
-                        border-left: 5px solid #F57C00;
-                    }
-                    QLabel {
-                        color: white;
-                        font-weight: bold;
-                        padding: 5px;
-                    }
-                    QPushButton {
-                        background-color: white;
-                        color: #F57C00;
-                        font-weight: bold;
-                        padding: 8px 16px;
-                        border-radius: 4px;
-                        border: none;
-                    }
-                    QPushButton:hover {
-                        background-color: #f5f5f5;
-                    }
-                """)
+    def _show_update_banner(self, db_version: int, local_version: int) -> None:
+        """Show a prominent banner when external updates are detected."""
+        if hasattr(self, "_update_banner") and self._update_banner:
+            return
 
-    layout = QHBoxLayout()
-    layout.setContentsMargins(15, 10, 15, 10)
+        self._update_banner = QWidget()
+        self._update_banner.setStyleSheet("""
+                        QWidget {
+                            background-color: #FF9800;
+                            border: 2px solid #F57C00;
+                            border-left: 5px solid #F57C00;
+                        }
+                        QLabel {
+                            color: white;
+                            font-weight: bold;
+                            padding: 5px;
+                        }
+                        QPushButton {
+                            background-color: white;
+                            color: #F57C00;
+                            font-weight: bold;
+                            padding: 8px 16px;
+                            border-radius: 4px;
+                            border: none;
+                        }
+                        QPushButton:hover {
+                            background-color: #f5f5f5;
+                        }
+                    """)
 
-    icon = QLabel("⚠️")
-    icon.setStyleSheet("font-size: 24px;")
-    layout.addWidget(icon)
+        layout = QHBoxLayout()
+        layout.setContentsMargins(15, 10, 15, 10)
 
-    message = QLabel(
-        f"<b>This record was updated by another user</b><br>"
-        f"<small>Your version: {local_version} → Database version: {db_version}</small>"
-    )
-    layout.addWidget(message)
-    layout.addStretch()
+        icon = QLabel("⚠️")
+        icon.setStyleSheet("font-size: 24px;")
+        layout.addWidget(icon)
 
-    reload_btn = QPushButton("🔄 Reload Now")
-    reload_btn.clicked.connect(host._reload_from_banner)
-    layout.addWidget(reload_btn)
+        message = QLabel(
+            f"<b>This record was updated by another user</b><br>"
+            f"<small>Your version: {local_version} → Database version: {db_version}</small>"
+        )
+        layout.addWidget(message)
+        layout.addStretch()
 
-    dismiss_btn = QPushButton("✕ Dismiss")
-    dismiss_btn.clicked.connect(host._dismiss_banner)
-    layout.addWidget(dismiss_btn)
+        reload_btn = QPushButton("🔄 Reload Now")
+        reload_btn.clicked.connect(self._reload_from_banner)
+        layout.addWidget(reload_btn)
 
-    host._update_banner.setLayout(layout)
+        dismiss_btn = QPushButton("✕ Dismiss")
+        dismiss_btn.clicked.connect(self._dismiss_banner)
+        layout.addWidget(dismiss_btn)
 
-    # Insert banner at position 1 (after header, before progress)
-    host.layout().insertWidget(1, host._update_banner)
+        self._update_banner.setLayout(layout)
 
-    # Update sync status
-    update_sync_status(host, False, "Out of Sync")
+        # Insert banner at position 1 (after header, before progress)
+        self.layout().insertWidget(1, self._update_banner)
 
+        self._update_sync_status(False, "Out of Sync")
 
-def reload_from_banner(host) -> None:
-    """Reload record from update banner."""
-    record_id = host.session.get_active_record_id()
-    if record_id:
-        reply = QMessageBox.question(
-            host,
-            "Reload Record",
-            "Reloading will discard any unsaved changes. Continue?",
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.Yes,
+    def _reload_from_banner(self) -> None:
+        """Reload record from update banner."""
+        record_id = self.session.get_active_record_id()
+        if record_id:
+            reply = QMessageBox.question(
+                self,
+                "Reload Record",
+                "Reloading will discard any unsaved changes. Continue?",
+                QMessageBox.Yes | QMessageBox.No,
+                QMessageBox.Yes,
+            )
+
+            if reply == QMessageBox.Yes:
+                self.load_record(record_id)
+                self._dismiss_banner()
+                self._update_sync_status(True, "Reloaded")
+
+    def _dismiss_banner(self) -> None:
+        """Remove the update notification banner."""
+        if hasattr(self, "_update_banner") and self._update_banner:
+            self._update_banner.deleteLater()
+            self._update_banner = None
+
+    def _handle_note_conflict(self, conflict) -> None:
+        """Handle note update conflicts from optimistic locking."""
+        QMessageBox.warning(
+            self,
+            "Record Updated",
+            "This record was updated by another user. "
+            "Please reload before editing notes.",
+        )
+        self._show_update_banner(
+            conflict.actual_version, conflict.expected_version
         )
 
-        if reply == QMessageBox.Yes:
-            host.load_record(record_id)
-            dismiss_banner(host)
-            update_sync_status(host, True, "Reloaded")
 
-
-def dismiss_banner(host) -> None:
-    """Remove the update notification banner."""
-    if hasattr(host, "_update_banner") and host._update_banner:
-        host._update_banner.deleteLater()
-        host._update_banner = None
-
-
-def handle_note_conflict(host, conflict) -> None:
-    """Handle note update conflicts from optimistic locking."""
-    QMessageBox.warning(
-        host,
-        "Record Updated",
-        "This record was updated by another user. "
-        "Please reload before editing notes.",
-    )
-    show_update_banner(host, conflict.actual_version, conflict.expected_version)
+# Backward-compat aliases so existing tests continue to work.
+update_sync_status = _SyncMixin._update_sync_status
+check_for_external_changes = _SyncMixin._check_for_external_changes
+show_update_banner = _SyncMixin._show_update_banner
+reload_from_banner = _SyncMixin._reload_from_banner
+dismiss_banner = _SyncMixin._dismiss_banner
+handle_note_conflict = _SyncMixin._handle_note_conflict

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/container/tab_state.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/container/tab_state.py
@@ -11,99 +11,109 @@ from sc_linac_physics.applications.rf_commissioning.models.persistence.database 
 )
 
 
-def init_tabs(host) -> None:
-    """Initialize tabs with enhanced visual feedback."""
-    for i, spec in enumerate(host.phase_specs):
-        tab_widget = QWidget()
-        tab_layout = QVBoxLayout()
-        tab_layout.setContentsMargins(0, 0, 0, 0)
+class _TabsMixin:
+    def _init_tabs(self) -> None:
+        """Initialize tabs with enhanced visual feedback."""
+        for i, spec in enumerate(self.phase_specs):
+            tab_widget = QWidget()
+            tab_layout = QVBoxLayout()
+            tab_layout.setContentsMargins(0, 0, 0, 0)
 
-        display = spec.display_class(parent=tab_widget, session=host.session)
-        host._phase_displays.append(display)
+            display = spec.display_class(
+                parent=tab_widget, session=self.session
+            )
+            self._phase_displays.append(display)
 
-        tab_layout.addWidget(display)
-        tab_widget.setLayout(tab_layout)
+            tab_layout.addWidget(display)
+            tab_widget.setLayout(tab_layout)
 
-        host.tabs.addTab(
-            tab_widget,
-            get_phase_icon(host, spec.phase) + " " + spec.title,
-        )
+            self.tabs.addTab(
+                tab_widget,
+                self._get_phase_icon(spec.phase) + " " + spec.title,
+            )
 
-    host.tabs.currentChanged.connect(host._on_tab_changed)
+        self.tabs.currentChanged.connect(self._on_tab_changed)
 
+    def _get_phase_icon(self, phase: CommissioningPhase | None) -> str:
+        """Get status icon for a phase."""
+        projection = self.session.get_active_phase_projection()
+        if projection is None:
+            return "○"
 
-def get_phase_icon(host, phase: CommissioningPhase | None) -> str:
-    """Get status icon for a phase."""
-    projection = host.session.get_active_phase_projection()
-    if projection is None:
+        current_phase = projection.get("current_phase")
+        phase_status = projection.get("phase_status", {})
+
+        if phase is None:
+            return "●"
+
+        status = phase_status.get(phase)
+        if status is not None:
+            if status.value == "complete":
+                return "✓"
+            if status.value == "failed":
+                return "✗"
+
+        if phase == current_phase:
+            return "▶"
+
+        phase_order = CommissioningPhase.get_phase_order()
+        current_idx = phase_order.index(current_phase)
+        phase_idx = phase_order.index(phase)
+        if phase_idx < current_idx:
+            return "✓"
         return "○"
 
-    current_phase = projection.get("current_phase")
-    phase_status = projection.get("phase_status", {})
+    def _update_tab_states(self) -> None:
+        """Update tab states and icons."""
+        projection = self.session.get_active_phase_projection()
+        if projection is None:
+            for i in range(1, self.tabs.count()):
+                self.tabs.setTabEnabled(i, False)
+            return
 
-    if phase is None:
-        return "●"
+        current_phase = projection.get("current_phase")
+        phase_status = projection.get("phase_status", {})
+        phase_order = CommissioningPhase.get_phase_order()
+        current_index = phase_order.index(current_phase)
 
-    status = phase_status.get(phase)
-    if status is not None:
-        if status.value == "complete":
-            return "✓"
-        if status.value == "failed":
-            return "✗"
+        for i, spec in enumerate(self.phase_specs):
+            if spec.phase is None:
+                self.tabs.setTabEnabled(i, True)
+                continue
 
-    if phase == current_phase:
-        return "▶"
+            phase_index = phase_order.index(spec.phase)
+            status = phase_status.get(spec.phase)
+            is_done = status is not None and status.value in {
+                "complete",
+                "skipped",
+            }
+            is_accessible = phase_index <= current_index or is_done
 
-    phase_order = CommissioningPhase.get_phase_order()
-    current_idx = phase_order.index(current_phase)
-    phase_idx = phase_order.index(phase)
-    if phase_idx < current_idx:
-        return "✓"
-    return "○"
+            self.tabs.setTabEnabled(i, is_accessible)
 
+            icon = self._get_phase_icon(spec.phase)
+            self.tabs.setTabText(i, f"{icon} {spec.title}")
 
-def update_tab_states(host) -> None:
-    """Update tab states and icons."""
-    projection = host.session.get_active_phase_projection()
-    if projection is None:
-        for i in range(1, host.tabs.count()):
-            host.tabs.setTabEnabled(i, False)
-        return
+            if status is not None and status.value == "failed":
+                self.tabs.tabBar().setTabTextColor(i, Qt.red)
+            elif phase_index == current_index:
+                self.tabs.tabBar().setTabTextColor(i, Qt.blue)
+            elif phase_index < current_index:
+                self.tabs.tabBar().setTabTextColor(i, Qt.darkGreen)
+            else:
+                self.tabs.tabBar().setTabTextColor(i, Qt.gray)
 
-    current_phase = projection.get("current_phase")
-    phase_status = projection.get("phase_status", {})
-    phase_order = CommissioningPhase.get_phase_order()
-    current_index = phase_order.index(current_phase)
-
-    for i, spec in enumerate(host.phase_specs):
-        if spec.phase is None:
-            host.tabs.setTabEnabled(i, True)
-            continue
-
-        phase_index = phase_order.index(spec.phase)
-        status = phase_status.get(spec.phase)
-        is_done = status is not None and status.value in {"complete", "skipped"}
-        is_accessible = phase_index <= current_index or is_done
-
-        host.tabs.setTabEnabled(i, is_accessible)
-
-        icon = get_phase_icon(host, spec.phase)
-        host.tabs.setTabText(i, f"{icon} {spec.title}")
-
-        if status is not None and status.value == "failed":
-            host.tabs.tabBar().setTabTextColor(i, Qt.red)
-        elif phase_index == current_index:
-            host.tabs.tabBar().setTabTextColor(i, Qt.blue)
-        elif phase_index < current_index:
-            host.tabs.tabBar().setTabTextColor(i, Qt.darkGreen)
-        else:
-            host.tabs.tabBar().setTabTextColor(i, Qt.gray)
+    def _on_tab_changed(self, index: int) -> None:
+        """Handle tab changes by auto-saving current work."""
+        if self.session.has_active_record():
+            try:
+                self.save_active_record()
+            except RecordConflictError:
+                self._update_sync_status(False, "Unsaved changes")
 
 
-def on_tab_changed(host, index: int) -> None:
-    """Handle tab changes by auto-saving current work."""
-    if host.session.has_active_record():
-        try:
-            host.save_active_record()
-        except RecordConflictError:
-            host._update_sync_status(False, "Unsaved changes")
+# Backward-compat aliases so existing tests continue to work.
+init_tabs = _TabsMixin._init_tabs
+get_phase_icon = _TabsMixin._get_phase_icon
+update_tab_states = _TabsMixin._update_tab_states
+on_tab_changed = _TabsMixin._on_tab_changed

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/controllers/batch_piezo_pre_rf_controller.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/controllers/batch_piezo_pre_rf_controller.py
@@ -228,13 +228,13 @@ class BatchPiezoPreRFController(QObject):
             )
 
         # Load or create the commissioning record for this cavity
-        record_id = self.session.db.get_record_id_for_cavity(
+        record_id = self.session.get_record_id_for_cavity(
             linac_idx,
             cavity_spec.cryomodule,
             str(cavity_spec.cavity_number),
         )
         if record_id is not None:
-            loaded = self.session.db.get_record_with_version(record_id)
+            loaded = self.session.get_record_with_version(record_id)
             if loaded is None:
                 raise ValueError(f"Record {record_id} not found in database")
             record, version = loaded
@@ -245,7 +245,7 @@ class BatchPiezoPreRFController(QObject):
                 cryomodule=cavity_spec.cryomodule,
                 cavity_number=cavity_spec.cavity_number,
             )
-            record_id = self.session.db.save_record(record)
+            record_id = self.session.save_record(record)
             state.record_version = 1
 
         state.record = record
@@ -491,7 +491,7 @@ class BatchPiezoPreRFController(QObject):
         if state.record is None or state.record_id is None:
             return
         try:
-            self.session.db.save_record(
+            self.session.save_record(
                 state.record,
                 state.record_id,
                 expected_version=state.record_version,

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/magnet_checkout_dialog.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/magnet_checkout_dialog.py
@@ -1,0 +1,169 @@
+"""Dialog for editing cryomodule magnet checkout status and notes."""
+
+from PyQt5.QtWidgets import (
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QHBoxLayout,
+    QLabel,
+    QMessageBox,
+    QTextEdit,
+    QVBoxLayout,
+)
+
+from sc_linac_physics.applications.rf_commissioning.models.cryomodule_models import (
+    CryomoduleCheckoutRecord,
+    CryomodulePhase,
+    CryomodulePhaseStatus,
+    MagnetCheckoutData,
+)
+from sc_linac_physics.applications.rf_commissioning.models.persistence.database import (
+    RecordConflictError,
+)
+from sc_linac_physics.applications.rf_commissioning.session_manager import (
+    CommissioningSession,
+)
+
+
+class MagnetCheckoutDialog(QDialog):
+    """Modal dialog for recording magnet checkout pass/fail with operator and notes."""
+
+    def __init__(
+        self,
+        session: CommissioningSession,
+        linac: str,
+        cryomodule: str,
+        parent=None,
+    ):
+        super().__init__(parent)
+        self.session = session
+        self.linac = linac
+        self.cryomodule = cryomodule
+
+        self.setWindowTitle(f"Magnet Checkout - {linac}_CM{cryomodule}")
+
+        loaded = session.get_cryomodule_record_with_version(linac, cryomodule)
+        if loaded is None:
+            self._cm_record = CryomoduleCheckoutRecord(
+                linac=linac, cryomodule=cryomodule
+            )
+            self._record_id = None
+            self._record_version = None
+        else:
+            self._cm_record, self._record_version = loaded
+            self._record_id = session.get_cryomodule_record_id(
+                linac, cryomodule
+            )
+
+        self._build_ui()
+
+    def _build_ui(self) -> None:
+        layout = QVBoxLayout()
+
+        status_row = QHBoxLayout()
+        status_row.addWidget(QLabel("Status:"))
+        self.status_combo = QComboBox()
+        self.status_combo.addItems(["PENDING", "PASS", "FAIL"])
+        status_row.addWidget(self.status_combo)
+        layout.addLayout(status_row)
+
+        operator_row = QHBoxLayout()
+        operator_row.addWidget(QLabel("Operator:"))
+        self.operator_combo = QComboBox()
+        self.operator_combo.addItem("👤 Select operator...", "")
+        for op in self.session.get_operators():
+            self.operator_combo.addItem(f"👤 {op}", op)
+        self.operator_combo.setMinimumWidth(200)
+        operator_row.addWidget(self.operator_combo)
+        layout.addLayout(operator_row)
+
+        layout.addWidget(QLabel("Notes:"))
+        self.notes_input = QTextEdit()
+        self.notes_input.setPlaceholderText(
+            "Optional notes for magnet checkout result"
+        )
+        self.notes_input.setMinimumHeight(120)
+        layout.addWidget(self.notes_input)
+
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.Save | QDialogButtonBox.Cancel
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+        self.setLayout(layout)
+        self._populate_from_record()
+
+    def _populate_from_record(self) -> None:
+        checkout = self._cm_record.magnet_checkout
+        if checkout is None:
+            self.status_combo.setCurrentText("PENDING")
+            self.notes_input.setPlainText(self._cm_record.notes or "")
+        else:
+            self.status_combo.setCurrentText(
+                "PASS" if checkout.passed else "FAIL"
+            )
+            self.notes_input.setPlainText(checkout.notes or "")
+            if checkout.operator:
+                idx = self.operator_combo.findData(checkout.operator)
+                if idx >= 0:
+                    self.operator_combo.setCurrentIndex(idx)
+
+    def save(self) -> bool:
+        """Validate and persist the checkout result. Returns True on success."""
+        selected_status = self.status_combo.currentText().upper()
+        selected_operator = self.operator_combo.currentData() or ""
+
+        if selected_status != "PENDING" and not selected_operator:
+            QMessageBox.warning(
+                self,
+                "Operator Required",
+                "An operator must be selected for PASS/FAIL checkout results.",
+            )
+            return False
+
+        notes = self.notes_input.toPlainText().strip()
+
+        if selected_status == "PENDING":
+            self._cm_record.magnet_checkout = None
+            self._cm_record.set_phase_status(
+                CryomodulePhase.MAGNET_CHECKOUT,
+                CryomodulePhaseStatus.NOT_STARTED,
+            )
+        else:
+            self._cm_record.magnet_checkout = MagnetCheckoutData(
+                passed=(selected_status == "PASS"),
+                operator=selected_operator,
+                notes=notes,
+            )
+            self._cm_record.set_phase_status(
+                CryomodulePhase.MAGNET_CHECKOUT,
+                (
+                    CryomodulePhaseStatus.COMPLETE
+                    if selected_status == "PASS"
+                    else CryomodulePhaseStatus.FAILED
+                ),
+            )
+
+        self._cm_record.notes = notes
+
+        try:
+            self.session.save_cryomodule_record(
+                self._cm_record,
+                record_id=self._record_id,
+                expected_version=self._record_version,
+            )
+        except RecordConflictError as conflict:
+            QMessageBox.warning(
+                self,
+                "Save Conflict",
+                (
+                    "Magnet checkout was updated by another user. "
+                    f"Expected version {conflict.expected_version}, "
+                    f"database has version {conflict.current_version}."
+                ),
+            )
+            return False
+
+        return True

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/multi_phase_screen.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/multi_phase_screen.py
@@ -7,79 +7,54 @@ from PyQt5.QtCore import QTimer, Qt
 from PyQt5.QtWidgets import (
     QDialog,
     QDialogButtonBox,
-    QHBoxLayout,
     QLabel,
     QLineEdit,
     QMessageBox,
-    QComboBox,
     QSplitter,
     QTabWidget,
-    QTableWidget,
-    QTextEdit,
     QVBoxLayout,
-    QWidget,
 )
 from pydm import Display, PyDMApplication
 
-from sc_linac_physics.applications.rf_commissioning.models.cryomodule_models import (
-    CryomoduleCheckoutRecord,
-    CryomodulePhase,
-    CryomodulePhaseStatus,
-    MagnetCheckoutData,
-)
 from sc_linac_physics.applications.rf_commissioning.models.data_models import (
-    CommissioningPhase,
     CommissioningRecord,
 )
-from sc_linac_physics.applications.rf_commissioning.models.persistence.database import (
-    RecordConflictError,
+from sc_linac_physics.applications.rf_commissioning.ui.magnet_checkout_dialog import (
+    MagnetCheckoutDialog,
 )
 from sc_linac_physics.applications.rf_commissioning.session_manager import (
     CommissioningSession,
 )
 from sc_linac_physics.applications.rf_commissioning.ui.container import (
     PhaseTabSpec,
-    build_note_dialog,
-    build_compact_progress_bar,
     build_default_phase_specs,
-    build_enhanced_notes_panel,
-    build_header_panel,
-    check_for_external_changes,
-    confirm_and_start_new,
-    dismiss_banner,
-    handle_note_conflict,
-    load_selected_record,
-    load_notes,
-    on_load_or_start,
-    on_edit_note,
-    quick_add_note,
-    reload_from_banner,
-    get_selected_note_ref,
-    handle_save_conflict,
-    load_record,
-    save_active_record,
-    on_phase_advanced,
-    on_tab_changed,
-    start_new_record,
-    show_database_browser,
-    show_measurement_history,
-    show_update_banner,
-    show_notes_context_menu,
-    show_record_selector,
-    sync_cavity_selection_from_record,
-    init_tabs,
-    start_new_from_dialog,
-    get_phase_icon,
-    update_progress_indicator,
-    update_sync_status,
-    update_tab_states,
+    _HeaderMixin,
+    _ProgressMixin,
+    _RecordSelectorMixin,
+    _TabsMixin,
+    _NotesPanelMixin,
+    _NoteActionsMixin,
+    _SyncMixin,
+    _PersistenceMixin,
+    _RecordLifecycleMixin,
 )
 from sc_linac_physics.utils.sc_linac.linac_utils import (
     get_linac_for_cryomodule,
 )
 
 
-class MultiPhaseCommissioningDisplay(Display):
+class MultiPhaseCommissioningDisplay(
+    _TabsMixin,
+    _SyncMixin,
+    _PersistenceMixin,
+    _RecordLifecycleMixin,
+    _RecordSelectorMixin,
+    _NotesPanelMixin,
+    _NoteActionsMixin,
+    _ProgressMixin,
+    _HeaderMixin,
+    Display,
+):
     """Container window that hosts multiple phase displays.
 
     This redesigned display keeps critical information always visible:
@@ -162,13 +137,6 @@ class MultiPhaseCommissioningDisplay(Display):
         # REMOVED: self._restore_last_session()
         # Operator must explicitly select operator and cavity each time
 
-    # =============================================================================
-    # HEADER PANEL - Always visible operator/cavity selection
-    # =============================================================================
-    def _build_header_panel(self) -> QWidget:
-        """Build persistent header with operator and cavity selection."""
-        return build_header_panel(self)
-
     def _on_cavity_selection_changed(self) -> None:
         """Update CM status on CM change; load cavity record only when cavity is selected."""
         cryomodule = self.cryomodule_combo.currentText()
@@ -211,7 +179,7 @@ class MultiPhaseCommissioningDisplay(Display):
             self.magnet_status_badge.set_status("PENDING")
             return
 
-        cm_record = self.session.db.get_cryomodule_record(
+        cm_record = self.session.get_cryomodule_record(
             effective_linac, cryomodule
         )
         if cm_record is None or cm_record.magnet_checkout is None:
@@ -235,7 +203,7 @@ class MultiPhaseCommissioningDisplay(Display):
             return
 
         linac_index = int(effective_linac[1])
-        cavity_records = self.session.db.get_records_by_cryomodule(
+        cavity_records = self.session.get_records_by_cryomodule(
             linac_index, cryomodule, active_only=False
         )
         completed = sum(
@@ -245,8 +213,8 @@ class MultiPhaseCommissioningDisplay(Display):
         )
         self.cavity_completion_label.setText(f"{completed}/8 Complete")
 
-    def _open_magnet_checkout_screen(self) -> None:  # noqa: C901
-        """Open modal screen for CM magnet checkout status and notes."""
+    def _open_magnet_checkout_screen(self) -> None:
+        """Open modal dialog for CM magnet checkout status and notes."""
         cryomodule = self.cryomodule_combo.currentText()
         if not cryomodule or cryomodule == "Select CM...":
             QMessageBox.information(
@@ -265,137 +233,17 @@ class MultiPhaseCommissioningDisplay(Display):
             )
             return
 
-        loaded = self.session.db.get_cryomodule_record_with_version(
-            linac, cryomodule
+        dialog = MagnetCheckoutDialog(
+            self.session, linac, cryomodule, parent=self
         )
-        if loaded is None:
-            cm_record = CryomoduleCheckoutRecord(
-                linac=linac, cryomodule=cryomodule
-            )
-            cm_record_id = None
-            cm_record_version = None
-        else:
-            cm_record, cm_record_version = loaded
-            cm_record_id = self.session.db.get_cryomodule_record_id(
-                linac, cryomodule
-            )
-
-        dialog = QDialog(self)
-        dialog.setWindowTitle(f"Magnet Checkout - {linac}_CM{cryomodule}")
-        dialog_layout = QVBoxLayout()
-
-        status_row = QHBoxLayout()
-        status_row.addWidget(QLabel("Status:"))
-        status_combo = QComboBox()
-        status_combo.addItems(["PENDING", "PASS", "FAIL"])
-        status_row.addWidget(status_combo)
-        dialog_layout.addLayout(status_row)
-
-        # Operator selection (required for PASS/FAIL)
-        operator_row = QHBoxLayout()
-        operator_row.addWidget(QLabel("Operator:"))
-        operator_combo = QComboBox()
-        operator_combo.addItem("👤 Select operator...", "")
-        for op in self.session.get_operators():
-            operator_combo.addItem(f"👤 {op}", op)
-        operator_combo.setMinimumWidth(200)
-        operator_row.addWidget(operator_combo)
-        dialog_layout.addLayout(operator_row)
-
-        dialog_layout.addWidget(QLabel("Notes:"))
-        notes_input = QTextEdit()
-        notes_input.setPlaceholderText(
-            "Optional notes for magnet checkout result"
-        )
-        notes_input.setMinimumHeight(120)
-        dialog_layout.addWidget(notes_input)
-
-        if cm_record.magnet_checkout is None:
-            status_combo.setCurrentText("PENDING")
-            notes_input.setPlainText(cm_record.notes or "")
-        else:
-            status_combo.setCurrentText(
-                "PASS" if cm_record.magnet_checkout.passed else "FAIL"
-            )
-            notes_input.setPlainText(cm_record.magnet_checkout.notes or "")
-            # Pre-populate operator if exists
-            if cm_record.magnet_checkout.operator:
-                idx = operator_combo.findData(
-                    cm_record.magnet_checkout.operator
-                )
-                if idx >= 0:
-                    operator_combo.setCurrentIndex(idx)
-
-        buttons = QDialogButtonBox(
-            QDialogButtonBox.Save | QDialogButtonBox.Cancel
-        )
-        buttons.accepted.connect(dialog.accept)
-        buttons.rejected.connect(dialog.reject)
-        dialog_layout.addWidget(buttons)
-
-        dialog.setLayout(dialog_layout)
-
         if dialog.exec_() != QDialog.Accepted:
             return
 
-        selected_status = status_combo.currentText().upper()
-        selected_operator = operator_combo.currentData() or ""
-
-        # Validate operator is selected for PASS/FAIL
-        if selected_status != "PENDING" and not selected_operator:
-            QMessageBox.warning(
-                self,
-                "Operator Required",
-                "An operator must be selected for PASS/FAIL checkout results.",
-            )
-            return
-
-        notes = notes_input.toPlainText().strip()
-
-        if selected_status == "PENDING":
-            cm_record.magnet_checkout = None
-            cm_record.set_phase_status(
-                CryomodulePhase.MAGNET_CHECKOUT,
-                CryomodulePhaseStatus.NOT_STARTED,
-            )
-        else:
-            cm_record.magnet_checkout = MagnetCheckoutData(
-                passed=(selected_status == "PASS"),
-                operator=selected_operator,
-                notes=notes,
-            )
-            cm_record.set_phase_status(
-                CryomodulePhase.MAGNET_CHECKOUT,
-                (
-                    CryomodulePhaseStatus.COMPLETE
-                    if selected_status == "PASS"
-                    else CryomodulePhaseStatus.FAILED
-                ),
-            )
-
-        cm_record.notes = notes
-
-        try:
-            self.session.db.save_cryomodule_record(
-                cm_record,
-                record_id=cm_record_id,
-                expected_version=cm_record_version,
-            )
-        except RecordConflictError as conflict:
-            QMessageBox.warning(
-                self,
-                "Save Conflict",
-                (
-                    "Magnet checkout was updated by another user. "
-                    f"Expected version {conflict.expected_version}, "
-                    f"database has version {conflict.current_version}."
-                ),
-            )
+        if not dialog.save():
             return
 
         self._refresh_magnet_badge(cryomodule, linac)
         self._refresh_cavity_completion_label(cryomodule)
-
         self._update_sync_status(True, "Magnet checkout updated")
 
     def _populate_operator_combo(self, restore_selection: str = None) -> None:
@@ -409,7 +257,6 @@ class MultiPhaseCommissioningDisplay(Display):
         self.operator_combo.addItem("👤 Select operator...", "")
 
         if operators:
-            # Add all operators
             for op in operators:
                 self.operator_combo.addItem(f"👤 {op}", op)
 
@@ -463,163 +310,6 @@ class MultiPhaseCommissioningDisplay(Display):
         # Reset to previous selection if cancelled
         self.operator_combo.setCurrentIndex(0)
 
-    # =============================================================================
-    # PROGRESS BAR - Compact horizontal phase indicator
-    # =============================================================================
-
-    def _build_compact_progress_bar(self) -> QWidget:
-        return build_compact_progress_bar(self)
-
-    def update_progress_indicator(self, record) -> None:
-        update_progress_indicator(self, record)
-
-    def _on_load_or_start(self) -> None:
-        """Intelligent load/start with validation and recent records."""
-        on_load_or_start(self)
-
-    def _show_record_selector(
-        self,
-        cavity_display_name: str,
-        linac: str,
-        cryomodule: str,
-        cavity_number: str,
-        records: list,
-    ) -> None:
-        """Show dialog to select existing record or start new."""
-        show_record_selector(
-            self,
-            cavity_display_name,
-            linac,
-            cryomodule,
-            cavity_number,
-            records,
-        )
-
-    def _load_selected_record(
-        self, table: QTableWidget, dialog: QDialog
-    ) -> None:
-        """Load the selected record from the table."""
-        load_selected_record(self, table, dialog)
-
-    def _start_new_from_dialog(
-        self,
-        cavity_display_name: str,
-        linac: str,
-        cryomodule: str,
-        cavity_number: str,
-        dialog: QDialog,
-    ) -> None:
-        """Start new record from the selection dialog."""
-        start_new_from_dialog(
-            self,
-            cavity_display_name,
-            linac,
-            cryomodule,
-            cavity_number,
-            dialog,
-        )
-
-    def _confirm_and_start_new(
-        self,
-        cavity_display_name: str,
-        linac: str,
-        cryomodule: str,
-        cavity_number: str,
-    ) -> None:
-        """Confirm and start a new commissioning record."""
-        confirm_and_start_new(
-            self,
-            cavity_display_name,
-            linac,
-            cryomodule,
-            cavity_number,
-        )
-
-    # =============================================================================
-    # TABS - Phase navigation with visual feedback
-    # =============================================================================
-
-    def _init_tabs(self) -> None:
-        init_tabs(self)
-
-    def _get_phase_icon(self, phase: CommissioningPhase | None) -> str:
-        return get_phase_icon(self, phase)
-
-    def _update_tab_states(self) -> None:
-        update_tab_states(self)
-
-    def _on_tab_changed(self, index: int) -> None:
-        on_tab_changed(self, index)
-
-        # =============================================================================
-        # NOTES PANEL - Always accessible note taking
-        # =============================================================================
-
-    def _build_enhanced_notes_panel(self) -> QWidget:
-        """Build always-accessible notes panel with better UX."""
-        return build_enhanced_notes_panel(self)
-
-    def _load_notes(self) -> None:
-        """Load and display all notes for the active record."""
-        load_notes(self)
-
-    def _quick_add_note(self) -> None:
-        quick_add_note(self)
-
-    def _show_notes_context_menu(self, position) -> None:
-        show_notes_context_menu(self, position)
-
-    def _on_edit_note(self) -> None:
-        on_edit_note(self)
-
-    def _get_selected_note_ref(self):
-        return get_selected_note_ref(self)
-
-    def _build_note_dialog(
-        self,
-        title: str,
-        operator_default: str,
-        note_default: str = "",
-    ) -> tuple[str | None, str | None]:
-        return build_note_dialog(
-            self,
-            title,
-            operator_default,
-            note_default,
-        )
-
-    # =============================================================================
-    # SYNC STATUS - External change detection and notification
-    # =============================================================================
-
-    def _update_sync_status(self, is_synced: bool, message: str = "") -> None:
-        update_sync_status(self, is_synced, message)
-
-    def _check_for_external_changes(self) -> None:
-        check_for_external_changes(self)
-
-    def _show_update_banner(self, db_version: int, local_version: int) -> None:
-        show_update_banner(self, db_version, local_version)
-
-    def _reload_from_banner(self) -> None:
-        reload_from_banner(self)
-
-    def _dismiss_banner(self) -> None:
-        dismiss_banner(self)
-
-    def _handle_note_conflict(self, conflict: RecordConflictError) -> None:
-        handle_note_conflict(self, conflict)
-
-    # =============================================================================
-    # RECORD MANAGEMENT
-    # =============================================================================
-
-    def start_new_record(self, cryomodule: str, cavity_number: str) -> bool:
-        return start_new_record(self, cryomodule, cavity_number)
-
-    def load_record(self, record_id: int) -> bool:
-        return load_record(self, record_id)
-
     @staticmethod
     def _linac_str(linac: int) -> str:
         return f"L{linac}B"
@@ -632,30 +322,6 @@ class MultiPhaseCommissioningDisplay(Display):
         linac_str = self._linac_str(record.linac)
         self._refresh_magnet_badge(record.cryomodule, linac_str)
         self._refresh_cavity_completion_label(record.cryomodule, linac_str)
-
-    def _sync_cavity_selection_from_record(
-        self, record: CommissioningRecord
-    ) -> None:
-        sync_cavity_selection_from_record(self, record)
-
-    def on_phase_advanced(self, record: CommissioningRecord) -> None:
-        on_phase_advanced(self, record)
-
-    def save_active_record(self) -> bool:
-        return save_active_record(self)
-
-    def _handle_save_conflict(self, conflict: RecordConflictError) -> bool:
-        return handle_save_conflict(self, conflict)
-
-    # =============================================================================
-    # MEASUREMENT HISTORY
-    # =============================================================================
-
-    def _show_measurement_history(self):
-        show_measurement_history(self)
-
-    def _show_database_browser(self) -> None:
-        show_database_browser(self)
 
     def _open_batch_pre_rf_window(self) -> None:
         """Open (or raise) the floating batch Piezo Pre-RF window."""

--- a/tests/applications/rf_commissioning/test_batch_piezo_pre_rf_controller.py
+++ b/tests/applications/rf_commissioning/test_batch_piezo_pre_rf_controller.py
@@ -30,14 +30,14 @@ from sc_linac_physics.applications.rf_commissioning.models.data_models import (
 
 def _mock_session(*, existing_record_id=None, existing_record=None):
     session = Mock()
-    session.db.get_record_id_for_cavity.return_value = existing_record_id
+    session.get_record_id_for_cavity.return_value = existing_record_id
     if existing_record_id is not None:
         record = existing_record or CommissioningRecord(
             linac=0, cryomodule="01", cavity_number=1
         )
-        session.db.get_record_with_version.return_value = (record, 1)
+        session.get_record_with_version.return_value = (record, 1)
     else:
-        session.db.save_record.return_value = 99
+        session.save_record.return_value = 99
     session.workflow.start_phase_for_record.return_value = SimpleNamespace(
         phase_instance_id=42, run_id=7, attempt_number=1
     )
@@ -136,7 +136,7 @@ class TestInitRecordAndContext:
 
         ctrl._init_record_and_context(state, "op")
 
-        session.db.save_record.assert_called_once()
+        session.save_record.assert_called_once()
         assert state.record is not None
         assert state.record_id == 99
         assert state.record_version == 1
@@ -153,7 +153,7 @@ class TestInitRecordAndContext:
 
         ctrl._init_record_and_context(state, "op")
 
-        session.db.save_record.assert_not_called()
+        session.save_record.assert_not_called()
         assert state.record is existing
         assert state.record_id == 5
         assert state.record_version == 1
@@ -169,7 +169,7 @@ class TestInitRecordAndContext:
 
     def test_raises_when_record_missing_after_id_lookup(self):
         session = _mock_session(existing_record_id=5)
-        session.db.get_record_with_version.return_value = None
+        session.get_record_with_version.return_value = None
         ctrl = _make_controller(session)
         state = CavityRunState(
             spec=CavitySpec(cryomodule="01", cavity_number=1)
@@ -380,7 +380,7 @@ class TestCollectCavity:
     def test_calls_save_record_on_success(self):
         ctrl, state = self._state_with_mock_phase()
         ctrl._collect_cavity(state)
-        ctrl.session.db.save_record.assert_called()
+        ctrl.session.save_record.assert_called()
 
     def test_missing_result_data_emits_failed_and_none_payload(self):
         ctrl, state = self._state_with_mock_phase()
@@ -589,13 +589,13 @@ class TestPersistRecord:
         ctrl, state = _make_state()
         state.record_version = 2
         ctrl._persist_record(state)
-        ctrl.session.db.save_record.assert_called_with(
+        ctrl.session.save_record.assert_called_with(
             state.record, state.record_id, expected_version=2
         )
 
     def test_save_record_exception_does_not_propagate(self):
         ctrl, state = _make_state()
-        ctrl.session.db.save_record.side_effect = RuntimeError("db down")
+        ctrl.session.save_record.side_effect = RuntimeError("db down")
         ctrl._persist_record(state)  # should not raise
 
 

--- a/tests/applications/rf_commissioning/ui/test_container_helpers.py
+++ b/tests/applications/rf_commissioning/ui/test_container_helpers.py
@@ -23,6 +23,15 @@ from sc_linac_physics.applications.rf_commissioning.models.persistence.database 
     RecordConflictError,
 )
 from sc_linac_physics.applications.rf_commissioning.ui.container import (
+    _HeaderMixin,
+    _NoteActionsMixin,
+    _NotesPanelMixin,
+    _PersistenceMixin,
+    _ProgressMixin,
+    _RecordLifecycleMixin,
+    _RecordSelectorMixin,
+    _SyncMixin,
+    _TabsMixin,
     note_actions,
     notes,
     persistence,
@@ -31,6 +40,21 @@ from sc_linac_physics.applications.rf_commissioning.ui.container import (
     sync,
     tab_state,
 )
+
+
+class _Stub(
+    _TabsMixin,
+    _SyncMixin,
+    _PersistenceMixin,
+    _RecordLifecycleMixin,
+    _RecordSelectorMixin,
+    _NotesPanelMixin,
+    _NoteActionsMixin,
+    _ProgressMixin,
+    _HeaderMixin,
+    QWidget,
+):
+    """Minimal QWidget stub that carries all mixin methods for unit testing."""
 
 
 class _Signal:
@@ -80,7 +104,7 @@ class _Tabs:
 
 @pytest.fixture
 def host_stub(qtbot):
-    host = QWidget()
+    host = _Stub()
     qtbot.addWidget(host)
     host.setLayout(QVBoxLayout())
 
@@ -88,10 +112,10 @@ def host_stub(qtbot):
         get_active_phase_projection=Mock(return_value=None),
         has_active_record=Mock(return_value=False),
         get_active_record_id=Mock(return_value=None),
+        get_active_record_version=Mock(return_value=1),
+        get_record_with_version=Mock(return_value=None),
         get_operators=Mock(return_value=["Alice", "Bob"]),
         add_operator=Mock(),
-        _active_record_version=1,
-        db=SimpleNamespace(get_record_with_version=Mock(return_value=None)),
         database=object(),
     )
     host.tabs = _Tabs()
@@ -104,6 +128,13 @@ def host_stub(qtbot):
     host._update_cm_status_panel = Mock()
     host.save_active_record = Mock()
     host._on_tab_changed = Mock()
+    # Delegate to module-level aliases so monkeypatch on the alias still works.
+    host._build_note_dialog = lambda *a, **kw: note_actions.build_note_dialog(
+        host, *a, **kw
+    )
+    host._confirm_and_start_new = (
+        lambda *a, **kw: records.confirm_and_start_new(host, *a, **kw)
+    )
 
     host.cryomodule_combo = QComboBox()
     host.cryomodule_combo.addItem("Select CM...")
@@ -240,11 +271,11 @@ def test_sync_helpers_cover_change_and_reload_paths(host_stub, monkeypatch):
 
     host_stub.session.has_active_record.return_value = True
     host_stub.session.get_active_record_id.return_value = 7
-    host_stub.session.db.get_record_with_version.return_value = (
+    host_stub.session.get_record_with_version.return_value = (
         object(),
         5,
     )
-    host_stub.session._active_record_version = 3
+    host_stub.session.get_active_record_version.return_value = 3
 
     sync.check_for_external_changes(host_stub)
     assert host_stub._update_banner is not None
@@ -316,7 +347,7 @@ def test_persistence_save_and_merge_paths(host_stub, monkeypatch):
             return 0
 
     monkeypatch.setattr(persistence, "MergeDialog", _CancelMerge)
-    host_stub.session.db.get_record_with_version.return_value = (
+    host_stub.session.get_record_with_version.return_value = (
         SimpleNamespace(),
         2,
     )
@@ -422,7 +453,7 @@ def test_records_load_and_start_paths(host_stub, monkeypatch):
     host_stub.operator_combo.setCurrentIndex(1)
     host_stub.cryomodule_combo.setCurrentIndex(1)
     host_stub.cavity_combo.setCurrentIndex(1)
-    host_stub.session.db.find_records_for_cavity = Mock(return_value=[])
+    host_stub.session.find_records_for_cavity = Mock(return_value=[])
 
     monkeypatch.setattr(records, "get_linac_for_cryomodule", lambda _cm: "L1B")
     called = Mock()
@@ -533,10 +564,10 @@ def test_persistence_merge_success_failure_and_dialogs(host_stub, monkeypatch):
         def get_merged_record(self):
             return SimpleNamespace()
 
-    host_stub.session.db = SimpleNamespace(
-        get_record_with_version=Mock(return_value=(SimpleNamespace(), 7)),
-        save_record=Mock(),
+    host_stub.session.get_record_with_version = Mock(
+        return_value=(SimpleNamespace(), 7)
     )
+    host_stub.session.save_record = Mock()
     monkeypatch.setattr(persistence, "MergeDialog", _MergeAccepted)
     assert (
         persistence.handle_save_conflict(
@@ -547,13 +578,12 @@ def test_persistence_merge_success_failure_and_dialogs(host_stub, monkeypatch):
         )
         is True
     )
-    assert host_stub.session.db.save_record.call_count == 1
+    assert host_stub.session.save_record.call_count == 1
     assert (
-        host_stub.session.db.save_record.call_args.kwargs["expected_version"]
-        == 7
+        host_stub.session.save_record.call_args.kwargs["expected_version"] == 7
     )
 
-    host_stub.session.db.save_record = Mock(
+    host_stub.session.save_record = Mock(
         side_effect=RuntimeError("save failed")
     )
     assert (
@@ -602,15 +632,13 @@ def test_persistence_merge_retries_on_second_conflict(host_stub, monkeypatch):
                 actual_version=8,
             )
 
-    host_stub.session.db = SimpleNamespace(
-        get_record_with_version=Mock(
-            side_effect=[
-                (SimpleNamespace(name="v7"), 7),
-                (SimpleNamespace(name="v8"), 8),
-            ]
-        ),
-        save_record=Mock(side_effect=_save_record),
+    host_stub.session.get_record_with_version = Mock(
+        side_effect=[
+            (SimpleNamespace(name="v7"), 7),
+            (SimpleNamespace(name="v8"), 8),
+        ]
     )
+    host_stub.session.save_record = Mock(side_effect=_save_record)
 
     monkeypatch.setattr(persistence, "MergeDialog", _MergeAccepted)
 
@@ -627,15 +655,15 @@ def test_persistence_merge_retries_on_second_conflict(host_stub, monkeypatch):
     )
 
     assert dialog_calls["count"] == 2
-    assert host_stub.session.db.save_record.call_count == 2
+    assert host_stub.session.save_record.call_count == 2
     assert (
-        host_stub.session.db.save_record.call_args_list[0].kwargs[
+        host_stub.session.save_record.call_args_list[0].kwargs[
             "expected_version"
         ]
         == 7
     )
     assert (
-        host_stub.session.db.save_record.call_args_list[1].kwargs[
+        host_stub.session.save_record.call_args_list[1].kwargs[
             "expected_version"
         ]
         == 8

--- a/tests/applications/rf_commissioning/ui/test_container_ui_builders.py
+++ b/tests/applications/rf_commissioning/ui/test_container_ui_builders.py
@@ -84,6 +84,9 @@ def test_show_record_selector_renders_table_and_hooks_actions(
     host = QWidget()
     host.load_record = Mock(return_value=True)
     host._update_sync_status = Mock()
+    host._load_selected_record = (
+        lambda table, dialog: records.load_selected_record(host, table, dialog)
+    )
     qtbot.addWidget(host)
 
     records_data = [

--- a/tests/applications/rf_commissioning/ui/test_multi_phase_screen.py
+++ b/tests/applications/rf_commissioning/ui/test_multi_phase_screen.py
@@ -4,14 +4,11 @@ from types import SimpleNamespace
 from unittest.mock import Mock, call
 
 import pytest
-from PyQt5.QtWidgets import QComboBox, QDialog, QLabel, QTextEdit
+from PyQt5.QtWidgets import QComboBox, QDialog, QLabel
 
 import sc_linac_physics.applications.rf_commissioning.ui.multi_phase_screen as multi_phase_screen
 from sc_linac_physics.applications.rf_commissioning.models.data_models import (
     CommissioningPhase,
-)
-from sc_linac_physics.applications.rf_commissioning.models.cryomodule_models import (
-    CryomoduleCheckoutRecord,
 )
 from sc_linac_physics.applications.rf_commissioning.ui.multi_phase_screen import (
     MultiPhaseCommissioningDisplay,
@@ -28,11 +25,14 @@ class _StaticCombo:
 
 @pytest.fixture
 def display_stub():
-    db = Mock()
     session = SimpleNamespace(
-        db=db,
         get_operators=Mock(return_value=["Alice", "Bob"]),
         add_operator=Mock(),
+        get_cryomodule_record=Mock(return_value=None),
+        get_records_by_cryomodule=Mock(return_value=[]),
+        get_cryomodule_record_with_version=Mock(return_value=None),
+        get_cryomodule_record_id=Mock(return_value=None),
+        save_cryomodule_record=Mock(),
     )
     return SimpleNamespace(
         session=session,
@@ -79,27 +79,27 @@ def test_on_cavity_selection_changed_starts_or_loads(display_stub, monkeypatch):
 def test_refresh_magnet_badge_maps_statuses(display_stub):
     linac = "L1B"
 
-    display_stub.session.db.get_cryomodule_record.return_value = None
+    display_stub.session.get_cryomodule_record.return_value = None
     MultiPhaseCommissioningDisplay._refresh_magnet_badge(
         display_stub, "01", linac
     )
 
-    display_stub.session.db.get_cryomodule_record.return_value = (
-        SimpleNamespace(magnet_checkout=None)
-    )
-    MultiPhaseCommissioningDisplay._refresh_magnet_badge(
-        display_stub, "01", linac
-    )
-
-    display_stub.session.db.get_cryomodule_record.return_value = (
-        SimpleNamespace(magnet_checkout=SimpleNamespace(passed=True))
+    display_stub.session.get_cryomodule_record.return_value = SimpleNamespace(
+        magnet_checkout=None
     )
     MultiPhaseCommissioningDisplay._refresh_magnet_badge(
         display_stub, "01", linac
     )
 
-    display_stub.session.db.get_cryomodule_record.return_value = (
-        SimpleNamespace(magnet_checkout=SimpleNamespace(passed=False))
+    display_stub.session.get_cryomodule_record.return_value = SimpleNamespace(
+        magnet_checkout=SimpleNamespace(passed=True)
+    )
+    MultiPhaseCommissioningDisplay._refresh_magnet_badge(
+        display_stub, "01", linac
+    )
+
+    display_stub.session.get_cryomodule_record.return_value = SimpleNamespace(
+        magnet_checkout=SimpleNamespace(passed=False)
     )
     MultiPhaseCommissioningDisplay._refresh_magnet_badge(
         display_stub, "01", linac
@@ -114,7 +114,7 @@ def test_refresh_magnet_badge_maps_statuses(display_stub):
 
 
 def test_refresh_cavity_completion_label_counts_complete_records(display_stub):
-    display_stub.session.db.get_records_by_cryomodule.return_value = [
+    display_stub.session.get_records_by_cryomodule.return_value = [
         SimpleNamespace(
             current_phase=CommissioningPhase.COMPLETE,
             overall_status="in_progress",
@@ -193,7 +193,7 @@ def test_open_magnet_checkout_screen_requires_cryomodule(
     info.assert_called_once()
 
 
-def test_open_magnet_checkout_screen_requires_operator_for_pass(
+def test_open_magnet_checkout_screen_cancelled_does_nothing(
     display_stub, monkeypatch
 ):
     monkeypatch.setattr(
@@ -201,30 +201,17 @@ def test_open_magnet_checkout_screen_requires_operator_for_pass(
         "get_linac_for_cryomodule",
         lambda _cm: "L1B",
     )
-    display_stub.session.db.get_cryomodule_record_with_version.return_value = (
-        CryomoduleCheckoutRecord(linac="L1B", cryomodule="01"),
-        3,
+    dialog_mock = Mock()
+    dialog_mock.exec_.return_value = QDialog.Rejected
+    monkeypatch.setattr(
+        multi_phase_screen, "MagnetCheckoutDialog", lambda *a, **kw: dialog_mock
     )
-    display_stub.session.db.get_cryomodule_record_id.return_value = 9
-
-    class _Dialog(QDialog):
-        def __init__(self, parent=None):
-            super().__init__(None)
-
-        def exec_(self):
-            combos = self.findChildren(QComboBox)
-            combos[0].setCurrentText("PASS")
-            combos[1].setCurrentIndex(0)
-            return QDialog.Accepted
-
-    warn = Mock()
-    monkeypatch.setattr(multi_phase_screen, "QDialog", _Dialog)
-    monkeypatch.setattr(multi_phase_screen.QMessageBox, "warning", warn)
+    display_stub._refresh_magnet_badge = Mock()
 
     MultiPhaseCommissioningDisplay._open_magnet_checkout_screen(display_stub)
 
-    assert "Operator Required" in warn.call_args.args[1]
-    display_stub.session.db.save_cryomodule_record.assert_not_called()
+    dialog_mock.save.assert_not_called()
+    display_stub._refresh_magnet_badge.assert_not_called()
 
 
 def test_open_magnet_checkout_screen_saves_and_updates_header(
@@ -235,37 +222,42 @@ def test_open_magnet_checkout_screen_saves_and_updates_header(
         "get_linac_for_cryomodule",
         lambda _cm: "L1B",
     )
-    display_stub.session.db.get_cryomodule_record_with_version.return_value = (
-        CryomoduleCheckoutRecord(linac="L1B", cryomodule="01"),
-        3,
+    dialog_mock = Mock()
+    dialog_mock.exec_.return_value = QDialog.Accepted
+    dialog_mock.save.return_value = True
+    monkeypatch.setattr(
+        multi_phase_screen, "MagnetCheckoutDialog", lambda *a, **kw: dialog_mock
     )
-    display_stub.session.db.get_cryomodule_record_id.return_value = 9
     display_stub._refresh_magnet_badge = Mock()
     display_stub._refresh_cavity_completion_label = Mock()
 
-    class _Dialog(QDialog):
-        def __init__(self, parent=None):
-            super().__init__(None)
-
-        def exec_(self):
-            combos = self.findChildren(QComboBox)
-            combos[0].setCurrentText("PASS")
-            combos[1].setCurrentIndex(1)
-            self.findChildren(QTextEdit)[0].setPlainText(" done ")
-            return QDialog.Accepted
-
-    monkeypatch.setattr(multi_phase_screen, "QDialog", _Dialog)
-
     MultiPhaseCommissioningDisplay._open_magnet_checkout_screen(display_stub)
 
-    save_call = display_stub.session.db.save_cryomodule_record.call_args
-    saved_record = save_call.args[0]
-    assert saved_record.magnet_checkout.passed is True
-    assert saved_record.magnet_checkout.operator == "Alice"
-    assert saved_record.magnet_checkout.notes == "done"
+    dialog_mock.save.assert_called_once()
     display_stub._refresh_magnet_badge.assert_called_once_with("01", "L1B")
     display_stub._refresh_cavity_completion_label.assert_called_once_with("01")
     display_stub._update_sync_status.assert_called_once()
+
+
+def test_open_magnet_checkout_screen_save_failure_skips_refresh(
+    display_stub, monkeypatch
+):
+    monkeypatch.setattr(
+        multi_phase_screen,
+        "get_linac_for_cryomodule",
+        lambda _cm: "L1B",
+    )
+    dialog_mock = Mock()
+    dialog_mock.exec_.return_value = QDialog.Accepted
+    dialog_mock.save.return_value = False
+    monkeypatch.setattr(
+        multi_phase_screen, "MagnetCheckoutDialog", lambda *a, **kw: dialog_mock
+    )
+    display_stub._refresh_magnet_badge = Mock()
+
+    MultiPhaseCommissioningDisplay._open_magnet_checkout_screen(display_stub)
+
+    display_stub._refresh_magnet_badge.assert_not_called()
 
 
 def test_update_cm_status_panel_ignores_none_and_updates_valid_record(


### PR DESCRIPTION

Three structural cleanups in the multi-phase commissioning UI:

1. Session facade — all UI code now calls CommissioningSession proxy methods instead of reaching through session.db directly. Added get_record_with_version, save_record, find_records_for_cavity, get_cryomodule_record, and related methods to CommissioningSession; updated batch controller and all container helpers accordingly.

2. MagnetCheckoutDialog — extracted the 130-line inline dialog from _open_magnet_checkout_screen into a proper MagnetCheckoutDialog(QDialog) class in ui/magnet_checkout_dialog.py.

3. Mixin conversion — all nine ui/container/ modules are now mixin classes (_TabsMixin, _SyncMixin, _PersistenceMixin, _RecordLifecycleMixin, _RecordSelectorMixin, _NotesPanelMixin, _NoteActionsMixin, _ProgressMixin, _HeaderMixin). MultiPhaseCommissioningDisplay inherits from all nine, removing ~33 trivial one-liner wrapper methods. Backward-compat module-level aliases are retained so existing test call sites continue to work.

Generated with AI

Co-Authored-By: SLAC AI