### PR TITLE
fix(platform_paths): scope macOS paths under ~/.sc_linac_physics

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,42 +5,91 @@ Operator displays, analysis tools, and command-line interface for the LCLS-II su
 [![CI](https://github.com/slaclab/sc_linac_physics/actions/workflows/python-app.yml/badge.svg?branch=main)](https://github.com/slaclab/sc_linac_physics/actions/workflows/python-app.yml)
 [![Release](https://github.com/slaclab/sc_linac_physics/actions/workflows/release.yml/badge.svg?branch=main)](https://github.com/slaclab/sc_linac_physics/actions/workflows/release.yml)
 
-The SC linac accelerates the LCLS-II electron beam through five sections (L0B–L4B) containing 60 cryomodules and 296 superconducting RF cavities. This package provides the software used by operators and physicists to control, monitor, and commission those cavities: PyDM-based GUIs, hierarchical setup automation, fault monitoring, and analysis tools for Q0 measurement, microphonics, and tuning.
+The LCLS superconducting linac accelerates an electron beam through five sections (L0B–L4B) containing 60 cryomodules and 480 superconducting RF cavities. This package provides the software used by operators and physicists to control, monitor, and commission those cavities: PyDM-based GUIs, hierarchical setup automation, fault monitoring, and analysis tools for Q0 measurement, microphonics, and tuning.
 
 For architecture documentation and per-application guides, see [`docs/`](docs/index.md).
 
 ## Installation
 
-Requires Python 3.12+. If you don't have a Python environment, [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/) is a convenient option:
+This project requires Python 3.12+. The easiest way to get started:
+
+1. **Install conda** (if you don't have it): Follow the [conda installation guide](https://docs.conda.io/projects/conda/en/latest/user-guide/install/)
+
+2. **Create a Python environment:**
 
 ```bash
-conda create -n sclp "python>=3.12" && conda activate sclp
+conda create -n sclp "python>=3.12"
+conda activate sclp
 ```
 
-Install from source (not published to PyPI):
+3. **Install this package** from source (not published to PyPI):
+
+Optional: set up GitHub SSH first (recommended for contributors):
+
+```bash
+ssh-keygen -t ed25519 -C "your_email@example.com"
+eval "$(ssh-agent -s)"
+ssh-add ~/.ssh/id_ed25519
+cat ~/.ssh/id_ed25519.pub
+```
+
+Add the printed key to GitHub:
+
+- https://github.com/settings/keys
+
+Then verify SSH access:
+
+```bash
+ssh -T git@github.com
+```
+
+Clone with SSH:
 
 ```bash
 git clone git@github.com:slaclab/sc_linac_physics.git
+```
+
+Or clone with HTTPS (no SSH key setup required):
+
+```bash
+git clone https://github.com/slaclab/sc_linac_physics.git
+```
+
+Then install:
+
+```bash
 cd sc_linac_physics
-pip install -e ".[dev,test]"   # development + testing
-# pip install -e .             # package only
+pip install -e ".[dev,test]"
+```
+
+For package-only installation (without development/testing dependencies), use:
+
+```bash
+pip install -e .
 ```
 
 > Two dependencies (`edmbutton`, `lcls-tools`) install from `github.com/slaclab` and require network access.
 
-## Quick start
+## Quick Start
 
-To run displays locally without live accelerator hardware, start the simulator in one terminal (remember to activate your conda environment in each new terminal with `conda activate sclp`):
+### Running displays locally
+
+To run displays without live accelerator hardware, start the simulator in one terminal:
 
 ```bash
+conda activate sclp
 sc-sim
 ```
 
-Then launch any display in another:
+Then launch any display in another terminal:
 
 ```bash
 sc-srf-home
 ```
+
+### Learning to develop
+
+New to this codebase? Start with the [Getting Started Guide](docs/getting_started.md), which walks you through three hands-on exercises building displays from scratch. You'll learn EPICS, PyQt, and PyDM basics along the way. The guide uses `sc-sim` for live data and also includes a layout-only mode with `PYDM_DEFAULT_PROTOCOL=fake`.
 
 ## Usage
 

--- a/src/sc_linac_physics/utils/platform_paths.py
+++ b/src/sc_linac_physics/utils/platform_paths.py
@@ -30,7 +30,7 @@ def get_srf_base_dir(
     """Return the SRF base directory for the current platform."""
     if is_linux(system_name=system_name):
         return Path("/home/physics/srf")
-    return _current_home(home_dir)
+    return _current_home(home_dir) / ".sc_linac_physics"
 
 
 def get_database_dir(
@@ -39,9 +39,10 @@ def get_database_dir(
     home_dir: Path | None = None,
 ) -> Path:
     """Return the default databases directory for the current platform."""
-    if is_linux(system_name=system_name):
-        return Path("/home/physics/srf/databases")
-    return _current_home(home_dir) / "databases"
+    return (
+        get_srf_base_dir(system_name=system_name, home_dir=home_dir)
+        / "databases"
+    )
 
 
 def get_json_dir(
@@ -50,9 +51,7 @@ def get_json_dir(
     home_dir: Path | None = None,
 ) -> Path:
     """Return the default JSON directory for the current platform."""
-    if is_linux(system_name=system_name):
-        return Path("/home/physics/srf/json")
-    return _current_home(home_dir) / "json"
+    return get_srf_base_dir(system_name=system_name, home_dir=home_dir) / "json"
 
 
 def get_log_base_dir(
@@ -61,9 +60,10 @@ def get_log_base_dir(
     home_dir: Path | None = None,
 ) -> Path:
     """Return the default logfiles directory for the current platform."""
-    if is_linux(system_name=system_name):
-        return Path("/home/physics/srf/logfiles")
-    return _current_home(home_dir) / "logfiles"
+    return (
+        get_srf_base_dir(system_name=system_name, home_dir=home_dir)
+        / "logfiles"
+    )
 
 
 def get_ssa_cal_base_dir(
@@ -74,4 +74,6 @@ def get_ssa_cal_base_dir(
     """Return the root directory where SSA calibration plots are stored."""
     if is_linux(system_name=system_name):
         return Path("/u1/lcls/physics/rf_lcls2/ssa_cal")
-    return _current_home(home_dir) / "ssa_cal"
+    return (
+        get_srf_base_dir(system_name=system_name, home_dir=home_dir) / "ssa_cal"
+    )

--- a/tests/applications/tuning/state/test_common.py
+++ b/tests/applications/tuning/state/test_common.py
@@ -21,9 +21,10 @@ def test_platform_default_paths_macos_like():
         Path("/Users/tester"),
     )
 
-    assert base_dir == Path("/Users/tester")
-    assert db_path == Path("/Users/tester/databases/tune_status.sqlite")
-    assert json_path == Path("/Users/tester/json/tune_status.json")
+    base = Path("/Users/tester") / ".sc_linac_physics"
+    assert base_dir == base
+    assert db_path == base / "databases" / "tune_status.sqlite"
+    assert json_path == base / "json" / "tune_status.json"
 
 
 def test_resolve_paths_use_platform_defaults_for_default_base_dir():

--- a/tests/applications/tuning/state/test_common_comprehensive.py
+++ b/tests/applications/tuning/state/test_common_comprehensive.py
@@ -27,9 +27,10 @@ def test_platform_default_paths_macos_like():
         Path("/Users/tester"),
     )
 
-    assert base_dir == Path("/Users/tester")
-    assert db_path == Path("/Users/tester/databases/tune_status.sqlite")
-    assert json_path == Path("/Users/tester/json/tune_status.json")
+    base = Path("/Users/tester") / ".sc_linac_physics"
+    assert base_dir == base
+    assert db_path == base / "databases" / "tune_status.sqlite"
+    assert json_path == base / "json" / "tune_status.json"
 
 
 def test_resolve_paths_use_platform_defaults_for_default_base_dir():

--- a/tests/utils/test_platform_paths.py
+++ b/tests/utils/test_platform_paths.py
@@ -5,6 +5,7 @@ from sc_linac_physics.utils.platform_paths import (
     get_json_dir,
     get_log_base_dir,
     get_srf_base_dir,
+    get_ssa_cal_base_dir,
     is_linux,
     is_macos,
 )
@@ -40,6 +41,22 @@ def test_platform_paths_macos_like():
     assert (
         get_log_base_dir(system_name="Darwin", home_dir=home)
         == base / "logfiles"
+    )
+
+
+def test_ssa_cal_base_dir_linux():
+    home = Path("/Users/tester")
+    assert get_ssa_cal_base_dir(system_name="Linux", home_dir=home) == Path(
+        "/u1/lcls/physics/rf_lcls2/ssa_cal"
+    )
+
+
+def test_ssa_cal_base_dir_macos_like():
+    home = Path("/Users/tester")
+    base = home / ".sc_linac_physics"
+    assert (
+        get_ssa_cal_base_dir(system_name="Darwin", home_dir=home)
+        == base / "ssa_cal"
     )
 
 

--- a/tests/utils/test_platform_paths.py
+++ b/tests/utils/test_platform_paths.py
@@ -29,16 +29,17 @@ def test_platform_paths_linux():
 
 def test_platform_paths_macos_like():
     home = Path("/Users/tester")
+    base = home / ".sc_linac_physics"
 
-    assert get_srf_base_dir(system_name="Darwin", home_dir=home) == home
+    assert get_srf_base_dir(system_name="Darwin", home_dir=home) == base
     assert (
         get_database_dir(system_name="Darwin", home_dir=home)
-        == home / "databases"
+        == base / "databases"
     )
-    assert get_json_dir(system_name="Darwin", home_dir=home) == home / "json"
+    assert get_json_dir(system_name="Darwin", home_dir=home) == base / "json"
     assert (
         get_log_base_dir(system_name="Darwin", home_dir=home)
-        == home / "logfiles"
+        == base / "logfiles"
     )
 
 


### PR DESCRIPTION
  Also expand README installation steps and update cavity count to 480.

  The platform_paths change is the substantive fix — subdirectory paths on macOS were scattered directly under ~ instead of a dedicated app folder, and the duplication across
  get_database_dir/get_json_dir/get_log_base_dir is cleaned up by delegating to get_srf_base_dir. The README changes are minor docs improvements that fit in the body.