### PR TITLE
refactor(rf-commissioning): add session facade methods and extract MagnetCheckoutDialog

### DIFF
--- a/src/sc_linac_physics/applications/rf_commissioning/session_manager.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/session_manager.py
@@ -5,6 +5,9 @@ Coordinates database access and record management across all commissioning phase
 
 import logging
 
+from sc_linac_physics.applications.rf_commissioning.models.cryomodule_models import (
+    CryomoduleCheckoutRecord,
+)
 from sc_linac_physics.applications.rf_commissioning.models.data_models import (
     CommissioningRecord,
     CommissioningPhase,
@@ -600,3 +603,65 @@ class CommissioningSession:
         except Exception as e:
             logger.exception("Failed to update general note: %s", e)
             return False
+
+    # ==================== RECORD QUERY METHODS ====================
+
+    def get_record_with_version(
+        self, record_id: int
+    ) -> tuple[CommissioningRecord, int] | None:
+        return self.db.get_record_with_version(record_id)
+
+    def save_record(
+        self,
+        record: CommissioningRecord,
+        record_id: int | None = None,
+        expected_version: int | None = None,
+    ) -> int:
+        return self.db.save_record(record, record_id, expected_version)
+
+    def find_records_for_cavity(
+        self, linac: int, cryomodule: str, cavity_number: str
+    ) -> list[dict]:
+        return self.db.find_records_for_cavity(linac, cryomodule, cavity_number)
+
+    def get_record_id_for_cavity(
+        self, linac: int, cryomodule: str, cavity_number: str
+    ) -> int | None:
+        return self.db.get_record_id_for_cavity(
+            linac, cryomodule, cavity_number
+        )
+
+    def get_active_record_version(self) -> int | None:
+        return self._active_record_version
+
+    # ==================== CRYOMODULE METHODS ====================
+
+    def get_cryomodule_record(
+        self, linac: str, cryomodule: str
+    ) -> CryomoduleCheckoutRecord | None:
+        return self.db.get_cryomodule_record(linac, cryomodule)
+
+    def get_cryomodule_record_with_version(
+        self, linac: str, cryomodule: str
+    ) -> tuple[CryomoduleCheckoutRecord, int] | None:
+        return self.db.get_cryomodule_record_with_version(linac, cryomodule)
+
+    def get_cryomodule_record_id(
+        self, linac: str, cryomodule: str
+    ) -> int | None:
+        return self.db.get_cryomodule_record_id(linac, cryomodule)
+
+    def save_cryomodule_record(
+        self,
+        record: CryomoduleCheckoutRecord,
+        record_id: int | None = None,
+        expected_version: int | None = None,
+    ) -> int:
+        return self.db.save_cryomodule_record(
+            record, record_id, expected_version
+        )
+
+    def get_records_by_cryomodule(
+        self, linac: int, cryomodule: str, active_only: bool = False
+    ) -> list[CommissioningRecord]:
+        return self.db.get_records_by_cryomodule(linac, cryomodule, active_only)

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/controllers/batch_piezo_pre_rf_controller.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/controllers/batch_piezo_pre_rf_controller.py
@@ -228,13 +228,13 @@ class BatchPiezoPreRFController(QObject):
             )
 
         # Load or create the commissioning record for this cavity
-        record_id = self.session.db.get_record_id_for_cavity(
+        record_id = self.session.get_record_id_for_cavity(
             linac_idx,
             cavity_spec.cryomodule,
             str(cavity_spec.cavity_number),
         )
         if record_id is not None:
-            loaded = self.session.db.get_record_with_version(record_id)
+            loaded = self.session.get_record_with_version(record_id)
             if loaded is None:
                 raise ValueError(f"Record {record_id} not found in database")
             record, version = loaded
@@ -245,7 +245,7 @@ class BatchPiezoPreRFController(QObject):
                 cryomodule=cavity_spec.cryomodule,
                 cavity_number=cavity_spec.cavity_number,
             )
-            record_id = self.session.db.save_record(record)
+            record_id = self.session.save_record(record)
             state.record_version = 1
 
         state.record = record
