### PR TITLE
feat(cavity-display): keep timestamped fault events from archiver fetches

### DIFF
--- a/src/sc_linac_physics/displays/cavity_display/backend/backend_cavity.py
+++ b/src/sc_linac_physics/displays/cavity_display/backend/backend_cavity.py
@@ -5,7 +5,7 @@ Backend cavity fault monitoring and management with batch PV initialization.
 from collections import OrderedDict, defaultdict
 from datetime import datetime, timedelta
 from time import time
-from typing import DefaultDict, Optional, Dict, List
+from typing import DefaultDict, Optional, Dict, List, Tuple
 
 from lcls_tools.common.data.archiver import (
     get_values_over_time_range,
@@ -15,7 +15,9 @@ from lcls_tools.common.data.archiver import (
 from sc_linac_physics.displays.cavity_display.backend.fault import (
     Fault,
     FaultCounter,
+    FaultEvent,
     PVInvalidError,
+    SeverityLevel,
 )
 from sc_linac_physics.displays.cavity_display.utils import utils
 from sc_linac_physics.displays.cavity_display.utils.utils import (
@@ -24,21 +26,10 @@ from sc_linac_physics.displays.cavity_display.utils.utils import (
     SEVERITY_SUFFIX,
     SpreadsheetError,
     display_hash,
-    severity_of_fault,
     cavity_fault_logger,
 )
 from sc_linac_physics.utils.epics import PV, PVBatch
 from sc_linac_physics.utils.sc_linac.cavity import Cavity
-
-
-# Constants for severity levels
-class SeverityLevel:
-    """EPICS alarm severity levels."""
-
-    NO_ALARM = 0
-    WARNING = 1
-    ALARM = 2
-    INVALID = 3
 
 
 class FaultLevel:
@@ -344,23 +335,20 @@ class BackendCavity(Cavity):
     def get_fault_counts(
         self, start_time: datetime, end_time: datetime
     ) -> DefaultDict[str, FaultCounter]:
-        """Analyze fault history over a time range using archiver data.
+        """Fault counts by TLC over a time range; see get_fault_history."""
+        counts, _ = self.get_fault_history(start_time, end_time)
+        return counts
 
-        This method retrieves cavity fault status and severity from the archiver
-        and aggregates fault counts by TLC (Three Letter Code).
+    def get_fault_history(
+        self, start_time: datetime, end_time: datetime
+    ) -> Tuple[DefaultDict[str, FaultCounter], List[FaultEvent]]:
+        """Fetch this cavity's fault history from the archiver.
 
-        For duplicate TLCs (e.g., MGT with X, Y, Q variants), the maximum
-        fault count is used to represent the TLC.
-
-        Args:
-            start_time: Beginning of analysis period
-            end_time: End of analysis period
-
-        Returns:
-            Dictionary mapping TLC to FaultCounter with statistics
+        Returns (counts by TLC, chronological FaultEvents); both are
+        empty if the archiver query fails. Callers fetching many
+        cavities should batch the query themselves and use
+        process_fault_history().
         """
-        result: DefaultDict[str, FaultCounter] = defaultdict(FaultCounter)
-
         try:
             data: Dict[str, ArchiveDataHandler] = get_values_over_time_range(
                 pv_list=[self.pv_addr("CUDSTATUS"), self.pv_addr("CUDSEVR")],
@@ -371,38 +359,68 @@ class BackendCavity(Cavity):
             cavity_fault_logger.error(
                 f"Error retrieving archiver data for {self.pv_prefix}: {e}"
             )
-            return result
+            return defaultdict(FaultCounter), []
 
-        statuses: ArchiveDataHandler = data[self.pv_addr("CUDSTATUS")]
-        severities: ArchiveDataHandler = data[self.pv_addr("CUDSEVR")]
+        return self.process_fault_history(
+            statuses=data[self.pv_addr("CUDSTATUS")],
+            severities=data[self.pv_addr("CUDSEVR")],
+        )
+
+    def process_fault_history(
+        self,
+        statuses: ArchiveDataHandler,
+        severities: ArchiveDataHandler,
+    ) -> Tuple[DefaultDict[str, FaultCounter], List[FaultEvent]]:
+        """Aggregate archived status/severity samples into counts and events.
+
+        Note the archiver includes one sample from before the requested
+        start (the last known value), so the first event can predate the
+        range. That sample is the only trace of a fault that was already
+        standing when the range began.
+        """
+        result: DefaultDict[str, FaultCounter] = defaultdict(FaultCounter)
+        fault_events: List[FaultEvent] = []
+
+        # Both lists are chronological, so one merge pass finds the
+        # severity in effect at each status (rescanning gets slow fast)
+        severity_values = severities.values
+        severity_timestamps = [
+            self._round_to_10ms(ts) for ts in severities.timestamps
+        ]
+        severity_idx = 0
+        current_severity = None
 
         for status, status_ts in zip(statuses.values, statuses.timestamps):
-            # Skip if status indicates cavity number (no fault)
+            # The cavity number as status means OK; keep the event so
+            # it's clear when a fault ended
             if status == str(self.number):
+                fault_events.append(
+                    FaultEvent(status_ts, status, SeverityLevel.NO_ALARM)
+                )
                 continue
 
-            # Round timestamp to 10ms precision for matching with severity data
-            try:
-                ts = status_ts.replace(
-                    microsecond=round(status_ts.microsecond / 10000) * 10000
-                )
-            except ValueError:
-                # Handle edge case where rounding exceeds valid range
-                ts = status_ts + timedelta(seconds=1)
+            ts = self._round_to_10ms(status_ts)
+            while (
+                severity_idx < len(severity_timestamps)
+                and (ts - severity_timestamps[severity_idx]).total_seconds()
+                >= 0
+            ):
+                current_severity = severity_values[severity_idx]
+                severity_idx += 1
 
-            severity = severity_of_fault(ts, severities)
+            result[status].count_severity(current_severity)
+            fault_events.append(FaultEvent(status_ts, status, current_severity))
 
-            # Categorize by severity level
-            if severity == SeverityLevel.NO_ALARM:
-                result[status].ok_count += 1
-            elif severity == SeverityLevel.WARNING:
-                result[status].warning_count += 1
-            elif severity == SeverityLevel.ALARM:
-                result[status].alarm_count += 1
-            else:  # INVALID
-                result[status].invalid_count += 1
+        return result, fault_events
 
-        return result
+    @staticmethod
+    def _round_to_10ms(ts: datetime) -> datetime:
+        """Round to 10ms precision for status/severity matching."""
+        try:
+            return ts.replace(microsecond=round(ts.microsecond / 10000) * 10000)
+        except ValueError:
+            # Rounding carried past the end of the second
+            return ts + timedelta(seconds=1)
 
     def run_through_faults(self) -> None:
         """Check all faults and update cavity status PVs (optimized batch version).

--- a/src/sc_linac_physics/displays/cavity_display/backend/fault.py
+++ b/src/sc_linac_physics/displays/cavity_display/backend/fault.py
@@ -36,14 +36,14 @@ class SeverityLevel:
 class FaultEvent:
     """A single cavity status transition from the archiver.
 
-    Returns to OK are included (severity NO_ALARM) so consumers can
-    tell when a fault cleared; for those, tlc holds the cavity number
-    string instead of a three letter code.
+    Returns to OK are included (severity NO_ALARM) so users can
+    tell when a fault cleared; for those, status holds the cavity
+    number string instead of a three-letter code.
     """
 
     timestamp: datetime
-    tlc: str
-    severity: int
+    status: str
+    severity: Optional[int]
 
 
 @dataclasses.dataclass
@@ -62,9 +62,11 @@ class FaultCounter:
     invalid_count: int = 0
     warning_count: int = 0
 
-    def count_severity(self, severity: int) -> None:
-        """Tally one sample; unrecognized severities count as invalid."""
-        if severity == SeverityLevel.NO_ALARM:
+    def count_severity(self, severity: Optional[int]) -> None:
+        """Tally one sample; missing/unrecognized severities count as invalid."""
+        if severity is None:
+            self.invalid_count += 1
+        elif severity == SeverityLevel.NO_ALARM:
             self.ok_count += 1
         elif severity == SeverityLevel.WARNING:
             self.warning_count += 1

--- a/src/sc_linac_physics/displays/cavity_display/backend/fault.py
+++ b/src/sc_linac_physics/displays/cavity_display/backend/fault.py
@@ -23,6 +23,29 @@ from sc_linac_physics.utils.epics import (
 )
 
 
+class SeverityLevel:
+    """EPICS alarm severity levels."""
+
+    NO_ALARM = 0
+    WARNING = 1
+    ALARM = 2
+    INVALID = 3
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class FaultEvent:
+    """A single cavity status transition from the archiver.
+
+    Returns to OK are included (severity NO_ALARM) so consumers can
+    tell when a fault cleared; for those, tlc holds the cavity number
+    string instead of a three letter code.
+    """
+
+    timestamp: datetime
+    tlc: str
+    severity: int
+
+
 @dataclasses.dataclass
 class FaultCounter:
     """Tracks fault statistics over a time period.
@@ -38,6 +61,17 @@ class FaultCounter:
     ok_count: int = 0
     invalid_count: int = 0
     warning_count: int = 0
+
+    def count_severity(self, severity: int) -> None:
+        """Tally one sample; unrecognized severities count as invalid."""
+        if severity == SeverityLevel.NO_ALARM:
+            self.ok_count += 1
+        elif severity == SeverityLevel.WARNING:
+            self.warning_count += 1
+        elif severity == SeverityLevel.ALARM:
+            self.alarm_count += 1
+        else:
+            self.invalid_count += 1
 
     @property
     def sum_fault_count(self) -> int:

--- a/tests/displays/cavity_display/backend/test_backend_cavity.py
+++ b/tests/displays/cavity_display/backend/test_backend_cavity.py
@@ -153,3 +153,74 @@ def test_run_through_faults_faulted(cavity):
     cavity._description_pv_obj.put.assert_called_with(
         faulted_fault.short_description
     )
+
+
+def _make_handler(samples):
+    """Build an ArchiveDataHandler-like mock from (value, timestamp) pairs."""
+    handler = MagicMock()
+    handler.values = [value for value, _ in samples]
+    handler.timestamps = [ts for _, ts in samples]
+    return handler
+
+
+class TestProcessFaultHistory:
+    def test_counts_and_events_match_severities(self, cavity):
+        """Statuses pick up the severity in effect at their timestamp."""
+        base = datetime(2025, 6, 2, 12, 0, 0)
+        statuses = _make_handler(
+            [
+                ("SSA", base + timedelta(seconds=10)),
+                (str(cavity.number), base + timedelta(seconds=20)),
+                ("QCH", base + timedelta(seconds=30)),
+            ]
+        )
+        severities = _make_handler(
+            [
+                (2, base + timedelta(seconds=10)),  # alarm during SSA
+                (0, base + timedelta(seconds=20)),
+                (1, base + timedelta(seconds=30)),  # warning during QCH
+            ]
+        )
+
+        counts, events = cavity.process_fault_history(statuses, severities)
+
+        assert counts["SSA"].alarm_count == 1
+        assert counts["QCH"].warning_count == 1
+        # All three transitions recorded, including the OK one
+        assert len(events) == 3
+        assert events[0].severity == 2
+        assert events[1].severity == 0  # the OK clear
+        assert events[2].severity == 1
+        assert events[0].timestamp < events[1].timestamp < events[2].timestamp
+
+    def test_severity_matching_equivalent_to_per_sample_scan(self, cavity):
+        """The merge pass must match severity_of_fault's per-sample scan."""
+        from sc_linac_physics.displays.cavity_display.utils.utils import (
+            severity_of_fault,
+        )
+
+        base = datetime(2025, 6, 2, 12, 0, 0)
+        # offset timestamps so the matching isn't trivial
+        severities = _make_handler(
+            [(i % 4, base + timedelta(seconds=5 * i)) for i in range(40)]
+        )
+        statuses = _make_handler(
+            [("SSA", base + timedelta(seconds=3 + 7 * i)) for i in range(25)]
+        )
+
+        _, events = cavity.process_fault_history(statuses, severities)
+
+        for event in events:
+            ts = cavity._round_to_10ms(event.timestamp)
+            assert event.severity == severity_of_fault(ts, severities)
+
+    def test_status_before_any_severity_counts_invalid(self, cavity):
+        """A status sample with no severity yet has severity None."""
+        base = datetime(2025, 6, 2, 12, 0, 0)
+        statuses = _make_handler([("SSA", base)])
+        severities = _make_handler([(2, base + timedelta(seconds=10))])
+
+        counts, events = cavity.process_fault_history(statuses, severities)
+
+        assert counts["SSA"].invalid_count == 1
+        assert events[0].severity is None


### PR DESCRIPTION
get_fault_counts only gave back aggregated counts, so there was no way to
see when faults actually happened in a fetched range. I split it into
get_fault_history, which also returns the individual timestamped events
(including the returns to OK), and process_fault_history, which does the
aggregation on data you've already fetched. get_fault_counts is still
there as a wrapper so nothing that calls it changes.

The events are what the time slider I'm working on needs, it can
re-aggregate counts over a sub-window without going back to the archiver.
process_fault_history taking pre-fetched data also means a caller pulling
lots of cavities can batch the archiver query instead of one call each.

Also swapped the severity matching to a single pass over the two sample
lists, it was rescanning the whole severity list for every status sample
before, which got really slow on week-long fetches.

Slider itself is a separate PR, this is just the backend piece.