### PR TITLE
fix: handle scipy linregress NaN slope

### DIFF
--- a/src/sc_linac_physics/applications/q0/calibration.py
+++ b/src/sc_linac_physics/applications/q0/calibration.py
@@ -108,7 +108,7 @@ class Calibration:
             )
 
             if np.isnan(slope):
-                self._slope = None
+                raise ValueError("Cannot calculate a linear regression")
             else:
                 self.adjustment = intercept
                 self._slope = slope


### PR DESCRIPTION
Explicitly raise ValueError when linregress returns NaN slope, fixing the failing calibration test.