@@ -491,7 +491,7 @@ class BatchPiezoPreRFController(QObject):
         if state.record is None or state.record_id is None:
             return
         try:
-            self.session.db.save_record(
+            self.session.save_record(
                 state.record,
                 state.record_id,
                 expected_version=state.record_version,

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/magnet_checkout_dialog.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/magnet_checkout_dialog.py
@@ -1,0 +1,169 @@
+"""Dialog for editing cryomodule magnet checkout status and notes."""
+
+from PyQt5.QtWidgets import (
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QHBoxLayout,
+    QLabel,
+    QMessageBox,
+    QTextEdit,
+    QVBoxLayout,
+)
+
+from sc_linac_physics.applications.rf_commissioning.models.cryomodule_models import (
+    CryomoduleCheckoutRecord,
+    CryomodulePhase,
+    CryomodulePhaseStatus,
+    MagnetCheckoutData,
+)
+from sc_linac_physics.applications.rf_commissioning.models.persistence.database import (
+    RecordConflictError,
+)
+from sc_linac_physics.applications.rf_commissioning.session_manager import (
+    CommissioningSession,
+)
+
+
+class MagnetCheckoutDialog(QDialog):
+    """Modal dialog for recording magnet checkout pass/fail with operator and notes."""
+
+    def __init__(
+        self,
+        session: CommissioningSession,
+        linac: str,
+        cryomodule: str,
+        parent=None,
+    ):
+        super().__init__(parent)
+        self.session = session
+        self.linac = linac
+        self.cryomodule = cryomodule
+
+        self.setWindowTitle(f"Magnet Checkout - {linac}_CM{cryomodule}")
+
+        loaded = session.get_cryomodule_record_with_version(linac, cryomodule)
+        if loaded is None:
+            self._cm_record = CryomoduleCheckoutRecord(
+                linac=linac, cryomodule=cryomodule
+            )
+            self._record_id = None
+            self._record_version = None
+        else:
+            self._cm_record, self._record_version = loaded
+            self._record_id = session.get_cryomodule_record_id(
+                linac, cryomodule
+            )
+
+        self._build_ui()
+
+    def _build_ui(self) -> None:
+        layout = QVBoxLayout()
+
+        status_row = QHBoxLayout()
+        status_row.addWidget(QLabel("Status:"))
+        self.status_combo = QComboBox()
+        self.status_combo.addItems(["PENDING", "PASS", "FAIL"])
+        status_row.addWidget(self.status_combo)
+        layout.addLayout(status_row)
+
+        operator_row = QHBoxLayout()
+        operator_row.addWidget(QLabel("Operator:"))
+        self.operator_combo = QComboBox()
+        self.operator_combo.addItem("👤 Select operator...", "")
+        for op in self.session.get_operators():
+            self.operator_combo.addItem(f"👤 {op}", op)
+        self.operator_combo.setMinimumWidth(200)
+        operator_row.addWidget(self.operator_combo)
+        layout.addLayout(operator_row)
+
+        layout.addWidget(QLabel("Notes:"))
+        self.notes_input = QTextEdit()
+        self.notes_input.setPlaceholderText(
+            "Optional notes for magnet checkout result"
+        )
+        self.notes_input.setMinimumHeight(120)
+        layout.addWidget(self.notes_input)
+
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.Save | QDialogButtonBox.Cancel
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+        self.setLayout(layout)
+        self._populate_from_record()
+
+    def _populate_from_record(self) -> None:
+        checkout = self._cm_record.magnet_checkout
+        if checkout is None:
+            self.status_combo.setCurrentText("PENDING")
+            self.notes_input.setPlainText(self._cm_record.notes or "")
+        else:
+            self.status_combo.setCurrentText(
+                "PASS" if checkout.passed else "FAIL"
+            )
+            self.notes_input.setPlainText(checkout.notes or "")
+            if checkout.operator:
+                idx = self.operator_combo.findData(checkout.operator)
+                if idx >= 0:
+                    self.operator_combo.setCurrentIndex(idx)
+
+    def save(self) -> bool:
+        """Validate and persist the checkout result. Returns True on success."""
+        selected_status = self.status_combo.currentText().upper()
+        selected_operator = self.operator_combo.currentData() or ""
+
+        if selected_status != "PENDING" and not selected_operator:
+            QMessageBox.warning(
+                self,
+                "Operator Required",
+                "An operator must be selected for PASS/FAIL checkout results.",
+            )
+            return False
+
+        notes = self.notes_input.toPlainText().strip()
+
+        if selected_status == "PENDING":
+            self._cm_record.magnet_checkout = None
+            self._cm_record.set_phase_status(
+                CryomodulePhase.MAGNET_CHECKOUT,
+                CryomodulePhaseStatus.NOT_STARTED,
+            )
+        else:
+            self._cm_record.magnet_checkout = MagnetCheckoutData(
+                passed=(selected_status == "PASS"),
+                operator=selected_operator,
+                notes=notes,
+            )
+            self._cm_record.set_phase_status(
+                CryomodulePhase.MAGNET_CHECKOUT,
+                (
+                    CryomodulePhaseStatus.COMPLETE
+                    if selected_status == "PASS"
+                    else CryomodulePhaseStatus.FAILED
+                ),
+            )
+
+        self._cm_record.notes = notes
+
+        try:
+            self.session.save_cryomodule_record(
+                self._cm_record,
+                record_id=self._record_id,
+                expected_version=self._record_version,
+            )
+        except RecordConflictError as conflict:
+            QMessageBox.warning(
+                self,
+                "Save Conflict",
+                (
+                    "Magnet checkout was updated by another user. "
+                    f"Expected version {conflict.expected_version}, "
+                    f"database has version {conflict.current_version}."
+                ),
+            )
+            return False
+
+        return True

--- a/src/sc_linac_physics/applications/rf_commissioning/ui/multi_phase_screen.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/ui/multi_phase_screen.py
@@ -7,25 +7,19 @@ from PyQt5.QtCore import QTimer, Qt
 from PyQt5.QtWidgets import (
     QDialog,
     QDialogButtonBox,
-    QHBoxLayout,
     QLabel,
     QLineEdit,
     QMessageBox,
-    QComboBox,
     QSplitter,
     QTabWidget,
     QTableWidget,
-    QTextEdit,
     QVBoxLayout,
     QWidget,
 )
 from pydm import Display, PyDMApplication
 
-from sc_linac_physics.applications.rf_commissioning.models.cryomodule_models import (
-    CryomoduleCheckoutRecord,
-    CryomodulePhase,
-    CryomodulePhaseStatus,
-    MagnetCheckoutData,
+from sc_linac_physics.applications.rf_commissioning.ui.magnet_checkout_dialog import (
+    MagnetCheckoutDialog,
 )
 from sc_linac_physics.applications.rf_commissioning.models.data_models import (
     CommissioningPhase,
@@ -211,7 +205,7 @@ class MultiPhaseCommissioningDisplay(Display):
             self.magnet_status_badge.set_status("PENDING")
             return
 
-        cm_record = self.session.db.get_cryomodule_record(
+        cm_record = self.session.get_cryomodule_record(
             effective_linac, cryomodule
         )
         if cm_record is None or cm_record.magnet_checkout is None:
@@ -235,7 +229,7 @@ class MultiPhaseCommissioningDisplay(Display):
             return
 
         linac_index = int(effective_linac[1])
-        cavity_records = self.session.db.get_records_by_cryomodule(
+        cavity_records = self.session.get_records_by_cryomodule(
             linac_index, cryomodule, active_only=False
         )
         completed = sum(
@@ -245,8 +239,8 @@ class MultiPhaseCommissioningDisplay(Display):
         )
         self.cavity_completion_label.setText(f"{completed}/8 Complete")
 
-    def _open_magnet_checkout_screen(self) -> None:  # noqa: C901
-        """Open modal screen for CM magnet checkout status and notes."""
+    def _open_magnet_checkout_screen(self) -> None:
+        """Open modal dialog for CM magnet checkout status and notes."""
         cryomodule = self.cryomodule_combo.currentText()
         if not cryomodule or cryomodule == "Select CM...":
             QMessageBox.information(
@@ -265,137 +259,17 @@ class MultiPhaseCommissioningDisplay(Display):
             )
             return
 
-        loaded = self.session.db.get_cryomodule_record_with_version(
-            linac, cryomodule
+        dialog = MagnetCheckoutDialog(
+            self.session, linac, cryomodule, parent=self
         )
-        if loaded is None:
-            cm_record = CryomoduleCheckoutRecord(
-                linac=linac, cryomodule=cryomodule
-            )
-            cm_record_id = None
-            cm_record_version = None
-        else:
-            cm_record, cm_record_version = loaded
-            cm_record_id = self.session.db.get_cryomodule_record_id(
-                linac, cryomodule
-            )
-
-        dialog = QDialog(self)
-        dialog.setWindowTitle(f"Magnet Checkout - {linac}_CM{cryomodule}")
-        dialog_layout = QVBoxLayout()
-
-        status_row = QHBoxLayout()
-        status_row.addWidget(QLabel("Status:"))
-        status_combo = QComboBox()
-        status_combo.addItems(["PENDING", "PASS", "FAIL"])
-        status_row.addWidget(status_combo)
-        dialog_layout.addLayout(status_row)
-
-        # Operator selection (required for PASS/FAIL)
-        operator_row = QHBoxLayout()
-        operator_row.addWidget(QLabel("Operator:"))
-        operator_combo = QComboBox()
-        operator_combo.addItem("👤 Select operator...", "")
-        for op in self.session.get_operators():
-            operator_combo.addItem(f"👤 {op}", op)
-        operator_combo.setMinimumWidth(200)
-        operator_row.addWidget(operator_combo)
-        dialog_layout.addLayout(operator_row)
-
-        dialog_layout.addWidget(QLabel("Notes:"))
-        notes_input = QTextEdit()
-        notes_input.setPlaceholderText(
-            "Optional notes for magnet checkout result"
-        )
-        notes_input.setMinimumHeight(120)
-        dialog_layout.addWidget(notes_input)
-
-        if cm_record.magnet_checkout is None:
-            status_combo.setCurrentText("PENDING")
-            notes_input.setPlainText(cm_record.notes or "")
-        else:
-            status_combo.setCurrentText(
-                "PASS" if cm_record.magnet_checkout.passed else "FAIL"
-            )
-            notes_input.setPlainText(cm_record.magnet_checkout.notes or "")
-            # Pre-populate operator if exists
-            if cm_record.magnet_checkout.operator:
-                idx = operator_combo.findData(
-                    cm_record.magnet_checkout.operator
-                )
-                if idx >= 0:
-                    operator_combo.setCurrentIndex(idx)
-
-        buttons = QDialogButtonBox(
-            QDialogButtonBox.Save | QDialogButtonBox.Cancel
-        )
-        buttons.accepted.connect(dialog.accept)
-        buttons.rejected.connect(dialog.reject)
-        dialog_layout.addWidget(buttons)
-
-        dialog.setLayout(dialog_layout)
-
         if dialog.exec_() != QDialog.Accepted:
             return
 
-        selected_status = status_combo.currentText().upper()
-        selected_operator = operator_combo.currentData() or ""
-
-        # Validate operator is selected for PASS/FAIL
-        if selected_status != "PENDING" and not selected_operator:
-            QMessageBox.warning(
-                self,
-                "Operator Required",
-                "An operator must be selected for PASS/FAIL checkout results.",
-            )
-            return
-
-        notes = notes_input.toPlainText().strip()
-
-        if selected_status == "PENDING":
-            cm_record.magnet_checkout = None
-            cm_record.set_phase_status(
-                CryomodulePhase.MAGNET_CHECKOUT,
-                CryomodulePhaseStatus.NOT_STARTED,
-            )
-        else:
-            cm_record.magnet_checkout = MagnetCheckoutData(
-                passed=(selected_status == "PASS"),
-                operator=selected_operator,
-                notes=notes,
-            )
-            cm_record.set_phase_status(
-                CryomodulePhase.MAGNET_CHECKOUT,
-                (
-                    CryomodulePhaseStatus.COMPLETE
-                    if selected_status == "PASS"
-                    else CryomodulePhaseStatus.FAILED
-                ),
-            )
-
-        cm_record.notes = notes
-
-        try:
-            self.session.db.save_cryomodule_record(
-                cm_record,
-                record_id=cm_record_id,
-                expected_version=cm_record_version,
-            )
-        except RecordConflictError as conflict:
-            QMessageBox.warning(
-                self,
-                "Save Conflict",
-                (
-                    "Magnet checkout was updated by another user. "
-                    f"Expected version {conflict.expected_version}, "
-                    f"database has version {conflict.current_version}."
-                ),
-            )
+        if not dialog.save():
             return
 
         self._refresh_magnet_badge(cryomodule, linac)
         self._refresh_cavity_completion_label(cryomodule)
-
         self._update_sync_status(True, "Magnet checkout updated")
 
     def _populate_operator_combo(self, restore_selection: str = None) -> None:

--- a/tests/applications/rf_commissioning/test_batch_piezo_pre_rf_controller.py
+++ b/tests/applications/rf_commissioning/test_batch_piezo_pre_rf_controller.py
@@ -30,14 +30,14 @@ from sc_linac_physics.applications.rf_commissioning.models.data_models import (
 
 def _mock_session(*, existing_record_id=None, existing_record=None):
     session = Mock()
-    session.db.get_record_id_for_cavity.return_value = existing_record_id
+    session.get_record_id_for_cavity.return_value = existing_record_id
     if existing_record_id is not None:
         record = existing_record or CommissioningRecord(
             linac=0, cryomodule="01", cavity_number=1
         )
-        session.db.get_record_with_version.return_value = (record, 1)
+        session.get_record_with_version.return_value = (record, 1)
     else:
-        session.db.save_record.return_value = 99
+        session.save_record.return_value = 99
     session.workflow.start_phase_for_record.return_value = SimpleNamespace(
         phase_instance_id=42, run_id=7, attempt_number=1
     )
@@ -136,7 +136,7 @@ class TestInitRecordAndContext:
 
         ctrl._init_record_and_context(state, "op")
 
-        session.db.save_record.assert_called_once()
+        session.save_record.assert_called_once()
         assert state.record is not None
         assert state.record_id == 99
         assert state.record_version == 1
@@ -153,7 +153,7 @@ class TestInitRecordAndContext:
 
         ctrl._init_record_and_context(state, "op")
 
-        session.db.save_record.assert_not_called()
+        session.save_record.assert_not_called()
         assert state.record is existing
         assert state.record_id == 5
         assert state.record_version == 1
@@ -169,7 +169,7 @@ class TestInitRecordAndContext:
 
     def test_raises_when_record_missing_after_id_lookup(self):
         session = _mock_session(existing_record_id=5)
-        session.db.get_record_with_version.return_value = None
+        session.get_record_with_version.return_value = None
         ctrl = _make_controller(session)
         state = CavityRunState(
             spec=CavitySpec(cryomodule="01", cavity_number=1)
@@ -380,7 +380,7 @@ class TestCollectCavity:
     def test_calls_save_record_on_success(self):
         ctrl, state = self._state_with_mock_phase()
         ctrl._collect_cavity(state)
-        ctrl.session.db.save_record.assert_called()
+        ctrl.session.save_record.assert_called()
 
     def test_missing_result_data_emits_failed_and_none_payload(self):
         ctrl, state = self._state_with_mock_phase()
@@ -589,13 +589,13 @@ class TestPersistRecord:
         ctrl, state = _make_state()
         state.record_version = 2
         ctrl._persist_record(state)
-        ctrl.session.db.save_record.assert_called_with(
+        ctrl.session.save_record.assert_called_with(
             state.record, state.record_id, expected_version=2
         )
 
     def test_save_record_exception_does_not_propagate(self):
         ctrl, state = _make_state()
-        ctrl.session.db.save_record.side_effect = RuntimeError("db down")
+        ctrl.session.save_record.side_effect = RuntimeError("db down")
         ctrl._persist_record(state)  # should not raise
 
 

--- a/tests/applications/rf_commissioning/ui/test_multi_phase_screen.py
+++ b/tests/applications/rf_commissioning/ui/test_multi_phase_screen.py
@@ -4,14 +4,11 @@ from types import SimpleNamespace
 from unittest.mock import Mock, call
 
 import pytest
-from PyQt5.QtWidgets import QComboBox, QDialog, QLabel, QTextEdit
+from PyQt5.QtWidgets import QComboBox, QDialog, QLabel
 
 import sc_linac_physics.applications.rf_commissioning.ui.multi_phase_screen as multi_phase_screen
 from sc_linac_physics.applications.rf_commissioning.models.data_models import (
     CommissioningPhase,
-)
-from sc_linac_physics.applications.rf_commissioning.models.cryomodule_models import (
-    CryomoduleCheckoutRecord,
 )
 from sc_linac_physics.applications.rf_commissioning.ui.multi_phase_screen import (
     MultiPhaseCommissioningDisplay,
@@ -28,11 +25,14 @@ class _StaticCombo:
 
 @pytest.fixture
 def display_stub():
-    db = Mock()
     session = SimpleNamespace(
-        db=db,
         get_operators=Mock(return_value=["Alice", "Bob"]),
         add_operator=Mock(),
+        get_cryomodule_record=Mock(return_value=None),
+        get_records_by_cryomodule=Mock(return_value=[]),
+        get_cryomodule_record_with_version=Mock(return_value=None),
+        get_cryomodule_record_id=Mock(return_value=None),
+        save_cryomodule_record=Mock(),
     )
     return SimpleNamespace(
         session=session,
@@ -79,27 +79,27 @@ def test_on_cavity_selection_changed_starts_or_loads(display_stub, monkeypatch):
 def test_refresh_magnet_badge_maps_statuses(display_stub):
     linac = "L1B"
 
-    display_stub.session.db.get_cryomodule_record.return_value = None
+    display_stub.session.get_cryomodule_record.return_value = None
     MultiPhaseCommissioningDisplay._refresh_magnet_badge(
         display_stub, "01", linac
     )
 
-    display_stub.session.db.get_cryomodule_record.return_value = (
-        SimpleNamespace(magnet_checkout=None)
-    )
-    MultiPhaseCommissioningDisplay._refresh_magnet_badge(
-        display_stub, "01", linac
-    )
-
-    display_stub.session.db.get_cryomodule_record.return_value = (
-        SimpleNamespace(magnet_checkout=SimpleNamespace(passed=True))
+    display_stub.session.get_cryomodule_record.return_value = SimpleNamespace(
+        magnet_checkout=None
     )
     MultiPhaseCommissioningDisplay._refresh_magnet_badge(
         display_stub, "01", linac
     )
 
-    display_stub.session.db.get_cryomodule_record.return_value = (
-        SimpleNamespace(magnet_checkout=SimpleNamespace(passed=False))
+    display_stub.session.get_cryomodule_record.return_value = SimpleNamespace(
+        magnet_checkout=SimpleNamespace(passed=True)
+    )
+    MultiPhaseCommissioningDisplay._refresh_magnet_badge(
+        display_stub, "01", linac
+    )
+
+    display_stub.session.get_cryomodule_record.return_value = SimpleNamespace(
+        magnet_checkout=SimpleNamespace(passed=False)
     )
     MultiPhaseCommissioningDisplay._refresh_magnet_badge(
         display_stub, "01", linac
@@ -114,7 +114,7 @@ def test_refresh_magnet_badge_maps_statuses(display_stub):
 
 
 def test_refresh_cavity_completion_label_counts_complete_records(display_stub):
-    display_stub.session.db.get_records_by_cryomodule.return_value = [
+    display_stub.session.get_records_by_cryomodule.return_value = [
         SimpleNamespace(
             current_phase=CommissioningPhase.COMPLETE,
             overall_status="in_progress",
@@ -193,7 +193,7 @@ def test_open_magnet_checkout_screen_requires_cryomodule(
     info.assert_called_once()
 
 
-def test_open_magnet_checkout_screen_requires_operator_for_pass(
+def test_open_magnet_checkout_screen_cancelled_does_nothing(
     display_stub, monkeypatch
 ):
     monkeypatch.setattr(
@@ -201,30 +201,17 @@ def test_open_magnet_checkout_screen_requires_operator_for_pass(
         "get_linac_for_cryomodule",
         lambda _cm: "L1B",
     )
-    display_stub.session.db.get_cryomodule_record_with_version.return_value = (
-        CryomoduleCheckoutRecord(linac="L1B", cryomodule="01"),
-        3,
+    dialog_mock = Mock()
+    dialog_mock.exec_.return_value = QDialog.Rejected
+    monkeypatch.setattr(
+        multi_phase_screen, "MagnetCheckoutDialog", lambda *a, **kw: dialog_mock
     )
-    display_stub.session.db.get_cryomodule_record_id.return_value = 9
-
-    class _Dialog(QDialog):
-        def __init__(self, parent=None):
-            super().__init__(None)
-
-        def exec_(self):
-            combos = self.findChildren(QComboBox)
-            combos[0].setCurrentText("PASS")
-            combos[1].setCurrentIndex(0)
-            return QDialog.Accepted
-
-    warn = Mock()
-    monkeypatch.setattr(multi_phase_screen, "QDialog", _Dialog)
-    monkeypatch.setattr(multi_phase_screen.QMessageBox, "warning", warn)
+    display_stub._refresh_magnet_badge = Mock()
 
     MultiPhaseCommissioningDisplay._open_magnet_checkout_screen(display_stub)
 
-    assert "Operator Required" in warn.call_args.args[1]
-    display_stub.session.db.save_cryomodule_record.assert_not_called()
+    dialog_mock.save.assert_not_called()
+    display_stub._refresh_magnet_badge.assert_not_called()
 
 
 def test_open_magnet_checkout_screen_saves_and_updates_header(
@@ -235,37 +222,42 @@ def test_open_magnet_checkout_screen_saves_and_updates_header(
         "get_linac_for_cryomodule",
         lambda _cm: "L1B",
     )
-    display_stub.session.db.get_cryomodule_record_with_version.return_value = (
-        CryomoduleCheckoutRecord(linac="L1B", cryomodule="01"),
-        3,
+    dialog_mock = Mock()
+    dialog_mock.exec_.return_value = QDialog.Accepted
+    dialog_mock.save.return_value = True
+    monkeypatch.setattr(
+        multi_phase_screen, "MagnetCheckoutDialog", lambda *a, **kw: dialog_mock
     )
-    display_stub.session.db.get_cryomodule_record_id.return_value = 9
     display_stub._refresh_magnet_badge = Mock()
     display_stub._refresh_cavity_completion_label = Mock()
 
-    class _Dialog(QDialog):
-        def __init__(self, parent=None):
-            super().__init__(None)
-
-        def exec_(self):
-            combos = self.findChildren(QComboBox)
-            combos[0].setCurrentText("PASS")
-            combos[1].setCurrentIndex(1)
-            self.findChildren(QTextEdit)[0].setPlainText(" done ")
-            return QDialog.Accepted
-
-    monkeypatch.setattr(multi_phase_screen, "QDialog", _Dialog)
-
     MultiPhaseCommissioningDisplay._open_magnet_checkout_screen(display_stub)
 
-    save_call = display_stub.session.db.save_cryomodule_record.call_args
-    saved_record = save_call.args[0]
-    assert saved_record.magnet_checkout.passed is True
-    assert saved_record.magnet_checkout.operator == "Alice"
-    assert saved_record.magnet_checkout.notes == "done"
+    dialog_mock.save.assert_called_once()
     display_stub._refresh_magnet_badge.assert_called_once_with("01", "L1B")
     display_stub._refresh_cavity_completion_label.assert_called_once_with("01")
     display_stub._update_sync_status.assert_called_once()
+
+
+def test_open_magnet_checkout_screen_save_failure_skips_refresh(
+    display_stub, monkeypatch
+):
+    monkeypatch.setattr(
+        multi_phase_screen,
+        "get_linac_for_cryomodule",
+        lambda _cm: "L1B",
+    )
+    dialog_mock = Mock()
+    dialog_mock.exec_.return_value = QDialog.Accepted
+    dialog_mock.save.return_value = False
+    monkeypatch.setattr(
+        multi_phase_screen, "MagnetCheckoutDialog", lambda *a, **kw: dialog_mock
+    )
+    display_stub._refresh_magnet_badge = Mock()
+
+    MultiPhaseCommissioningDisplay._open_magnet_checkout_screen(display_stub)
+
+    display_stub._refresh_magnet_badge.assert_not_called()
 
 
 def test_update_cm_status_panel_ignores_none_and_updates_valid_record(


### PR DESCRIPTION

## Summary
This PR refactors cryomodule and record access methods by moving them from direct database access to the session manager layer, and extracts the magnet checkout UI into a dedicated dialog component.

## Changes

### 1. Session Manager API Expansion
**File**: `session_manager.py`

Added convenience methods to `CommissioningSession` that delegate to the underlying database:

**Record Query Methods:**
- `get_record_with_version(record_id)` - Retrieve a commissioning record with its version number
- `save_record(record, record_id, expected_version)` - Save/update a commissioning record with optimistic locking
- `find_records_for_cavity(linac, cryomodule, cavity_number)` - Query records for a specific cavity
- `get_record_id_for_cavity(linac, cryomodule, cavity_number)` - Get the record ID for a cavity
- `get_active_record_version()` - Get the currently active record version

**Cryomodule Methods:**
- `get_cryomodule_record(linac, cryomodule)` - Retrieve a cryomodule checkout record
- `get_cryomodule_record_with_version(linac, cryomodule)` - Retrieve with version for optimistic locking
- `get_cryomodule_record_id(linac, cryomodule)` - Get the record ID
- `save_cryomodule_record(record, record_id, expected_version)` - Save/update with optimistic locking
- `get_records_by_cryomodule(linac, cryomodule, active_only)` - Get all cavity records for a cryomodule

### 2. Magnet Checkout Dialog Extraction
**New File**: `magnet_checkout_dialog.py`

Extracted the inline magnet checkout UI into a dedicated `MagnetCheckoutDialog` class with:
- Clean separation of concerns (UI vs business logic)
- Validation logic (operator required for PASS/FAIL)
- Conflict detection and error handling
- `save()` method that returns success/failure for the caller to handle

### 3. Controller & UI Updates
**Files**: `batch_piezo_pre_rf_controller.py`, `multi_phase_screen.py`

- Updated all direct `session.db.*` calls to use the new `session.*` methods
- Simplified `_open_magnet_checkout_screen()` in `multi_phase_screen.py` by delegating to the new dialog
- Improved error handling flow (dialog returns success, caller handles refresh)

### 4. Test Updates
**Files**: `test_batch_piezo_pre_rf_controller.py`, `test_multi_phase_screen.py`

- Updated mocks to reflect new session manager API
- Simplified test setup by mocking `session.*` instead of `session.db.*`
- Refactored magnet checkout tests to validate dialog integration instead of inline UI

## Benefits

1. **Better Encapsulation**: Controllers and UI components interact with the session manager, not the database directly
2. **Easier Testing**: Single point to mock for database operations
3. **Improved Maintainability**: Magnet checkout dialog is now reusable and testable in isolation
4. **Consistent API**: All database operations go through the session manager
5. **Future-Proofing**: Session manager can add caching, logging, or business logic without changing consumers

## Testing

- All existing tests updated and passing
- No behavior changes, only refactoring