### PR TITLE
feat(rf-commissioning): add frequency tuning phase backend logic

### DIFF
--- a/src/sc_linac_physics/applications/rf_commissioning/COMPLETE_WORKFLOW_EXAMPLE.md
+++ b/src/sc_linac_physics/applications/rf_commissioning/COMPLETE_WORKFLOW_EXAMPLE.md
@@ -101,7 +101,7 @@ run_phase(
 
 # Continue technical phases.
 for phase, measurement in [
-    (CommissioningPhase.FREQUENCY_TUNING, {"final_detune_hz": 5.0}),
+    (CommissioningPhase.FREQUENCY_TUNING, {"df_cold_hz": 5000.0}),
     (CommissioningPhase.CAVITY_CHAR, {"loaded_q": 2.8e7}),
     (CommissioningPhase.PIEZO_WITH_RF, {"detune_gain": 0.10}),
     (CommissioningPhase.HIGH_POWER_RAMP, {"max_amplitude_reached": 17.5}),

--- a/src/sc_linac_physics/applications/rf_commissioning/models/data_models.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/models/data_models.py
@@ -225,13 +225,6 @@ class FrequencyTuningData:
     notes: str = ""
 
     @property
-    def df_cold_khz(self) -> float | None:
-        """Cold-landing detune in kHz."""
-        if self.df_cold_hz is None:
-            return None
-        return self.df_cold_hz / 1000
-
-    @property
     def positive_step_increases_frequency(self) -> bool | None:
         if self.hz_per_microstep is None:
             return None
@@ -268,7 +261,6 @@ class FrequencyTuningData:
         return serialize_model(
             self,
             computed_fields=(
-                "df_cold_khz",
                 "positive_step_increases_frequency",
                 "cold_landing_complete",
                 "pi_mode_complete",

--- a/src/sc_linac_physics/applications/rf_commissioning/models/data_models.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/models/data_models.py
@@ -174,10 +174,11 @@ class FrequencyTuningData:
     """
 
     # Cold landing phase data
-    initial_detune_hz: float | None = phase_display_field(
+    # The first measured detune is the cold-landing frequency, pushed to DF_COLD.
+    df_cold_hz: float | None = phase_display_field(
         default=None,
-        label="Initial Detune",
-        widget_name="freq_tuning_initial_detune",
+        label="Cold Landing Detune",
+        widget_name="freq_tuning_df_cold",
         format_spec=".3f",
         unit="Hz",
     )
@@ -224,11 +225,11 @@ class FrequencyTuningData:
     notes: str = ""
 
     @property
-    def initial_detune_khz(self) -> float | None:
-        """Initial detune in kHz."""
-        if self.initial_detune_hz is None:
+    def df_cold_khz(self) -> float | None:
+        """Cold-landing detune in kHz."""
+        if self.df_cold_hz is None:
             return None
-        return self.initial_detune_hz / 1000
+        return self.df_cold_hz / 1000
 
     @property
     def positive_step_increases_frequency(self) -> bool | None:
@@ -240,7 +241,7 @@ class FrequencyTuningData:
     def cold_landing_complete(self) -> bool:
         """Check if cold landing phase is complete."""
         return (
-            self.initial_detune_hz is not None
+            self.df_cold_hz is not None
             and self.hz_per_microstep is not None
             and self.steps_to_resonance is not None
         )
@@ -267,7 +268,7 @@ class FrequencyTuningData:
         return serialize_model(
             self,
             computed_fields=(
-                "initial_detune_khz",
+                "df_cold_khz",
                 "positive_step_increases_frequency",
                 "cold_landing_complete",
                 "pi_mode_complete",

--- a/src/sc_linac_physics/applications/rf_commissioning/phases/__init__.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/phases/__init__.py
@@ -10,6 +10,7 @@ from .phase_base import (
     PhaseStepResult,
     PhaseExecutionError,
 )
+from .frequency_tuning import FrequencyTuningLimits, FrequencyTuningPhase
 from .piezo_pre_rf import PiezoPreRFPhase
 from .ssa_char import SSACharPhase
 
@@ -19,6 +20,8 @@ __all__ = [
     "PhaseResult",
     "PhaseStepResult",
     "PhaseExecutionError",
+    "FrequencyTuningLimits",
+    "FrequencyTuningPhase",
     "PiezoPreRFPhase",
     "SSACharPhase",
 ]

--- a/src/sc_linac_physics/applications/rf_commissioning/phases/frequency_tuning.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/phases/frequency_tuning.py
@@ -77,10 +77,12 @@ class FrequencyTuningPhase(PhaseBase):
 
     Sequence:
     1. verify_initial_state    – stepper idle; prepare cavity (SSA on, reset interlocks, setup_tuning)
-    2. record_cold_landing     – record initial detune (operator pushes to DF_COLD via UI)
-    3. probe_stepper_direction – measure Hz/step (operator confirms; UI writes to SCALE)
-    4. tune_to_resonance       – delegate to Cavity._auto_tune (temp guard); write NSTEPS_COLD
-    5. record_results          – write FrequencyTuningData to commissioning record
+    2. record_cold_landing     – record cold-landing detune (operator pushes to DF_COLD via UI)
+    3. probe_stepper_direction – measure Hz/microstep (operator confirms; UI writes to SCALE_CALC.B)
+    4. apply_hz_per_step       – write confirmed Hz/microstep to SCALE_CALC.B
+    5. tune_to_resonance       – delegate to Cavity._auto_tune (temp guard); write NSTEPS_COLD
+    6. measure_pi_modes        – single-cavity FSCAN for 8π/9 and 7π/9 parasitic modes
+    7. record_results          – write FrequencyTuningData to commissioning record
     """
 
     def __init__(

--- a/src/sc_linac_physics/applications/rf_commissioning/phases/frequency_tuning.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/phases/frequency_tuning.py
@@ -51,8 +51,6 @@ class FrequencyTuningLimits:
     max_total_steps: int = 10_000_000
     cool_down_retries: int = 6
     cool_down_interval: float = 5.0
-    motor_start_wait: float = 5.0
-    motor_poll_interval: float = 2.0
     min_probe_delta_hz: float = 10.0
     pi_scan_freq_start: int = -3_500_000
     pi_scan_freq_stop: int = 50_000
@@ -161,15 +159,6 @@ class FrequencyTuningPhase(PhaseBase):
                 self.cavity.stepper_tuner.steps_cold_landing_pv
             )
         self._nsteps_cold_pv_obj.put(steps)
-
-    def _wait_for_motor(self) -> None:
-        """Block until motor_moving is False, checking abort each poll."""
-        time.sleep(self.limits.motor_start_wait)
-        while self.cavity.stepper_tuner.motor_moving:
-            if self.context.is_abort_requested():
-                self.cavity.stepper_tuner.abort()
-                raise PhaseExecutionError("Abort requested during stepper move")
-            time.sleep(self.limits.motor_poll_interval)
 
     def _check_temp_with_cooldown(self) -> tuple[bool, float, str]:
         """
@@ -446,7 +435,9 @@ class FrequencyTuningPhase(PhaseBase):
             },
         )
 
-    def _initialize_tuning_state(self, tuning_cb) -> tuple[int, int, float]:
+    def _initialize_tuning_state(
+        self, tuning_cb
+    ) -> tuple[int, int, float, "PhaseStepResult | None"]:
         total_steps = 0
         peak_temp = 0.0
 
@@ -454,15 +445,26 @@ class FrequencyTuningPhase(PhaseBase):
         # REG_TOTSGN was zeroed by the Stage 2 probe, so on the first run
         # signed_total starts at 0.  After an abort and restart it retains the
         # displacement already accumulated from cold landing, keeping NSTEPS_COLD
-        # accurate across partial runs.
+        # accurate across partial runs.  A read failure here must NOT default to
+        # 0 — that would silently corrupt the NSTEPS_COLD return trip — so we
+        # surface a RETRY instead.
         try:
             if self._step_signed_pv_obj is None:
                 self._step_signed_pv_obj = PV(
                     self.cavity.stepper_tuner.step_signed_pv
                 )
-            signed_total = int(self._step_signed_pv_obj.get() or 0)
-        except Exception:
-            signed_total = 0
+            signed_total = round(self._step_signed_pv_obj.get() or 0)
+        except Exception as exc:
+            return (
+                total_steps,
+                0,
+                peak_temp,
+                PhaseStepResult(
+                    result=PhaseResult.RETRY,
+                    message=f"Could not read signed step count to resume tuning: {exc}",
+                    retry_delay_seconds=3.0,
+                ),
+            )
 
         try:
             peak_temp = self._read_temp()
@@ -475,7 +477,7 @@ class FrequencyTuningPhase(PhaseBase):
         except Exception:
             pass
 
-        return total_steps, signed_total, peak_temp
+        return total_steps, signed_total, peak_temp, None
 
     def _emit_tuning_update(self, tuning_cb, signed_total: int) -> None:
         try:
@@ -579,7 +581,7 @@ class FrequencyTuningPhase(PhaseBase):
         speed: int = linac_utils.DEFAULT_STEPPER_SPEED,
     ) -> tuple[int, int, "PhaseStepResult | None"]:
         """Compute step size, execute stepper move, and invoke the Hz/step callback."""
-        hardware_max = self.cavity.stepper_tuner.max_steps
+        hardware_max = int(self.cavity.stepper_tuner.max_steps)
         estimated = max(1, round(abs(detune) / abs(hz_per_step)))
         magnitude = min(hardware_max, estimated)
         # Direction: steps_to_zero = detune / SCALE, so sign = sign(detune / signed_hz).
@@ -635,9 +637,11 @@ class FrequencyTuningPhase(PhaseBase):
         )
         speed = self.limits.move_speed
 
-        total_steps, signed_total, peak_temp = self._initialize_tuning_state(
-            tuning_cb
+        total_steps, signed_total, peak_temp, err = (
+            self._initialize_tuning_state(tuning_cb)
         )
+        if err is not None:
+            return err
 
         while True:
             total_steps, signed_total, peak_temp, converged, err = (
@@ -721,6 +725,20 @@ class FrequencyTuningPhase(PhaseBase):
             return err
         return self._read_mode_frequencies()
 
+    def _put_pv(
+        self, address: str, value, label: str
+    ) -> "PhaseStepResult | None":
+        """Write ``value`` to ``address``; return a RETRY result on failure."""
+        try:
+            PV(address).put(value)
+        except Exception as exc:
+            return PhaseStepResult(
+                result=PhaseResult.RETRY,
+                message=f"Could not write {label}: {exc}",
+                retry_delay_seconds=3.0,
+            )
+        return None
+
     def _check_rack_exclusivity(self, rack) -> "PhaseStepResult | None":
         rack_check = self.context.parameters.get("rack_check_callback")
         if rack_check is None:
@@ -746,14 +764,13 @@ class FrequencyTuningPhase(PhaseBase):
     def _select_cavity_for_fscan(self, rack) -> "PhaseStepResult | None":
         for cav_num, cav in rack.cavities.items():
             selected = 1 if cav_num == self.cavity.number else 0
-            try:
-                PV(cav.pv_addr("FSCAN:SEL")).put(selected)
-            except Exception as exc:
-                return PhaseStepResult(
-                    result=PhaseResult.RETRY,
-                    message=f"Could not write FSCAN:SEL for cavity {cav_num}: {exc}",
-                    retry_delay_seconds=3.0,
-                )
+            err = self._put_pv(
+                cav.pv_addr("FSCAN:SEL"),
+                selected,
+                f"FSCAN:SEL for cavity {cav_num}",
+            )
+            if err is not None:
+                return err
         return None
 
     def _configure_fscan_params(self, rack) -> "PhaseStepResult | None":
@@ -763,26 +780,13 @@ class FrequencyTuningPhase(PhaseBase):
             ("FSCAN:RMS_THRESH", self.limits.pi_scan_rms_thresh),
             ("FSCAN:MODE_OVERLAP", self.limits.pi_scan_mode_overlap),
         ):
-            try:
-                PV(rack.pv_prefix + suffix).put(value)
-            except Exception as exc:
-                return PhaseStepResult(
-                    result=PhaseResult.RETRY,
-                    message=f"Could not write {suffix}: {exc}",
-                    retry_delay_seconds=3.0,
-                )
+            err = self._put_pv(rack.pv_prefix + suffix, value, suffix)
+            if err is not None:
+                return err
         return None
 
     def _trigger_fscan(self, rack) -> "PhaseStepResult | None":
-        try:
-            PV(rack.pv_prefix + "FSCAN:START").put(1)
-        except Exception as exc:
-            return PhaseStepResult(
-                result=PhaseResult.RETRY,
-                message=f"Could not write FSCAN:START: {exc}",
-                retry_delay_seconds=3.0,
-            )
-        return None
+        return self._put_pv(rack.pv_prefix + "FSCAN:START", 1, "FSCAN:START")
 
     _FSCAN_STATE_NAMES = {
         0: "Await request",
@@ -836,14 +840,9 @@ class FrequencyTuningPhase(PhaseBase):
 
     def _push_mode_results(self) -> "PhaseStepResult | None":
         for proc_suffix in ("FSCAN:PUSH_8PI9.PROC", "FSCAN:PUSH_7PI9.PROC"):
-            try:
-                PV(self.cavity.pv_addr(proc_suffix)).put(1)
-            except Exception as exc:
-                return PhaseStepResult(
-                    result=PhaseResult.RETRY,
-                    message=f"Could not write {proc_suffix}: {exc}",
-                    retry_delay_seconds=3.0,
-                )
+            err = self._put_pv(self.cavity.pv_addr(proc_suffix), 1, proc_suffix)
+            if err is not None:
+                return err
         return None
 
     def _read_mode_frequencies(self) -> PhaseStepResult:

--- a/src/sc_linac_physics/applications/rf_commissioning/phases/frequency_tuning.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/phases/frequency_tuning.py
@@ -24,7 +24,6 @@ phase:
   6. Writes a FrequencyTuningData record.
 """
 
-import time
 from dataclasses import dataclass
 from datetime import datetime
 
@@ -39,12 +38,7 @@ from sc_linac_physics.applications.rf_commissioning.phases.phase_base import (
     PhaseResult,
     PhaseStepResult,
 )
-from sc_linac_physics.utils.epics import PV
 from sc_linac_physics.utils.sc_linac import linac_utils
-
-_FSCAN_STAT_SCAN_DONE = 5
-_FSCAN_STAT_SCAN_ABORTED = 6
-_FSCAN_STAT_FREQ_RESTORE_FAIL = 7
 
 
 @dataclass
@@ -673,11 +667,10 @@ class FrequencyTuningPhase(PhaseBase):
     # ------------------------------------------------------------------
 
     def _measure_pi_modes(self) -> PhaseStepResult:
-        """Run the full rack FSCAN sequence for this cavity and read back results.
+        """Run a single-cavity FSCAN via Rack.run_fscan and read back results.
 
-        Checks rack exclusivity, selects only this cavity, configures and
-        triggers the scan, waits for completion, pushes mode results, and
-        reads back the 8π/9 and 7π/9 frequencies.
+        Checks rack exclusivity (commissioning policy), delegates the scan
+        sequence to the rack, then reads back the 8π/9 and 7π/9 frequencies.
         """
         if self.context.dry_run:
             return PhaseStepResult(
@@ -696,39 +689,34 @@ class FrequencyTuningPhase(PhaseBase):
         err = self._check_rack_exclusivity(rack)
         if err is not None:
             return err
-        err = self._select_cavity_for_fscan(rack)
-        if err is not None:
-            return err
-        err = self._configure_fscan_params(rack)
-        if err is not None:
-            return err
-        err = self._trigger_fscan(rack)
-        if err is not None:
-            return err
 
-        status_cb = self.context.parameters.get("status_update_callback")
-        err = self._wait_for_fscan(rack, status_cb)
-        if err is not None:
-            return err
-
-        err = self._push_mode_results()
-        if err is not None:
-            return err
-        return self._read_mode_frequencies()
-
-    def _put_pv(
-        self, address: str, value, label: str
-    ) -> "PhaseStepResult | None":
-        """Write ``value`` to ``address``; return a RETRY result on failure."""
         try:
-            PV(address).put(value)
+            rack.run_fscan(
+                [self.cavity],
+                freq_start=self.limits.pi_scan_freq_start,
+                freq_stop=self.limits.pi_scan_freq_stop,
+                rms_thresh=self.limits.pi_scan_rms_thresh,
+                mode_overlap=self.limits.pi_scan_mode_overlap,
+                poll_interval=self.limits.pi_scan_poll_interval,
+                timeout_seconds=self.limits.pi_scan_timeout_seconds,
+                status_callback=self.context.parameters.get(
+                    "status_update_callback"
+                ),
+                should_abort=self.context.is_abort_requested,
+            )
+        except (linac_utils.FSCANError, linac_utils.CavityAbortError) as exc:
+            return PhaseStepResult(
+                result=PhaseResult.FAILED,
+                message=f"FSCAN failed: {exc}",
+            )
         except Exception as exc:
             return PhaseStepResult(
                 result=PhaseResult.RETRY,
-                message=f"Could not write {label}: {exc}",
+                message=f"Transient error during FSCAN: {exc}",
                 retry_delay_seconds=3.0,
             )
-        return None
+
+        return self._read_mode_frequencies()
 
     def _check_rack_exclusivity(self, rack) -> "PhaseStepResult | None":
         rack_check = self.context.parameters.get("rack_check_callback")
@@ -752,102 +740,26 @@ class FrequencyTuningPhase(PhaseBase):
             )
         return None
 
-    def _select_cavity_for_fscan(self, rack) -> "PhaseStepResult | None":
-        for cav_num, cav in rack.cavities.items():
-            selected = 1 if cav_num == self.cavity.number else 0
-            err = self._put_pv(
-                cav.pv_addr("FSCAN:SEL"),
-                selected,
-                f"FSCAN:SEL for cavity {cav_num}",
-            )
-            if err is not None:
-                return err
-        return None
-
-    def _configure_fscan_params(self, rack) -> "PhaseStepResult | None":
-        for suffix, value in (
-            ("FSCAN:FREQ_START", self.limits.pi_scan_freq_start),
-            ("FSCAN:FREQ_STOP", self.limits.pi_scan_freq_stop),
-            ("FSCAN:RMS_THRESH", self.limits.pi_scan_rms_thresh),
-            ("FSCAN:MODE_OVERLAP", self.limits.pi_scan_mode_overlap),
-        ):
-            err = self._put_pv(rack.pv_prefix + suffix, value, suffix)
-            if err is not None:
-                return err
-        return None
-
-    def _trigger_fscan(self, rack) -> "PhaseStepResult | None":
-        return self._put_pv(rack.pv_prefix + "FSCAN:START", 1, "FSCAN:START")
-
-    _FSCAN_STATE_NAMES = {
-        0: "Await request",
-        1: "No cav selected",
-        2: "Bad range",
-        3: "Search in progress",
-        4: "Shift mode",
-        5: "Scan done",
-        6: "Scan aborted",
-        7: "Freq restore fail",
-    }
-
-    def _wait_for_fscan(self, rack, status_cb) -> "PhaseStepResult | None":
-        stat_pv = PV(rack.pv_prefix + "FSCAN:STAT")
-        scan_start = time.monotonic()
-        deadline = scan_start + self.limits.pi_scan_timeout_seconds
-        while time.monotonic() < deadline:
-            if self.context.is_abort_requested():
-                return PhaseStepResult(
-                    result=PhaseResult.FAILED,
-                    message="Abort requested while waiting for FSCAN",
-                )
-            try:
-                stat = int(stat_pv.get())
-            except Exception as exc:
-                return PhaseStepResult(
-                    result=PhaseResult.RETRY,
-                    message=f"Could not read FSCAN:STAT: {exc}",
-                    retry_delay_seconds=self.limits.pi_scan_poll_interval,
-                )
-            if stat == _FSCAN_STAT_SCAN_DONE:
-                return None
-            if stat in (
-                _FSCAN_STAT_SCAN_ABORTED,
-                _FSCAN_STAT_FREQ_RESTORE_FAIL,
-            ):
-                name = self._FSCAN_STATE_NAMES.get(stat, str(stat))
-                return PhaseStepResult(
-                    result=PhaseResult.FAILED,
-                    message=f"FSCAN failed: {name} (state {stat})",
-                )
-            if status_cb:
-                elapsed = time.monotonic() - scan_start
-                name = self._FSCAN_STATE_NAMES.get(stat, str(stat))
-                status_cb(f"FSCAN: {name} ({elapsed:.0f}s elapsed)")
-            time.sleep(self.limits.pi_scan_poll_interval)
-        return PhaseStepResult(
-            result=PhaseResult.FAILED,
-            message=f"FSCAN did not complete within {self.limits.pi_scan_timeout_seconds:.0f} s",
-        )
-
-    def _push_mode_results(self) -> "PhaseStepResult | None":
-        for proc_suffix in ("FSCAN:PUSH_8PI9.PROC", "FSCAN:PUSH_7PI9.PROC"):
-            err = self._put_pv(self.cavity.pv_addr(proc_suffix), 1, proc_suffix)
-            if err is not None:
-                return err
-        return None
-
     def _read_mode_frequencies(self) -> PhaseStepResult:
         results: dict = {}
-        for key, suffix in (
-            ("mode_8pi_9_hz", "FSCAN:8PI9MODE"),
-            ("mode_7pi_9_hz", "FSCAN:7PI9MODE"),
+        for key, pv_obj, label in (
+            (
+                "mode_8pi_9_hz",
+                self.cavity.fscan_8pi9_mode_pv_obj,
+                "FSCAN:8PI9MODE",
+            ),
+            (
+                "mode_7pi_9_hz",
+                self.cavity.fscan_7pi9_mode_pv_obj,
+                "FSCAN:7PI9MODE",
+            ),
         ):
             try:
-                results[key] = float(PV(self.cavity.pv_addr(suffix)).get())
+                results[key] = float(pv_obj.get())
             except Exception as exc:
                 return PhaseStepResult(
                     result=PhaseResult.RETRY,
-                    message=f"Could not read {suffix}: {exc}",
+                    message=f"Could not read {label}: {exc}",
                     retry_delay_seconds=3.0,
                 )
         results["timestamp"] = datetime.now().isoformat()

--- a/src/sc_linac_physics/applications/rf_commissioning/phases/frequency_tuning.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/phases/frequency_tuning.py
@@ -265,34 +265,44 @@ class FrequencyTuningPhase(PhaseBase):
         )
 
     def _apply_hz_per_step(self) -> PhaseStepResult:
-        """Write the measured Hz/step to the SCALE PV after operator confirmation."""
+        """Persist the measured Hz/microstep after operator confirmation.
+
+        STEP:SCALE is a derived, read-only calc-record output
+        (SCALE = SCALE_CALC.B / 256), so we write the Hz-per-full-step field
+        (SCALE_CALC.B) and let the IOC recompute SCALE.
+        """
         if self.context.dry_run:
             return PhaseStepResult(
                 result=PhaseResult.SUCCESS,
-                message="Dry run: skipping SCALE PV write",
+                message="Dry run: skipping SCALE_CALC.B write",
                 data={"dry_run": True},
             )
 
         if self._hz_per_microstep is None:
             return PhaseStepResult(
                 result=PhaseResult.FAILED,
-                message="Hz/step not measured — probe_stepper_direction must run first",
+                message="Hz/microstep not measured — probe_stepper_direction must run first",
             )
 
         try:
-            self.cavity.stepper_tuner.hz_per_microstep_pv_obj.put(
+            self.cavity.stepper_tuner.set_hz_per_microstep(
                 self._hz_per_microstep
             )
         except Exception as exc:
             return PhaseStepResult(
                 result=PhaseResult.RETRY,
-                message=f"Could not write Hz/step to SCALE PV: {exc}",
+                message=f"Could not write Hz/step to SCALE_CALC.B: {exc}",
                 retry_delay_seconds=3.0,
             )
 
+        calc_b = self._hz_per_microstep * linac_utils.MICROSTEPS_PER_STEP
         return PhaseStepResult(
             result=PhaseResult.SUCCESS,
-            message=f"Wrote {self._hz_per_microstep:.4f} Hz/step to SCALE PV",
+            message=(
+                f"Wrote {self._hz_per_microstep:.4f} Hz/microstep "
+                f"(SCALE_CALC.B={calc_b:.4f} Hz/full-step); "
+                "IOC will recompute STEP:SCALE"
+            ),
         )
 
     def _do_probe_move(

--- a/src/sc_linac_physics/applications/rf_commissioning/phases/frequency_tuning.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/phases/frequency_tuning.py
@@ -183,9 +183,9 @@ class FrequencyTuningPhase(PhaseBase):
             return PhaseStepResult(
                 result=PhaseResult.FAILED,
                 message=(
-                    "DF_COLD not recorded — push the cold-landing frequency "
-                    f"({recorded:.0f} Hz) to DF_COLD before tuning "
-                    f"(DF_COLD currently reads {df_cold:.0f} Hz)"
+                    "DF_COLD does not match the recorded cold-landing "
+                    f"frequency — push {recorded:.0f} Hz to DF_COLD before "
+                    f"tuning (DF_COLD currently reads {df_cold:.0f} Hz)"
                 ),
             )
         return None
@@ -303,7 +303,10 @@ class FrequencyTuningPhase(PhaseBase):
         self.cavity.turn_off()
         self.cavity.ssa.turn_on()
         self.cavity.reset_interlocks()
-        self.cavity.setup_tuning()  # use_sela=False default → chirp mode
+        # setup_tuning(use_sela=False) puts the cavity in chirp mode (piezo
+        # feedback off, RF driven by the chirp generator rather than SELA)
+        # so detune can be read via CHIRP:DF while the stepper is moved.
+        self.cavity.setup_tuning()
 
     def _tune_config_warning(self) -> str | None:
         """Return a warning if the cavity is not at the COLD tune config.
@@ -401,23 +404,23 @@ class FrequencyTuningPhase(PhaseBase):
         probe_cb,
         speed: int = linac_utils.DEFAULT_STEPPER_SPEED,
     ) -> tuple[float, float]:
-        """Execute the forward+back probe move; return (d0_hz, d1_hz)."""
+        """Execute the forward+back probe move; return (detune0_hz, detune1_hz)."""
         self.cavity.stepper_tuner.reset_signed_steps()
-        d0 = self.cavity.detune_chirp
+        detune0_hz = self.cavity.detune_chirp
         try:
             if probe_cb:
-                probe_cb(0, d0)
+                probe_cb(0, detune0_hz)
         except Exception:
             pass
         self.cavity.stepper_tuner.move(probe, speed=speed, check_detune=False)
-        d1 = self.cavity.detune_chirp
+        detune1_hz = self.cavity.detune_chirp
         try:
             if probe_cb:
-                probe_cb(probe, d1)
+                probe_cb(probe, detune1_hz)
         except Exception:
             pass
         self.cavity.stepper_tuner.move(-probe, speed=speed, check_detune=False)
-        return d0, d1
+        return detune0_hz, detune1_hz
 
     def _probe_stepper_direction(self) -> PhaseStepResult:
         if self.context.dry_run:
@@ -439,7 +442,9 @@ class FrequencyTuningPhase(PhaseBase):
         speed = self.limits.move_speed
 
         try:
-            d0, d1 = self._do_probe_move(probe, probe_cb, speed=speed)
+            detune0_hz, detune1_hz = self._do_probe_move(
+                probe, probe_cb, speed=speed
+            )
         except (linac_utils.StepperError, linac_utils.StepperAbortError) as exc:
             return PhaseStepResult(
                 result=PhaseResult.FAILED,
@@ -452,7 +457,7 @@ class FrequencyTuningPhase(PhaseBase):
                 retry_delay_seconds=5.0,
             )
 
-        delta = d1 - d0
+        delta = detune1_hz - detune0_hz
 
         if abs(delta) < self.limits.min_probe_delta_hz:
             return PhaseStepResult(
@@ -464,9 +469,13 @@ class FrequencyTuningPhase(PhaseBase):
                 ),
             )
 
-        # SCALE convention: d(cavity_freq)/d(microstep) — probe is in microsteps.
-        # CHIRP:DF = ref_freq - cav_freq, so d(CHIRP:DF)/d(microstep) = -SCALE.
-        # Positive SCALE → positive microsteps increase cavity frequency → CHIRP:DF decreases.
+        # SCALE is defined as the cavity frequency change per microstep
+        # (d(cavity_freq)/d(microstep), i.e. Hz/microstep; probe is in
+        # microsteps). A positive number of microsteps decreases CHIRP:DF —
+        # this is the same relationship Cavity._auto_tune relies on (a
+        # positive detune drives a positive step estimate that reduces it) —
+        # so d(CHIRP:DF)/d(microstep) = -SCALE. We measured
+        # delta = d(CHIRP:DF) for +probe microsteps, so SCALE = -delta/probe.
         signed_hz_per_microstep = -delta / probe
         self._hz_per_microstep = signed_hz_per_microstep
 
@@ -479,8 +488,8 @@ class FrequencyTuningPhase(PhaseBase):
                 f"{'increases' if signed_hz_per_microstep > 0 else 'decreases'} frequency."
             ),
             data={
-                "d0_hz": d0,
-                "d1_hz": d1,
+                "d0_hz": detune0_hz,
+                "d1_hz": detune1_hz,
                 "s_d0": 0,
                 "s_d1": probe,
                 "delta_hz": delta,

--- a/src/sc_linac_physics/applications/rf_commissioning/phases/frequency_tuning.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/phases/frequency_tuning.py
@@ -12,19 +12,18 @@ phase:
      DF_COLD via the UI after reviewing.
   3. Runs a probe move to measure Hz/microstep; the operator confirms and the UI
      writes the value (to SCALE_CALC.B) via apply_hz_per_step.
-  4. Gates on DF_COLD having been recorded, then moves to resonance in small
-     chunks, checking motor temperature before each chunk.  There is no
-     automatic cool-down: if the temperature exceeds the limit the step fails
-     and the operator must investigate and re-run with an explicit
-     acknowledgement (over_temp_ack_c).  After converging, writes the (signed)
-     return-trip step count to the NSTEPS_COLD PV and sets tune_config to
-     RESONANCE.
+  4. Gates on DF_COLD having been recorded, then delegates to
+     Cavity._auto_tune to move to resonance (with a per-iteration stepper
+     temperature guard).  There is no automatic cool-down: if the temperature
+     exceeds the limit the step fails and the operator must investigate and
+     re-run with a higher acknowledgement ceiling (over_temp_ack_c).  After
+     converging, writes the (signed) return-trip step count to the NSTEPS_COLD
+     PV and sets tune_config to RESONANCE.
   5. Runs a single-cavity FSCAN to find the 8π/9 and 7π/9 parasitic modes and
      pushes results to the cavity mode-frequency PVs.
   6. Writes a FrequencyTuningData record.
 """
 
-import math
 import time
 from dataclasses import dataclass
 from datetime import datetime
@@ -80,7 +79,7 @@ class FrequencyTuningPhase(PhaseBase):
     1. verify_initial_state    – stepper idle; prepare cavity (SSA on, reset interlocks, setup_tuning)
     2. record_cold_landing     – record initial detune (operator pushes to DF_COLD via UI)
     3. probe_stepper_direction – measure Hz/step (operator confirms; UI writes to SCALE)
-    4. tune_to_resonance       – chunked loop with temperature guard; write NSTEPS_COLD
+    4. tune_to_resonance       – delegate to Cavity._auto_tune (temp guard); write NSTEPS_COLD
     5. record_results          – write FrequencyTuningData to commissioning record
     """
 
@@ -93,9 +92,6 @@ class FrequencyTuningPhase(PhaseBase):
         self.cavity = None
         # Signed: positive means +steps increase cavity frequency (matches SCALE PV convention)
         self._hz_per_microstep: float | None = None
-        # Over-temperature breaches the operator acknowledged this run:
-        # list of (temp_c, operator) tuples.
-        self._over_temp_acks: list[tuple[float, str]] = []
 
     @property
     def phase_type(self) -> CommissioningPhase:
@@ -486,66 +482,6 @@ class FrequencyTuningPhase(PhaseBase):
             },
         )
 
-    def _guard_temp(
-        self, total_steps: int, peak_temp: float
-    ) -> tuple[float, PhaseStepResult | None]:
-        """Check motor temperature; fail on over-temp unless acknowledged.
-
-        There is no automatic cool-down.  If the motor exceeds the limit the
-        step fails and the operator must investigate and re-run, passing
-        ``over_temp_ack_c`` (a temperature ceiling they authorize) via
-        context.parameters.  A reading hotter than that ceiling re-arms the
-        gate and requires a fresh acknowledgement.
-
-        Returns (updated_peak_temp, error_or_None).
-        """
-        try:
-            temp = self._read_temp()
-        except Exception as exc:
-            return peak_temp, PhaseStepResult(
-                result=PhaseResult.RETRY,
-                message=f"Could not read motor temperature: {exc}",
-                retry_delay_seconds=5.0,
-            )
-        peak_temp = max(peak_temp, temp)
-
-        if temp <= self.limits.temp_limit_c:
-            return peak_temp, None
-
-        ack_ceiling = self.context.parameters.get("over_temp_ack_c")
-        if ack_ceiling is not None and temp <= ack_ceiling:
-            # Operator acknowledged proceeding up to this temperature.
-            self._over_temp_acks.append((temp, self.context.operator))
-            return peak_temp, None
-
-        return peak_temp, PhaseStepResult(
-            result=PhaseResult.FAILED,
-            message=(
-                f"Stepper motor temp {temp:.1f} °C exceeds limit "
-                f"{self.limits.temp_limit_c} °C after {total_steps} steps. "
-                "Investigate; to proceed, acknowledge and re-run with "
-                f"over_temp_ack_c ≥ {temp:.1f}."
-            ),
-            data={
-                "total_steps": total_steps,
-                "peak_temp_c": peak_temp,
-                "stepper_temp_c": temp,
-                "temp_limit_c": self.limits.temp_limit_c,
-                "requires_over_temp_ack": True,
-            },
-        )
-
-    def _guard_detune(self) -> tuple[float, PhaseStepResult | None]:
-        """Read chirp detune. Returns (detune_hz, error_or_None)."""
-        try:
-            return self.cavity.detune_chirp, None
-        except Exception as exc:
-            return 0.0, PhaseStepResult(
-                result=PhaseResult.RETRY,
-                message=f"Could not read detune: {exc}",
-                retry_delay_seconds=3.0,
-            )
-
     def _tuning_dry_run_result(self) -> PhaseStepResult:
         return PhaseStepResult(
             result=PhaseResult.SUCCESS,
@@ -557,58 +493,150 @@ class FrequencyTuningPhase(PhaseBase):
             },
         )
 
-    def _initialize_tuning_state(
-        self, tuning_cb
-    ) -> tuple[int, int, float, "PhaseStepResult | None"]:
-        total_steps = 0
-        peak_temp = 0.0
+    def _tuning_iteration_hook(self) -> None:
+        """Per-iteration hook passed to Cavity._auto_tune.
 
-        # Read the current signed step count rather than resetting it.
-        # REG_TOTSGN was zeroed by the Stage 2 probe, so on the first run
-        # signed_total starts at 0.  After an abort and restart it retains the
-        # displacement already accumulated from cold landing, keeping NSTEPS_COLD
-        # accurate across partial runs.  A read failure here must NOT default to
-        # 0 — that would silently corrupt the NSTEPS_COLD return trip — so we
-        # surface a RETRY instead.
+        Surfaces the phase-level abort flag as an exception (so _auto_tune's
+        loop unwinds) and feeds the live tuning plot.  Signed step count comes
+        straight from the REG_TOTSGN hardware register that _auto_tune's moves
+        accumulate — no parallel bookkeeping needed.
+        """
+        if self.context.is_abort_requested():
+            raise linac_utils.CavityAbortError("Abort requested during tuning")
+        tuning_cb = self.context.parameters.get("tuning_update_callback")
+        if tuning_cb:
+            try:
+                signed = round(
+                    self.cavity.stepper_tuner.step_signed_pv_obj.get() or 0
+                )
+                tuning_cb(signed, self.cavity.detune_chirp)
+            except Exception:
+                pass
+
+    def _tune_to_resonance(self) -> PhaseStepResult:
+        if self.context.dry_run:
+            return self._tuning_dry_run_result()
+
+        if not self._hz_per_microstep:
+            return PhaseStepResult(
+                result=PhaseResult.FAILED,
+                message="hz_per_microstep not set — probe_stepper_direction must run first",
+            )
+
+        df_cold_err = self._check_df_cold_recorded()
+        if df_cold_err is not None:
+            return df_cold_err
+
+        # Operator-authorized over-temp ceiling (re-run raises it); default is
+        # the plain temperature limit.  _auto_tune fails hard on a breach.
+        ack_ceiling = self.context.parameters.get("over_temp_ack_c")
+        max_temp = (
+            ack_ceiling if ack_ceiling is not None else self.limits.temp_limit_c
+        )
+
+        bridged = self._run_auto_tune(max_temp)
+        if bridged is not None:
+            return bridged
+
+        # NSTEPS_COLD is the return trip: negation of the accumulated signed
+        # steps (read once from the hardware register _auto_tune drove).
         try:
             signed_total = round(
                 self.cavity.stepper_tuner.step_signed_pv_obj.get() or 0
             )
         except Exception as exc:
-            return (
-                total_steps,
-                0,
-                peak_temp,
-                PhaseStepResult(
-                    result=PhaseResult.RETRY,
-                    message=f"Could not read signed step count to resume tuning: {exc}",
-                    retry_delay_seconds=3.0,
-                ),
+            return PhaseStepResult(
+                result=PhaseResult.RETRY,
+                message=f"Could not read signed step count after tuning: {exc}",
+                retry_delay_seconds=3.0,
             )
 
-        try:
-            peak_temp = self._read_temp()
-        except Exception:
-            pass
+        err = self._write_cold_landing_steps(signed_total)
+        if err is not None:
+            return err
 
-        try:
-            if tuning_cb:
-                tuning_cb(signed_total, self.cavity.detune_chirp)
-        except Exception:
-            pass
+        err = self._write_tune_config_resonance()
+        if err is not None:
+            return err
 
-        return total_steps, signed_total, peak_temp, None
+        return self._tuning_success_result(signed_total, ack_ceiling)
 
-    def _emit_tuning_update(self, tuning_cb, signed_total: int) -> None:
+    def _run_auto_tune(self, max_temp: float) -> "PhaseStepResult | None":
+        """Delegate the tuning loop to Cavity._auto_tune.
+
+        Returns a FAILED/RETRY PhaseStepResult on failure, or None on success.
+        """
         try:
-            if tuning_cb:
-                tuning_cb(signed_total, self.cavity.detune_chirp)
+            self.cavity._auto_tune(
+                delta_hz_func=lambda: self.cavity.detune_chirp,
+                tolerance=self.limits.tolerance_hz,
+                iteration_callback=self._tuning_iteration_hook,
+                max_stepper_temp=max_temp,
+            )
+        except linac_utils.StepperTempError as exc:
+            temp = self._safe_read_temp()
+            return PhaseStepResult(
+                result=PhaseResult.FAILED,
+                message=(
+                    f"{exc}. Investigate; to proceed, acknowledge and re-run "
+                    "with a higher over_temp_ack_c."
+                ),
+                data={
+                    "stepper_temp_c": temp,
+                    "temp_limit_c": self.limits.temp_limit_c,
+                    "requires_over_temp_ack": True,
+                },
+            )
+        except (
+            linac_utils.DetuneError,
+            linac_utils.StepperError,
+            linac_utils.StepperAbortError,
+            linac_utils.CavityAbortError,
+        ) as exc:
+            return PhaseStepResult(
+                result=PhaseResult.FAILED,
+                message=f"Tuning to resonance failed: {exc}",
+            )
+        except Exception as exc:
+            return PhaseStepResult(
+                result=PhaseResult.RETRY,
+                message=f"Transient error during tuning: {exc}",
+                retry_delay_seconds=3.0,
+            )
+        return None
+
+    def _safe_read_temp(self) -> float | None:
+        try:
+            return self._read_temp()
         except Exception:
-            pass
+            return None
+
+    def _tuning_success_result(
+        self, signed_total: int, ack_ceiling: float | None
+    ) -> PhaseStepResult:
+        data = {
+            "total_steps": abs(signed_total),
+            "cold_landing_steps": -signed_total,
+            "final_timestamp": datetime.now().isoformat(),
+        }
+        # Audit trail: if the operator authorized proceeding over the temp
+        # limit, record the ceiling and who authorized it.
+        if ack_ceiling is not None and ack_ceiling > self.limits.temp_limit_c:
+            data["over_temp_acknowledged_c"] = ack_ceiling
+            data["over_temp_acknowledged_by"] = self.context.operator
+
+        return PhaseStepResult(
+            result=PhaseResult.SUCCESS,
+            message=(
+                f"Reached resonance. NSTEPS_COLD set to {-signed_total}. "
+                "tune_config set to RESONANCE."
+            ),
+            data=data,
+        )
 
     def _write_cold_landing_steps(
         self, signed_total: int
-    ) -> PhaseStepResult | None:
+    ) -> "PhaseStepResult | None":
         # NSTEPS_COLD stores the return-trip step count (from resonance to cold
         # landing), which is the negation of the steps we just took.
         try:
@@ -622,202 +650,6 @@ class FrequencyTuningPhase(PhaseBase):
                 retry_delay_seconds=3.0,
             )
         return None
-
-    def _one_tuning_iteration(
-        self,
-        total_steps: int,
-        signed_total: int,
-        peak_temp: float,
-        hz_per_step: float,
-        hz_update_cb=None,
-        speed: int = linac_utils.DEFAULT_STEPPER_SPEED,
-    ) -> tuple[int, int, float, bool, PhaseStepResult | None]:
-        """Execute one iteration of the tuning loop.
-
-        Returns (new_total_steps, new_signed_total, new_peak_temp, converged, error_or_None).
-        signed_total accumulates the signed step count for writing to NSTEPS_COLD.
-        """
-        if self.context.is_abort_requested():
-            return (
-                total_steps,
-                signed_total,
-                peak_temp,
-                False,
-                PhaseStepResult(
-                    result=PhaseResult.FAILED,
-                    message=f"Abort requested after {total_steps} steps",
-                ),
-            )
-
-        peak_temp, err = self._guard_temp(total_steps, peak_temp)
-        if err is not None:
-            return total_steps, signed_total, peak_temp, False, err
-
-        detune, err = self._guard_detune()
-        if err is not None:
-            return total_steps, signed_total, peak_temp, False, err
-
-        if abs(detune) <= self.limits.tolerance_hz:
-            return total_steps, signed_total, peak_temp, True, None
-
-        if total_steps >= self.limits.max_total_steps:
-            return (
-                total_steps,
-                signed_total,
-                peak_temp,
-                False,
-                PhaseStepResult(
-                    result=PhaseResult.FAILED,
-                    message=(
-                        f"Reached max step limit ({self.limits.max_total_steps}) "
-                        f"without converging; final detune {detune:.0f} Hz"
-                    ),
-                    data={
-                        "total_steps": total_steps,
-                        "final_detune_hz": detune,
-                        "peak_temp_c": peak_temp,
-                    },
-                ),
-            )
-
-        magnitude, steps_this_move, err = self._do_move(
-            total_steps, peak_temp, detune, hz_per_step, hz_update_cb, speed
-        )
-        if err is not None:
-            return total_steps, signed_total, peak_temp, False, err
-        return (
-            total_steps + magnitude,
-            signed_total + steps_this_move,
-            peak_temp,
-            False,
-            None,
-        )
-
-    def _do_move(
-        self,
-        total_steps: int,
-        peak_temp: float,
-        detune: float,
-        hz_per_step: float,
-        hz_update_cb,
-        speed: int = linac_utils.DEFAULT_STEPPER_SPEED,
-    ) -> tuple[int, int, "PhaseStepResult | None"]:
-        """Compute step size, execute stepper move, and invoke the Hz/step callback."""
-        hardware_max = int(self.cavity.stepper_tuner.max_steps)
-        estimated = max(1, round(abs(detune) / abs(hz_per_step)))
-        magnitude = min(hardware_max, estimated)
-        # Direction: steps_to_zero = detune / SCALE, so sign = sign(detune / signed_hz).
-        # This handles motors wired in either direction (positive or negative SCALE).
-        signed_hz = self._hz_per_microstep
-        if signed_hz:
-            steps_this_move = int(math.copysign(magnitude, detune / signed_hz))
-        else:
-            steps_this_move = int(math.copysign(magnitude, detune))
-
-        try:
-            self.cavity.stepper_tuner.move(
-                steps_this_move,
-                max_steps=hardware_max,
-                speed=speed,
-                check_detune=False,
-            )
-        except (linac_utils.StepperError, linac_utils.StepperAbortError) as exc:
-            return (
-                magnitude,
-                steps_this_move,
-                PhaseStepResult(
-                    result=PhaseResult.FAILED,
-                    message=f"Stepper error after {total_steps} steps: {exc}",
-                    data={"total_steps": total_steps, "peak_temp_c": peak_temp},
-                ),
-            )
-
-        if hz_update_cb is not None:
-            try:
-                hz_delta = abs(self.cavity.detune_chirp - detune)
-                if hz_delta > 0:
-                    hz_update_cb(magnitude, hz_delta)
-            except Exception:
-                pass
-
-        return magnitude, steps_this_move, None
-
-    def _tune_to_resonance(self) -> PhaseStepResult:
-        if self.context.dry_run:
-            return self._tuning_dry_run_result()
-
-        hz_per_step = self._hz_per_microstep
-        if not hz_per_step:
-            return PhaseStepResult(
-                result=PhaseResult.FAILED,
-                message="hz_per_microstep not set — probe_stepper_direction must run first",
-            )
-
-        df_cold_err = self._check_df_cold_recorded()
-        if df_cold_err is not None:
-            return df_cold_err
-
-        tuning_cb = self.context.parameters.get("tuning_update_callback")
-        hz_update_cb = self.context.parameters.get(
-            "hz_per_step_update_callback"
-        )
-        speed = self.limits.move_speed
-
-        total_steps, signed_total, peak_temp, err = (
-            self._initialize_tuning_state(tuning_cb)
-        )
-        if err is not None:
-            return err
-
-        while True:
-            total_steps, signed_total, peak_temp, converged, err = (
-                self._one_tuning_iteration(
-                    total_steps,
-                    signed_total,
-                    peak_temp,
-                    hz_per_step,
-                    hz_update_cb,
-                    speed,
-                )
-            )
-            if err is not None:
-                return err
-            self._emit_tuning_update(tuning_cb, signed_total)
-            if converged:
-                break
-
-        err = self._write_cold_landing_steps(signed_total)
-        if err is not None:
-            return err
-
-        err = self._write_tune_config_resonance()
-        if err is not None:
-            return err
-
-        return self._tuning_success_result(total_steps, signed_total)
-
-    def _tuning_success_result(
-        self, total_steps: int, signed_total: int
-    ) -> PhaseStepResult:
-        data = {
-            "total_steps": total_steps,
-            "cold_landing_steps": -signed_total,
-            "final_timestamp": datetime.now().isoformat(),
-        }
-        if self._over_temp_acks:
-            data["over_temp_acknowledged_c"] = max(
-                t for t, _ in self._over_temp_acks
-            )
-            data["over_temp_acknowledged_by"] = self.context.operator
-
-        return PhaseStepResult(
-            result=PhaseResult.SUCCESS,
-            message=(
-                f"Reached resonance in {total_steps} steps. "
-                f"NSTEPS_COLD set to {-signed_total}. tune_config set to RESONANCE."
-            ),
-            data=data,
-        )
 
     def _write_tune_config_resonance(self) -> "PhaseStepResult | None":
         # The cavity is now on resonance; record that state (mirrors

--- a/src/sc_linac_physics/applications/rf_commissioning/phases/frequency_tuning.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/phases/frequency_tuning.py
@@ -1,16 +1,20 @@
 """
 Frequency Tuning Phase
 
-Tunes the cavity stepper to resonance after initial cool-down.  Before moving
-the stepper this phase:
-  1. Checks that the stepper is idle and chirp detune is valid.
+Tunes the cavity stepper to resonance after initial cool-down.  Cavities are
+expected to start at the COLD tune config.  Before moving the stepper this
+phase:
+  1. Checks that the stepper is idle and chirp detune is valid; warns (but does
+     not fail) if the cavity is not at the COLD tune config.
   2. Records the cold-landing detune for display; the operator pushes it to
      DF_COLD via the UI after reviewing.
-  3. Runs a probe move to measure Hz/step; the operator confirms and the UI
-     writes the value to the SCALE PV via apply_hz_per_step.
-  4. Moves to resonance in small chunks, checking motor temperature before each
-     chunk and pausing if the temperature exceeds the limit.  After converging,
-     writes the (signed) return-trip step count to the NSTEPS_COLD PV.
+  3. Runs a probe move to measure Hz/microstep; the operator confirms and the UI
+     writes the value (to SCALE_CALC.B) via apply_hz_per_step.
+  4. Gates on DF_COLD having been recorded, then moves to resonance in small
+     chunks, checking motor temperature before each chunk and pausing if the
+     temperature exceeds the limit.  After converging, writes the (signed)
+     return-trip step count to the NSTEPS_COLD PV and sets tune_config to
+     RESONANCE.
   5. Runs a single-cavity FSCAN to find the 8π/9 and 7π/9 parasitic modes and
      pushes results to the cavity mode-frequency PVs.
   6. Writes a FrequencyTuningData record.
@@ -148,10 +152,51 @@ class FrequencyTuningPhase(PhaseBase):
             self._stepper_temp_pv_obj = PV(self.cavity.stepper_temp_pv)
         return self._stepper_temp_pv_obj.get()
 
-    def _write_df_cold(self, detune_hz: float) -> None:
+    def _read_df_cold(self) -> float:
+        # DF_COLD is written by the operator via the UI after reviewing the
+        # cold-landing frequency; the backend reads it back to gate tuning.
         if self._df_cold_pv_obj is None:
             self._df_cold_pv_obj = PV(self.cavity.pv_addr("DF_COLD"))
-        self._df_cold_pv_obj.put(detune_hz)
+        return self._df_cold_pv_obj.get()
+
+    _DF_COLD_MATCH_TOLERANCE_HZ = 1.0
+
+    def _check_df_cold_recorded(self) -> "PhaseStepResult | None":
+        """Ensure the operator pushed the cold-landing detune to DF_COLD.
+
+        Returns a FAILED/RETRY result if DF_COLD was not recorded, else None.
+        The recorded cold-landing detune (from record_cold_landing) is the
+        reliable reference: DF_COLD defaults to a valid 0, so there is no
+        INVALID severity to key off — we require DF_COLD to match it.
+        """
+        cold = self._get_checkpoint_data("record_cold_landing")
+        recorded = cold.get("df_cold_hz")
+        if recorded is None:
+            return PhaseStepResult(
+                result=PhaseResult.FAILED,
+                message=(
+                    "Cold landing frequency was not recorded — run "
+                    "record_cold_landing before tuning"
+                ),
+            )
+        try:
+            df_cold = self._read_df_cold()
+        except Exception as exc:
+            return PhaseStepResult(
+                result=PhaseResult.RETRY,
+                message=f"Could not read DF_COLD: {exc}",
+                retry_delay_seconds=3.0,
+            )
+        if abs(df_cold - recorded) > self._DF_COLD_MATCH_TOLERANCE_HZ:
+            return PhaseStepResult(
+                result=PhaseResult.FAILED,
+                message=(
+                    "DF_COLD not recorded — push the cold-landing frequency "
+                    f"({recorded:.0f} Hz) to DF_COLD before tuning "
+                    f"(DF_COLD currently reads {df_cold:.0f} Hz)"
+                ),
+            )
+        return None
 
     def _write_nsteps_cold(self, steps: int) -> None:
         if self._nsteps_cold_pv_obj is None:
@@ -227,10 +272,38 @@ class FrequencyTuningPhase(PhaseBase):
                 retry_delay_seconds=3.0,
             )
 
+        tune_config_warning = self._tune_config_warning()
+
+        message = f"Stepper idle, chirp valid. Temp {temp:.1f} °C, detune {detune:.0f} Hz"
+        if tune_config_warning:
+            message += f". WARNING: {tune_config_warning}"
+
         return PhaseStepResult(
             result=PhaseResult.SUCCESS,
-            message=f"Stepper idle, chirp valid. Temp {temp:.1f} °C, detune {detune:.0f} Hz",
-            data={"initial_temp_c": temp, "initial_detune_hz": detune},
+            message=message,
+            data={
+                "initial_temp_c": temp,
+                "initial_detune_hz": detune,
+                "tune_config_warning": tune_config_warning,
+            },
+        )
+
+    def _tune_config_warning(self) -> str | None:
+        """Return a warning if the cavity is not at the COLD tune config.
+
+        Cavities are expected to start at COLD; a different state is not fatal
+        (the operator may have a reason), so this only flags it.
+        """
+        try:
+            tune_config = self.cavity.tune_config_pv_obj.get()
+        except Exception:
+            return None
+        if tune_config == linac_utils.TUNE_CONFIG_COLD_VALUE:
+            return None
+        return (
+            f"tune_config is {tune_config} (expected COLD="
+            f"{linac_utils.TUNE_CONFIG_COLD_VALUE}); "
+            "cavity may not be at cold landing"
         )
 
     def _record_cold_landing(self) -> PhaseStepResult:
@@ -239,14 +312,14 @@ class FrequencyTuningPhase(PhaseBase):
                 result=PhaseResult.SUCCESS,
                 message="Dry run: cold landing snapshot simulated",
                 data={
-                    "initial_detune_hz": 0.0,
+                    "df_cold_hz": 0.0,
                     "initial_timestamp": datetime.now().isoformat(),
                     "dry_run": True,
                 },
             )
 
         try:
-            initial_detune_hz = self.cavity.detune_chirp
+            df_cold_hz = self.cavity.detune_chirp
         except Exception as exc:
             return PhaseStepResult(
                 result=PhaseResult.RETRY,
@@ -256,10 +329,10 @@ class FrequencyTuningPhase(PhaseBase):
 
         return PhaseStepResult(
             result=PhaseResult.SUCCESS,
-            message=f"Cold landing frequency recorded: detune={initial_detune_hz:.0f} Hz. "
+            message=f"Cold landing frequency recorded: detune={df_cold_hz:.0f} Hz. "
             "Push to DF_COLD when satisfied.",
             data={
-                "initial_detune_hz": initial_detune_hz,
+                "df_cold_hz": df_cold_hz,
                 "initial_timestamp": datetime.now().isoformat(),
             },
         )
@@ -641,6 +714,10 @@ class FrequencyTuningPhase(PhaseBase):
                 message="hz_per_microstep not set — probe_stepper_direction must run first",
             )
 
+        df_cold_err = self._check_df_cold_recorded()
+        if df_cold_err is not None:
+            return df_cold_err
+
         tuning_cb = self.context.parameters.get("tuning_update_callback")
         hz_update_cb = self.context.parameters.get(
             "hz_per_step_update_callback"
@@ -674,11 +751,15 @@ class FrequencyTuningPhase(PhaseBase):
         if err is not None:
             return err
 
+        err = self._write_tune_config_resonance()
+        if err is not None:
+            return err
+
         return PhaseStepResult(
             result=PhaseResult.SUCCESS,
             message=(
                 f"Reached resonance in {total_steps} steps. "
-                f"NSTEPS_COLD set to {-signed_total}."
+                f"NSTEPS_COLD set to {-signed_total}. tune_config set to RESONANCE."
             ),
             data={
                 "total_steps": total_steps,
@@ -686,6 +767,21 @@ class FrequencyTuningPhase(PhaseBase):
                 "final_timestamp": datetime.now().isoformat(),
             },
         )
+
+    def _write_tune_config_resonance(self) -> "PhaseStepResult | None":
+        # The cavity is now on resonance; record that state (mirrors
+        # Cavity.move_to_resonance).
+        try:
+            self.cavity.tune_config_pv_obj.put(
+                linac_utils.TUNE_CONFIG_RESONANCE_VALUE
+            )
+        except Exception as exc:
+            return PhaseStepResult(
+                result=PhaseResult.RETRY,
+                message=f"Could not set tune_config to RESONANCE: {exc}",
+                retry_delay_seconds=3.0,
+            )
+        return None
 
     # ------------------------------------------------------------------
     # Pi-mode scan step
@@ -919,7 +1015,7 @@ class FrequencyTuningPhase(PhaseBase):
         )
 
         self.context.record.frequency_tuning = FrequencyTuningData(
-            initial_detune_hz=cold.get("initial_detune_hz"),
+            df_cold_hz=cold.get("df_cold_hz"),
             initial_timestamp=initial_ts,
             steps_to_resonance=tune.get("total_steps"),
             final_timestamp=final_ts,

--- a/src/sc_linac_physics/applications/rf_commissioning/phases/frequency_tuning.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/phases/frequency_tuning.py
@@ -202,19 +202,30 @@ class FrequencyTuningPhase(PhaseBase):
                 data={"dry_run": True},
             )
 
-        if self.cavity.stepper_tuner.motor_moving:
+        try:
+            motor_moving = self.cavity.stepper_tuner.motor_moving
+            on_limit_switch = self.cavity.stepper_tuner.on_limit_switch
+            is_online = self.cavity.is_online
+        except Exception as exc:
+            return PhaseStepResult(
+                result=PhaseResult.RETRY,
+                message=f"Could not read initial stepper/cavity state: {exc}",
+                retry_delay_seconds=3.0,
+            )
+
+        if motor_moving:
             return PhaseStepResult(
                 result=PhaseResult.FAILED,
                 message="Stepper motor already moving — abort or wait for it to stop",
             )
 
-        if self.cavity.stepper_tuner.on_limit_switch:
+        if on_limit_switch:
             return PhaseStepResult(
                 result=PhaseResult.FAILED,
                 message="Stepper motor is on a limit switch — manual intervention required",
             )
 
-        if not self.cavity.is_online:
+        if not is_online:
             return PhaseStepResult(
                 result=PhaseResult.FAILED,
                 message="Cavity is not online — cannot prepare it for tuning",
@@ -453,19 +464,19 @@ class FrequencyTuningPhase(PhaseBase):
                 ),
             )
 
-        # SCALE convention: d(cavity_freq)/d(step).
-        # CHIRP:DF = ref_freq - cav_freq, so d(CHIRP:DF)/d(step) = -SCALE.
-        # Positive SCALE → positive steps increase cavity frequency → CHIRP:DF decreases.
-        signed_hz_per_step = -delta / probe
-        self._hz_per_microstep = signed_hz_per_step
+        # SCALE convention: d(cavity_freq)/d(microstep) — probe is in microsteps.
+        # CHIRP:DF = ref_freq - cav_freq, so d(CHIRP:DF)/d(microstep) = -SCALE.
+        # Positive SCALE → positive microsteps increase cavity frequency → CHIRP:DF decreases.
+        signed_hz_per_microstep = -delta / probe
+        self._hz_per_microstep = signed_hz_per_microstep
 
         return PhaseStepResult(
             result=PhaseResult.SUCCESS,
             message=(
-                f"Direction probe: Δdetune={delta:+.0f} Hz for +{probe} steps. "
-                f"Measured {abs(self._hz_per_microstep):.4f} Hz/step (confirm to write to SCALE PV). "
+                f"Direction probe: Δdetune={delta:+.0f} Hz for +{probe} microsteps. "
+                f"Measured {abs(self._hz_per_microstep):.4f} Hz/microstep (confirm to write to SCALE PV). "
                 f"move(+N) "
-                f"{'increases' if signed_hz_per_step > 0 else 'decreases'} frequency."
+                f"{'increases' if signed_hz_per_microstep > 0 else 'decreases'} frequency."
             ),
             data={
                 "d0_hz": d0,
@@ -776,7 +787,7 @@ class FrequencyTuningPhase(PhaseBase):
         """Placeholder step — actual population happens in finalize_phase()."""
         return PhaseStepResult(
             result=PhaseResult.SUCCESS,
-            message="Results collected; ready to finalise",
+            message="Results collected; ready to finalize",
         )
 
     # ------------------------------------------------------------------

--- a/src/sc_linac_physics/applications/rf_commissioning/phases/frequency_tuning.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/phases/frequency_tuning.py
@@ -4,8 +4,10 @@ Frequency Tuning Phase
 Tunes the cavity stepper to resonance after initial cool-down.  Cavities are
 expected to start at the COLD tune config.  Before moving the stepper this
 phase:
-  1. Checks that the stepper is idle and chirp detune is valid; warns (but does
-     not fail) if the cavity is not at the COLD tune config.
+  1. Checks that the stepper is idle, then prepares the cavity for tuning —
+     RF off, SSA on, reset interlocks, set up chirp (mirrors the production
+     SetupCavity + Cavity.setup_tuning path); warns (but does not fail) if the
+     cavity is not at the COLD tune config.
   2. Records the cold-landing detune for display; the operator pushes it to
      DF_COLD via the UI after reviewing.
   3. Runs a probe move to measure Hz/microstep; the operator confirms and the UI
@@ -73,7 +75,7 @@ class FrequencyTuningPhase(PhaseBase):
     Frequency Tuning Phase.
 
     Sequence:
-    1. verify_initial_state    – stepper idle, not on limit switch, chirp valid
+    1. verify_initial_state    – stepper idle; prepare cavity (SSA on, reset interlocks, setup_tuning)
     2. record_cold_landing     – record initial detune (operator pushes to DF_COLD via UI)
     3. probe_stepper_direction – measure Hz/step (operator confirms; UI writes to SCALE)
     4. tune_to_resonance       – chunked loop with temperature guard; write NSTEPS_COLD
@@ -218,28 +220,23 @@ class FrequencyTuningPhase(PhaseBase):
                 message="Stepper motor is on a limit switch — manual intervention required",
             )
 
-        if self.cavity.detune_invalid:
+        if not self.cavity.is_online:
             return PhaseStepResult(
                 result=PhaseResult.FAILED,
-                message=(
-                    "Chirp detune is invalid — ensure the chirp scan is running "
-                    "and producing a valid CHIRP:DF reading before starting this phase"
-                ),
+                message="Cavity is not online — cannot prepare it for tuning",
             )
 
-        try:
-            temp = self._read_temp()
-            detune = self.cavity.detune_chirp
-        except Exception as exc:
-            return PhaseStepResult(
-                result=PhaseResult.RETRY,
-                message=f"Could not read stepper/detune state: {exc}",
-                retry_delay_seconds=3.0,
-            )
+        prepared = self._prepare_and_read()
+        if isinstance(prepared, PhaseStepResult):
+            return prepared
+        temp, detune = prepared
 
         tune_config_warning = self._tune_config_warning()
 
-        message = f"Stepper idle, chirp valid. Temp {temp:.1f} °C, detune {detune:.0f} Hz"
+        message = (
+            "Cavity prepared for tuning (SSA on, interlocks reset, chirp valid). "
+            f"Temp {temp:.1f} °C, detune {detune:.0f} Hz"
+        )
         if tune_config_warning:
             message += f". WARNING: {tune_config_warning}"
 
@@ -252,6 +249,56 @@ class FrequencyTuningPhase(PhaseBase):
                 "tune_config_warning": tune_config_warning,
             },
         )
+
+    def _prepare_and_read(self) -> "PhaseStepResult | tuple[float, float]":
+        """Read temp, prepare the cavity, read detune.
+
+        Returns (temp_c, detune_hz) on success, or a FAILED/RETRY
+        PhaseStepResult if preparation could not complete.
+        """
+        try:
+            temp = self._read_temp()
+            self._prepare_cavity_for_tuning()
+            return temp, self.cavity.detune_chirp
+        except linac_utils.DetuneError as exc:
+            return PhaseStepResult(
+                result=PhaseResult.FAILED,
+                message=(
+                    "Could not establish a valid chirp detune "
+                    f"(find_chirp_range exhausted its range): {exc}"
+                ),
+            )
+        except linac_utils.CavityFaultError as exc:
+            return PhaseStepResult(
+                result=PhaseResult.FAILED,
+                message=f"Cavity still faulted after interlock resets: {exc}",
+            )
+        except (
+            linac_utils.StepperAbortError,
+            linac_utils.CavityAbortError,
+        ) as exc:
+            return PhaseStepResult(
+                result=PhaseResult.FAILED,
+                message=f"Aborted during cavity setup: {exc}",
+            )
+        except Exception as exc:
+            return PhaseStepResult(
+                result=PhaseResult.RETRY,
+                message=f"Could not prepare cavity / read state: {exc}",
+                retry_delay_seconds=3.0,
+            )
+
+    def _prepare_cavity_for_tuning(self) -> None:
+        """Prepare the cavity for chirp tuning, mirroring the production path.
+
+        RF off first so a latched interlock clears even if RF was requested on,
+        then SSA on, reset interlocks, and set up chirp tuning — the same
+        sequence as SetupCavity.setup + Cavity.setup_tuning.
+        """
+        self.cavity.turn_off()
+        self.cavity.ssa.turn_on()
+        self.cavity.reset_interlocks()
+        self.cavity.setup_tuning()  # use_sela=False default → chirp mode
 
     def _tune_config_warning(self) -> str | None:
         """Return a warning if the cavity is not at the COLD tune config.

--- a/src/sc_linac_physics/applications/rf_commissioning/phases/frequency_tuning.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/phases/frequency_tuning.py
@@ -153,11 +153,6 @@ class FrequencyTuningPhase(PhaseBase):
     def _read_temp(self) -> float:
         return self.cavity.stepper_temp_pv_obj.get()
 
-    def _read_df_cold(self) -> float:
-        # DF_COLD is written by the operator via the UI after reviewing the
-        # cold-landing frequency; the backend reads it back to gate tuning.
-        return self.cavity.df_cold_pv_obj.get()
-
     _DF_COLD_MATCH_TOLERANCE_HZ = 1.0
 
     def _check_df_cold_recorded(self) -> "PhaseStepResult | None":
@@ -178,8 +173,10 @@ class FrequencyTuningPhase(PhaseBase):
                     "record_cold_landing before tuning"
                 ),
             )
+        # DF_COLD is written by the operator via the UI after reviewing the
+        # cold-landing frequency; the backend reads it back to gate tuning.
         try:
-            df_cold = self._read_df_cold()
+            df_cold = self.cavity.df_cold_pv_obj.get()
         except Exception as exc:
             return PhaseStepResult(
                 result=PhaseResult.RETRY,
@@ -196,9 +193,6 @@ class FrequencyTuningPhase(PhaseBase):
                 ),
             )
         return None
-
-    def _write_nsteps_cold(self, steps: int) -> None:
-        self.cavity.stepper_tuner.steps_cold_landing_pv_obj.put(steps)
 
     # ------------------------------------------------------------------
     # Step implementations
@@ -569,7 +563,9 @@ class FrequencyTuningPhase(PhaseBase):
         # NSTEPS_COLD stores the return-trip step count (from resonance to cold
         # landing), which is the negation of the steps we just took.
         try:
-            self._write_nsteps_cold(-signed_total)
+            self.cavity.stepper_tuner.steps_cold_landing_pv_obj.put(
+                -signed_total
+            )
         except Exception as exc:
             return PhaseStepResult(
                 result=PhaseResult.RETRY,

--- a/src/sc_linac_physics/applications/rf_commissioning/phases/frequency_tuning.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/phases/frequency_tuning.py
@@ -55,7 +55,11 @@ class FrequencyTuningLimits:
     move_speed: int = linac_utils.DEFAULT_STEPPER_SPEED
     temp_limit_c: float = linac_utils.STEPPER_TEMP_LIMIT
     max_total_steps: int = 10_000_000
-    min_probe_delta_hz: float = 10.0
+    # A healthy probe move (probe_steps microsteps at ~0.005 Hz/microstep)
+    # produces a few hundred Hz of detune change on real cavities; require a
+    # solid fraction of that so a degraded/uncoupled stepper is caught, not
+    # just a totally dead one.
+    min_probe_delta_hz: float = 100.0
     pi_scan_freq_start: int = -3_500_000
     pi_scan_freq_stop: int = 50_000
     pi_scan_rms_thresh: float = 10.0

--- a/src/sc_linac_physics/applications/rf_commissioning/phases/frequency_tuning.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/phases/frequency_tuning.py
@@ -1,0 +1,929 @@
+"""
+Frequency Tuning Phase
+
+Tunes the cavity stepper to resonance after initial cool-down.  Before moving
+the stepper this phase:
+  1. Checks that the stepper is idle and chirp detune is valid.
+  2. Records the cold-landing detune for display; the operator pushes it to
+     DF_COLD via the UI after reviewing.
+  3. Runs a probe move to measure Hz/step; the operator confirms and the UI
+     writes the value to the SCALE PV via apply_hz_per_step.
+  4. Moves to resonance in small chunks, checking motor temperature before each
+     chunk and pausing if the temperature exceeds the limit.  After converging,
+     writes the (signed) return-trip step count to the NSTEPS_COLD PV.
+  5. Runs a single-cavity FSCAN to find the 8π/9 and 7π/9 parasitic modes and
+     pushes results to the cavity mode-frequency PVs.
+  6. Writes a FrequencyTuningData record.
+"""
+
+import math
+import time
+from dataclasses import dataclass
+from datetime import datetime
+
+from sc_linac_physics.applications.rf_commissioning.models.data_models import (
+    CommissioningPhase,
+    FrequencyTuningData,
+)
+from sc_linac_physics.applications.rf_commissioning.phases.phase_base import (
+    PhaseBase,
+    PhaseContext,
+    PhaseExecutionError,
+    PhaseResult,
+    PhaseStepResult,
+)
+from sc_linac_physics.utils.epics import PV
+from sc_linac_physics.utils.sc_linac import linac_utils
+
+_FSCAN_STAT_SCAN_DONE = 5
+_FSCAN_STAT_SCAN_ABORTED = 6
+_FSCAN_STAT_FREQ_RESTORE_FAIL = 7
+
+
+@dataclass
+class FrequencyTuningLimits:
+    """Configurable limits for the frequency tuning phase."""
+
+    tolerance_hz: float = 50.0
+    probe_steps: int = 50_000
+    move_speed: int = linac_utils.DEFAULT_STEPPER_SPEED
+    temp_limit_c: float = linac_utils.STEPPER_TEMP_LIMIT
+    max_total_steps: int = 10_000_000
+    cool_down_retries: int = 6
+    cool_down_interval: float = 5.0
+    motor_start_wait: float = 5.0
+    motor_poll_interval: float = 2.0
+    min_probe_delta_hz: float = 10.0
+    pi_scan_freq_start: int = -3_500_000
+    pi_scan_freq_stop: int = 50_000
+    pi_scan_rms_thresh: float = 10.0
+    pi_scan_mode_overlap: int = 1_000
+    pi_scan_poll_interval: float = 2.0
+    pi_scan_timeout_seconds: float = 300.0
+
+
+class FrequencyTuningPhase(PhaseBase):
+    """
+    Frequency Tuning Phase.
+
+    Sequence:
+    1. verify_initial_state    – stepper idle, not on limit switch, chirp valid
+    2. record_cold_landing     – record initial detune (operator pushes to DF_COLD via UI)
+    3. probe_stepper_direction – measure Hz/step (operator confirms; UI writes to SCALE)
+    4. tune_to_resonance       – chunked loop with temperature guard; write NSTEPS_COLD
+    5. record_results          – write FrequencyTuningData to commissioning record
+    """
+
+    def __init__(
+        self, context: PhaseContext, limits: FrequencyTuningLimits | None = None
+    ):
+        super().__init__(context)
+        self.limits = limits or FrequencyTuningLimits()
+        self._history_start = len(context.record.phase_history)
+        self.cavity = None
+        self._stepper_temp_pv_obj: PV | None = None
+        self._df_cold_pv_obj: PV | None = None
+        self._nsteps_cold_pv_obj: PV | None = None
+        self._step_signed_pv_obj: PV | None = None
+        self._hz_per_microstep: float | None = None
+        self._signed_hz_per_microstep: float | None = None
+
+    @property
+    def phase_type(self) -> CommissioningPhase:
+        return CommissioningPhase.FREQUENCY_TUNING
+
+    def validate_prerequisites(self) -> tuple[bool, str]:
+        cavity = self.context.parameters.get("cavity")
+        if cavity is None:
+            return False, "No cavity specified in context"
+
+        if not hasattr(cavity, "stepper_tuner") or cavity.stepper_tuner is None:
+            return False, "Cavity has no stepper_tuner object"
+
+        if not hasattr(cavity, "stepper_temp_pv") or not cavity.stepper_temp_pv:
+            return False, "Cavity has no stepper_temp_pv defined"
+
+        self.cavity = cavity
+        return True, "Prerequisites validated"
+
+    def get_phase_steps(self) -> list[str]:
+        return [
+            "verify_initial_state",
+            "record_cold_landing",
+            "probe_stepper_direction",
+            "apply_hz_per_step",
+            "tune_to_resonance",
+            "measure_pi_modes",
+            "record_results",
+        ]
+
+    def execute_step(self, step_name: str) -> PhaseStepResult:
+        if self.cavity is None:
+            raise PhaseExecutionError(
+                "Cavity not set — validate_prerequisites must be called first"
+            )
+
+        step_methods = {
+            "verify_initial_state": self._verify_initial_state,
+            "record_cold_landing": self._record_cold_landing,
+            "probe_stepper_direction": self._probe_stepper_direction,
+            "apply_hz_per_step": self._apply_hz_per_step,
+            "tune_to_resonance": self._tune_to_resonance,
+            "measure_pi_modes": self._measure_pi_modes,
+            "record_results": self._record_results,
+        }
+
+        if step_name not in step_methods:
+            return PhaseStepResult(
+                result=PhaseResult.FAILED,
+                message=f"Unknown step: {step_name}",
+            )
+
+        return step_methods[step_name]()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _read_temp(self) -> float:
+        if self._stepper_temp_pv_obj is None:
+            self._stepper_temp_pv_obj = PV(self.cavity.stepper_temp_pv)
+        return self._stepper_temp_pv_obj.get()
+
+    def _write_df_cold(self, detune_hz: float) -> None:
+        if self._df_cold_pv_obj is None:
+            self._df_cold_pv_obj = PV(self.cavity.pv_addr("DF_COLD"))
+        self._df_cold_pv_obj.put(detune_hz)
+
+    def _write_nsteps_cold(self, steps: int) -> None:
+        if self._nsteps_cold_pv_obj is None:
+            self._nsteps_cold_pv_obj = PV(
+                self.cavity.stepper_tuner.steps_cold_landing_pv
+            )
+        self._nsteps_cold_pv_obj.put(steps)
+
+    def _wait_for_motor(self) -> None:
+        """Block until motor_moving is False, checking abort each poll."""
+        time.sleep(self.limits.motor_start_wait)
+        while self.cavity.stepper_tuner.motor_moving:
+            if self.context.is_abort_requested():
+                self.cavity.stepper_tuner.abort()
+                raise PhaseExecutionError("Abort requested during stepper move")
+            time.sleep(self.limits.motor_poll_interval)
+
+    def _check_temp_with_cooldown(self) -> tuple[bool, float, str]:
+        """
+        Read motor temperature and wait for cool-down if over the limit.
+
+        Returns (ok, temp_c, message).
+        """
+        temp = self._read_temp()
+        if temp <= self.limits.temp_limit_c:
+            return True, temp, f"Motor temp {temp:.1f} °C OK"
+
+        for _ in range(self.limits.cool_down_retries):
+            time.sleep(self.limits.cool_down_interval)
+            temp = self._read_temp()
+            if temp <= self.limits.temp_limit_c:
+                return True, temp, f"Motor cooled to {temp:.1f} °C"
+
+        return (
+            False,
+            temp,
+            f"Motor temp {temp:.1f} °C still above limit "
+            f"{self.limits.temp_limit_c} °C after "
+            f"{self.limits.cool_down_retries} retries",
+        )
+
+    # ------------------------------------------------------------------
+    # Step implementations
+    # ------------------------------------------------------------------
+
+    def _verify_initial_state(self) -> PhaseStepResult:
+        if self.context.dry_run:
+            return PhaseStepResult(
+                result=PhaseResult.SUCCESS,
+                message="Dry run: skipping initial state check",
+                data={"dry_run": True},
+            )
+
+        if self.cavity.stepper_tuner.motor_moving:
+            return PhaseStepResult(
+                result=PhaseResult.FAILED,
+                message="Stepper motor already moving — abort or wait for it to stop",
+            )
+
+        if self.cavity.stepper_tuner.on_limit_switch:
+            return PhaseStepResult(
+                result=PhaseResult.FAILED,
+                message="Stepper motor is on a limit switch — manual intervention required",
+            )
+
+        if self.cavity.detune_invalid:
+            return PhaseStepResult(
+                result=PhaseResult.FAILED,
+                message=(
+                    "Chirp detune is invalid — ensure the chirp scan is running "
+                    "and producing a valid CHIRP:DF reading before starting this phase"
+                ),
+            )
+
+        try:
+            temp = self._read_temp()
+            detune = self.cavity.detune_chirp
+        except Exception as exc:
+            return PhaseStepResult(
+                result=PhaseResult.RETRY,
+                message=f"Could not read stepper/detune state: {exc}",
+                retry_delay_seconds=3.0,
+            )
+
+        return PhaseStepResult(
+            result=PhaseResult.SUCCESS,
+            message=f"Stepper idle, chirp valid. Temp {temp:.1f} °C, detune {detune:.0f} Hz",
+            data={"initial_temp_c": temp, "initial_detune_hz": detune},
+        )
+
+    def _record_cold_landing(self) -> PhaseStepResult:
+        if self.context.dry_run:
+            return PhaseStepResult(
+                result=PhaseResult.SUCCESS,
+                message="Dry run: cold landing snapshot simulated",
+                data={
+                    "initial_detune_hz": 0.0,
+                    "initial_timestamp": datetime.now().isoformat(),
+                    "dry_run": True,
+                },
+            )
+
+        try:
+            initial_detune_hz = self.cavity.detune_chirp
+        except Exception as exc:
+            return PhaseStepResult(
+                result=PhaseResult.RETRY,
+                message=f"Could not read cold landing detune: {exc}",
+                retry_delay_seconds=3.0,
+            )
+
+        return PhaseStepResult(
+            result=PhaseResult.SUCCESS,
+            message=f"Cold landing frequency recorded: detune={initial_detune_hz:.0f} Hz. "
+            "Push to DF_COLD when satisfied.",
+            data={
+                "initial_detune_hz": initial_detune_hz,
+                "initial_timestamp": datetime.now().isoformat(),
+            },
+        )
+
+    def _apply_hz_per_step(self) -> PhaseStepResult:
+        """Write the measured Hz/step to the SCALE PV after operator confirmation."""
+        if self.context.dry_run:
+            return PhaseStepResult(
+                result=PhaseResult.SUCCESS,
+                message="Dry run: skipping SCALE PV write",
+                data={"dry_run": True},
+            )
+
+        if self._signed_hz_per_microstep is None:
+            return PhaseStepResult(
+                result=PhaseResult.FAILED,
+                message="Hz/step not measured — probe_stepper_direction must run first",
+            )
+
+        try:
+            self.cavity.stepper_tuner.hz_per_microstep_pv_obj.put(
+                self._signed_hz_per_microstep
+            )
+        except Exception as exc:
+            return PhaseStepResult(
+                result=PhaseResult.RETRY,
+                message=f"Could not write Hz/step to SCALE PV: {exc}",
+                retry_delay_seconds=3.0,
+            )
+
+        return PhaseStepResult(
+            result=PhaseResult.SUCCESS,
+            message=f"Wrote {self._signed_hz_per_microstep:.4f} Hz/step to SCALE PV",
+        )
+
+    def _do_probe_move(
+        self,
+        probe: int,
+        probe_cb,
+        speed: int = linac_utils.DEFAULT_STEPPER_SPEED,
+    ) -> tuple[float, float]:
+        """Execute the forward+back probe move; return (d0_hz, d1_hz)."""
+        self.cavity.stepper_tuner.reset_signed_steps()
+        d0 = self.cavity.detune_chirp
+        try:
+            if probe_cb:
+                probe_cb(0, d0)
+        except Exception:
+            pass
+        self.cavity.stepper_tuner.move(probe, speed=speed, check_detune=False)
+        d1 = self.cavity.detune_chirp
+        try:
+            if probe_cb:
+                probe_cb(probe, d1)
+        except Exception:
+            pass
+        self.cavity.stepper_tuner.move(-probe, speed=speed, check_detune=False)
+        return d0, d1
+
+    def _probe_stepper_direction(self) -> PhaseStepResult:
+        if self.context.dry_run:
+            self._hz_per_microstep = 1.0
+            self._signed_hz_per_microstep = 1.0
+            return PhaseStepResult(
+                result=PhaseResult.SUCCESS,
+                message="Dry run: direction probe simulated",
+                data={
+                    "d0_hz": 0.0,
+                    "d1_hz": 0.0,
+                    "delta_hz": 0.0,
+                    "positive_step_increases_frequency": False,
+                    "hz_per_microstep": 1.0,
+                    "dry_run": True,
+                },
+            )
+
+        probe = self.limits.probe_steps
+        probe_cb = self.context.parameters.get("probe_update_callback")
+        speed = self.limits.move_speed
+
+        try:
+            d0, d1 = self._do_probe_move(probe, probe_cb, speed=speed)
+        except (linac_utils.StepperError, linac_utils.StepperAbortError) as exc:
+            return PhaseStepResult(
+                result=PhaseResult.FAILED,
+                message=f"Stepper error during direction probe: {exc}",
+            )
+        except Exception as exc:
+            return PhaseStepResult(
+                result=PhaseResult.RETRY,
+                message=f"Transient error during direction probe: {exc}",
+                retry_delay_seconds=5.0,
+            )
+
+        delta = d1 - d0
+
+        if abs(delta) < self.limits.min_probe_delta_hz:
+            return PhaseStepResult(
+                result=PhaseResult.FAILED,
+                message=(
+                    f"Probe move of {probe} steps produced only {abs(delta):.1f} Hz change "
+                    f"(minimum {self.limits.min_probe_delta_hz:.1f} Hz required). "
+                    "Check that the stepper is mechanically connected and the cavity is at 2 K."
+                ),
+            )
+
+        # SCALE convention: d(cavity_freq)/d(step).
+        # CHIRP:DF = ref_freq - cav_freq, so d(CHIRP:DF)/d(step) = -SCALE.
+        # Positive SCALE → positive steps increase cavity frequency → CHIRP:DF decreases.
+        signed_hz_per_step = -delta / probe
+        self._hz_per_microstep = abs(signed_hz_per_step)
+        self._signed_hz_per_microstep = signed_hz_per_step
+        positive_step_increases_frequency = signed_hz_per_step > 0
+
+        return PhaseStepResult(
+            result=PhaseResult.SUCCESS,
+            message=(
+                f"Direction probe: Δdetune={delta:+.0f} Hz for +{probe} steps. "
+                f"Measured {self._hz_per_microstep:.4f} Hz/step (confirm to write to SCALE PV). "
+                f"move(+N) "
+                f"{'increases' if positive_step_increases_frequency else 'decreases'} frequency."
+            ),
+            data={
+                "d0_hz": d0,
+                "d1_hz": d1,
+                "s_d0": 0,
+                "s_d1": probe,
+                "delta_hz": delta,
+                "positive_step_increases_frequency": positive_step_increases_frequency,
+                "hz_per_microstep": self._hz_per_microstep,
+                "probe_steps": probe,
+            },
+        )
+
+    def _guard_temp(
+        self, total_steps: int, peak_temp: float
+    ) -> tuple[float, PhaseStepResult | None]:
+        """Check motor temperature and wait for cool-down if needed.
+
+        Returns (updated_peak_temp, error_or_None).
+        """
+        try:
+            ok, temp, msg = self._check_temp_with_cooldown()
+            peak_temp = max(peak_temp, temp)
+        except Exception as exc:
+            return peak_temp, PhaseStepResult(
+                result=PhaseResult.RETRY,
+                message=f"Could not read motor temperature: {exc}",
+                retry_delay_seconds=5.0,
+            )
+        if not ok:
+            return peak_temp, PhaseStepResult(
+                result=PhaseResult.FAILED,
+                message=msg,
+                data={"total_steps": total_steps, "peak_temp_c": peak_temp},
+            )
+        return peak_temp, None
+
+    def _guard_detune(self) -> tuple[float, PhaseStepResult | None]:
+        """Read chirp detune. Returns (detune_hz, error_or_None)."""
+        try:
+            return self.cavity.detune_chirp, None
+        except Exception as exc:
+            return 0.0, PhaseStepResult(
+                result=PhaseResult.RETRY,
+                message=f"Could not read detune: {exc}",
+                retry_delay_seconds=3.0,
+            )
+
+    def _tuning_dry_run_result(self) -> PhaseStepResult:
+        return PhaseStepResult(
+            result=PhaseResult.SUCCESS,
+            message="Dry run: tuning to resonance simulated",
+            data={
+                "total_steps": 0,
+                "final_timestamp": datetime.now().isoformat(),
+                "dry_run": True,
+            },
+        )
+
+    def _initialize_tuning_state(self, tuning_cb) -> tuple[int, int, float]:
+        total_steps = 0
+        peak_temp = 0.0
+
+        # Read the current signed step count rather than resetting it.
+        # REG_TOTSGN was zeroed by the Stage 2 probe, so on the first run
+        # signed_total starts at 0.  After an abort and restart it retains the
+        # displacement already accumulated from cold landing, keeping NSTEPS_COLD
+        # accurate across partial runs.
+        try:
+            if self._step_signed_pv_obj is None:
+                self._step_signed_pv_obj = PV(
+                    self.cavity.stepper_tuner.step_signed_pv
+                )
+            signed_total = int(self._step_signed_pv_obj.get() or 0)
+        except Exception:
+            signed_total = 0
+
+        try:
+            peak_temp = self._read_temp()
+        except Exception:
+            pass
+
+        try:
+            if tuning_cb:
+                tuning_cb(signed_total, self.cavity.detune_chirp)
+        except Exception:
+            pass
+
+        return total_steps, signed_total, peak_temp
+
+    def _emit_tuning_update(self, tuning_cb, signed_total: int) -> None:
+        try:
+            if tuning_cb:
+                tuning_cb(signed_total, self.cavity.detune_chirp)
+        except Exception:
+            pass
+
+    def _write_cold_landing_steps(
+        self, signed_total: int
+    ) -> PhaseStepResult | None:
+        # NSTEPS_COLD stores the return-trip step count (from resonance to cold
+        # landing), which is the negation of the steps we just took.
+        try:
+            self._write_nsteps_cold(-signed_total)
+        except Exception as exc:
+            return PhaseStepResult(
+                result=PhaseResult.RETRY,
+                message=f"Could not write NSTEPS_COLD after tuning: {exc}",
+                retry_delay_seconds=3.0,
+            )
+        return None
+
+    def _one_tuning_iteration(
+        self,
+        total_steps: int,
+        signed_total: int,
+        peak_temp: float,
+        hz_per_step: float,
+        hz_update_cb=None,
+        speed: int = linac_utils.DEFAULT_STEPPER_SPEED,
+    ) -> tuple[int, int, float, bool, PhaseStepResult | None]:
+        """Execute one iteration of the tuning loop.
+
+        Returns (new_total_steps, new_signed_total, new_peak_temp, converged, error_or_None).
+        signed_total accumulates the signed step count for writing to NSTEPS_COLD.
+        """
+        if self.context.is_abort_requested():
+            return (
+                total_steps,
+                signed_total,
+                peak_temp,
+                False,
+                PhaseStepResult(
+                    result=PhaseResult.FAILED,
+                    message=f"Abort requested after {total_steps} steps",
+                ),
+            )
+
+        peak_temp, err = self._guard_temp(total_steps, peak_temp)
+        if err is not None:
+            return total_steps, signed_total, peak_temp, False, err
+
+        detune, err = self._guard_detune()
+        if err is not None:
+            return total_steps, signed_total, peak_temp, False, err
+
+        if abs(detune) <= self.limits.tolerance_hz:
+            return total_steps, signed_total, peak_temp, True, None
+
+        if total_steps >= self.limits.max_total_steps:
+            return (
+                total_steps,
+                signed_total,
+                peak_temp,
+                False,
+                PhaseStepResult(
+                    result=PhaseResult.FAILED,
+                    message=(
+                        f"Reached max step limit ({self.limits.max_total_steps}) "
+                        f"without converging; final detune {detune:.0f} Hz"
+                    ),
+                    data={
+                        "total_steps": total_steps,
+                        "final_detune_hz": detune,
+                        "peak_temp_c": peak_temp,
+                    },
+                ),
+            )
+
+        magnitude, steps_this_move, err = self._do_move(
+            total_steps, peak_temp, detune, hz_per_step, hz_update_cb, speed
+        )
+        if err is not None:
+            return total_steps, signed_total, peak_temp, False, err
+        return (
+            total_steps + magnitude,
+            signed_total + steps_this_move,
+            peak_temp,
+            False,
+            None,
+        )
+
+    def _do_move(
+        self,
+        total_steps: int,
+        peak_temp: float,
+        detune: float,
+        hz_per_step: float,
+        hz_update_cb,
+        speed: int = linac_utils.DEFAULT_STEPPER_SPEED,
+    ) -> tuple[int, int, "PhaseStepResult | None"]:
+        """Compute step size, execute stepper move, and invoke the Hz/step callback."""
+        hardware_max = self.cavity.stepper_tuner.max_steps
+        estimated = max(1, round(abs(detune) / hz_per_step))
+        magnitude = min(hardware_max, estimated)
+        # Direction: steps_to_zero = detune / SCALE, so sign = sign(detune / signed_hz).
+        # This handles motors wired in either direction (positive or negative SCALE).
+        signed_hz = self._signed_hz_per_microstep
+        if signed_hz:
+            steps_this_move = int(math.copysign(magnitude, detune / signed_hz))
+        else:
+            steps_this_move = int(math.copysign(magnitude, detune))
+
+        try:
+            self.cavity.stepper_tuner.move(
+                steps_this_move,
+                max_steps=hardware_max,
+                speed=speed,
+                check_detune=False,
+            )
+        except (linac_utils.StepperError, linac_utils.StepperAbortError) as exc:
+            return (
+                magnitude,
+                steps_this_move,
+                PhaseStepResult(
+                    result=PhaseResult.FAILED,
+                    message=f"Stepper error after {total_steps} steps: {exc}",
+                    data={"total_steps": total_steps, "peak_temp_c": peak_temp},
+                ),
+            )
+
+        if hz_update_cb is not None:
+            try:
+                hz_delta = abs(self.cavity.detune_chirp - detune)
+                if hz_delta > 0:
+                    hz_update_cb(magnitude, hz_delta)
+            except Exception:
+                pass
+
+        return magnitude, steps_this_move, None
+
+    def _tune_to_resonance(self) -> PhaseStepResult:
+        if self.context.dry_run:
+            return self._tuning_dry_run_result()
+
+        hz_per_step = self._hz_per_microstep
+        if not hz_per_step:
+            return PhaseStepResult(
+                result=PhaseResult.FAILED,
+                message="hz_per_microstep not set — probe_stepper_direction must run first",
+            )
+
+        tuning_cb = self.context.parameters.get("tuning_update_callback")
+        hz_update_cb = self.context.parameters.get(
+            "hz_per_step_update_callback"
+        )
+        speed = self.limits.move_speed
+
+        total_steps, signed_total, peak_temp = self._initialize_tuning_state(
+            tuning_cb
+        )
+
+        while True:
+            total_steps, signed_total, peak_temp, converged, err = (
+                self._one_tuning_iteration(
+                    total_steps,
+                    signed_total,
+                    peak_temp,
+                    hz_per_step,
+                    hz_update_cb,
+                    speed,
+                )
+            )
+            if err is not None:
+                return err
+            self._emit_tuning_update(tuning_cb, signed_total)
+            if converged:
+                break
+
+        err = self._write_cold_landing_steps(signed_total)
+        if err is not None:
+            return err
+
+        return PhaseStepResult(
+            result=PhaseResult.SUCCESS,
+            message=(
+                f"Reached resonance in {total_steps} steps. "
+                f"NSTEPS_COLD set to {-signed_total}."
+            ),
+            data={
+                "total_steps": total_steps,
+                "cold_landing_steps": -signed_total,
+                "final_timestamp": datetime.now().isoformat(),
+            },
+        )
+
+    # ------------------------------------------------------------------
+    # Pi-mode scan step
+    # ------------------------------------------------------------------
+
+    def _measure_pi_modes(self) -> PhaseStepResult:
+        """Run the full rack FSCAN sequence for this cavity and read back results.
+
+        Checks rack exclusivity, selects only this cavity, configures and
+        triggers the scan, waits for completion, pushes mode results, and
+        reads back the 8π/9 and 7π/9 frequencies.
+        """
+        if self.context.dry_run:
+            return PhaseStepResult(
+                result=PhaseResult.SUCCESS,
+                message="Dry run: pi mode scan skipped",
+                data={
+                    "mode_8pi_9_hz": 0.0,
+                    "mode_7pi_9_hz": 0.0,
+                    "timestamp": datetime.now().isoformat(),
+                    "dry_run": True,
+                },
+            )
+
+        rack = self.cavity.rack
+
+        err = self._check_rack_exclusivity(rack)
+        if err is not None:
+            return err
+        err = self._select_cavity_for_fscan(rack)
+        if err is not None:
+            return err
+        err = self._configure_fscan_params(rack)
+        if err is not None:
+            return err
+        err = self._trigger_fscan(rack)
+        if err is not None:
+            return err
+
+        status_cb = self.context.parameters.get("status_update_callback")
+        err = self._wait_for_fscan(rack, status_cb)
+        if err is not None:
+            return err
+
+        err = self._push_mode_results()
+        if err is not None:
+            return err
+        return self._read_mode_frequencies()
+
+    def _check_rack_exclusivity(self, rack) -> "PhaseStepResult | None":
+        rack_check = self.context.parameters.get("rack_check_callback")
+        if rack_check is None:
+            return None
+        try:
+            ok, reason = rack_check(rack)
+        except Exception as exc:
+            return PhaseStepResult(
+                result=PhaseResult.RETRY,
+                message=f"Rack check callback raised an exception: {exc}",
+                retry_delay_seconds=5.0,
+            )
+        if not ok:
+            return PhaseStepResult(
+                result=PhaseResult.FAILED,
+                message=(
+                    f"Cannot run FSCAN: another cavity in rack "
+                    f"{rack.rack_name} is being commissioned. {reason}"
+                ),
+            )
+        return None
+
+    def _select_cavity_for_fscan(self, rack) -> "PhaseStepResult | None":
+        for cav_num, cav in rack.cavities.items():
+            selected = 1 if cav_num == self.cavity.number else 0
+            try:
+                PV(cav.pv_addr("FSCAN:SEL")).put(selected)
+            except Exception as exc:
+                return PhaseStepResult(
+                    result=PhaseResult.RETRY,
+                    message=f"Could not write FSCAN:SEL for cavity {cav_num}: {exc}",
+                    retry_delay_seconds=3.0,
+                )
+        return None
+
+    def _configure_fscan_params(self, rack) -> "PhaseStepResult | None":
+        for suffix, value in (
+            ("FSCAN:FREQ_START", self.limits.pi_scan_freq_start),
+            ("FSCAN:FREQ_STOP", self.limits.pi_scan_freq_stop),
+            ("FSCAN:RMS_THRESH", self.limits.pi_scan_rms_thresh),
+            ("FSCAN:MODE_OVERLAP", self.limits.pi_scan_mode_overlap),
+        ):
+            try:
+                PV(rack.pv_prefix + suffix).put(value)
+            except Exception as exc:
+                return PhaseStepResult(
+                    result=PhaseResult.RETRY,
+                    message=f"Could not write {suffix}: {exc}",
+                    retry_delay_seconds=3.0,
+                )
+        return None
+
+    def _trigger_fscan(self, rack) -> "PhaseStepResult | None":
+        try:
+            PV(rack.pv_prefix + "FSCAN:START").put(1)
+        except Exception as exc:
+            return PhaseStepResult(
+                result=PhaseResult.RETRY,
+                message=f"Could not write FSCAN:START: {exc}",
+                retry_delay_seconds=3.0,
+            )
+        return None
+
+    _FSCAN_STATE_NAMES = {
+        0: "Await request",
+        1: "No cav selected",
+        2: "Bad range",
+        3: "Search in progress",
+        4: "Shift mode",
+        5: "Scan done",
+        6: "Scan aborted",
+        7: "Freq restore fail",
+    }
+
+    def _wait_for_fscan(self, rack, status_cb) -> "PhaseStepResult | None":
+        stat_pv = PV(rack.pv_prefix + "FSCAN:STAT")
+        scan_start = time.monotonic()
+        deadline = scan_start + self.limits.pi_scan_timeout_seconds
+        while time.monotonic() < deadline:
+            if self.context.is_abort_requested():
+                return PhaseStepResult(
+                    result=PhaseResult.FAILED,
+                    message="Abort requested while waiting for FSCAN",
+                )
+            try:
+                stat = int(stat_pv.get())
+            except Exception as exc:
+                return PhaseStepResult(
+                    result=PhaseResult.RETRY,
+                    message=f"Could not read FSCAN:STAT: {exc}",
+                    retry_delay_seconds=self.limits.pi_scan_poll_interval,
+                )
+            if stat == _FSCAN_STAT_SCAN_DONE:
+                return None
+            if stat in (
+                _FSCAN_STAT_SCAN_ABORTED,
+                _FSCAN_STAT_FREQ_RESTORE_FAIL,
+            ):
+                name = self._FSCAN_STATE_NAMES.get(stat, str(stat))
+                return PhaseStepResult(
+                    result=PhaseResult.FAILED,
+                    message=f"FSCAN failed: {name} (state {stat})",
+                )
+            if status_cb:
+                elapsed = time.monotonic() - scan_start
+                name = self._FSCAN_STATE_NAMES.get(stat, str(stat))
+                status_cb(f"FSCAN: {name} ({elapsed:.0f}s elapsed)")
+            time.sleep(self.limits.pi_scan_poll_interval)
+        return PhaseStepResult(
+            result=PhaseResult.FAILED,
+            message=f"FSCAN did not complete within {self.limits.pi_scan_timeout_seconds:.0f} s",
+        )
+
+    def _push_mode_results(self) -> "PhaseStepResult | None":
+        for proc_suffix in ("FSCAN:PUSH_8PI9.PROC", "FSCAN:PUSH_7PI9.PROC"):
+            try:
+                PV(self.cavity.pv_addr(proc_suffix)).put(1)
+            except Exception as exc:
+                return PhaseStepResult(
+                    result=PhaseResult.RETRY,
+                    message=f"Could not write {proc_suffix}: {exc}",
+                    retry_delay_seconds=3.0,
+                )
+        return None
+
+    def _read_mode_frequencies(self) -> PhaseStepResult:
+        results: dict = {}
+        for key, suffix in (
+            ("mode_8pi_9_hz", "FSCAN:8PI9MODE"),
+            ("mode_7pi_9_hz", "FSCAN:7PI9MODE"),
+        ):
+            try:
+                results[key] = float(PV(self.cavity.pv_addr(suffix)).get())
+            except Exception as exc:
+                return PhaseStepResult(
+                    result=PhaseResult.RETRY,
+                    message=f"Could not read {suffix}: {exc}",
+                    retry_delay_seconds=3.0,
+                )
+        results["timestamp"] = datetime.now().isoformat()
+        return PhaseStepResult(
+            result=PhaseResult.SUCCESS,
+            message=(
+                f"8π/9 mode: {results['mode_8pi_9_hz']:.0f} Hz, "
+                f"7π/9 mode: {results['mode_7pi_9_hz']:.0f} Hz"
+            ),
+            data=results,
+        )
+
+    def _record_results(self) -> PhaseStepResult:
+        """Placeholder step — actual population happens in finalize_phase()."""
+        return PhaseStepResult(
+            result=PhaseResult.SUCCESS,
+            message="Results collected; ready to finalise",
+        )
+
+    # ------------------------------------------------------------------
+    # Finalization
+    # ------------------------------------------------------------------
+
+    def _get_checkpoint_data(self, step_name: str) -> dict:
+        checkpoint = next(
+            (
+                cp
+                for cp in reversed(
+                    self.context.record.phase_history[self._history_start :]
+                )
+                if cp.phase == self.phase_type and cp.step_name == step_name
+            ),
+            None,
+        )
+        return checkpoint.measurements if checkpoint else {}
+
+    def finalize_phase(self) -> None:
+        cold = self._get_checkpoint_data("record_cold_landing")
+        probe = self._get_checkpoint_data("probe_stepper_direction")
+        tune = self._get_checkpoint_data("tune_to_resonance")
+        pi = self._get_checkpoint_data("measure_pi_modes")
+
+        initial_ts_raw = cold.get("initial_timestamp")
+        initial_ts = (
+            datetime.fromisoformat(initial_ts_raw) if initial_ts_raw else None
+        )
+        final_ts_raw = tune.get("final_timestamp")
+        final_ts = (
+            datetime.fromisoformat(final_ts_raw) if final_ts_raw else None
+        )
+
+        self.context.record.frequency_tuning = FrequencyTuningData(
+            initial_detune_hz=cold.get("initial_detune_hz"),
+            initial_timestamp=initial_ts,
+            steps_to_resonance=tune.get("total_steps"),
+            final_timestamp=final_ts,
+            positive_step_increases_frequency=probe.get(
+                "positive_step_increases_frequency"
+            ),
+            hz_per_microstep=probe.get("hz_per_microstep"),
+            cold_landing_steps=tune.get("cold_landing_steps"),
+            mode_8pi_9_frequency=pi.get("mode_8pi_9_hz"),
+            mode_7pi_9_frequency=pi.get("mode_7pi_9_hz"),
+        )

--- a/src/sc_linac_physics/applications/rf_commissioning/phases/frequency_tuning.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/phases/frequency_tuning.py
@@ -11,8 +11,10 @@ phase:
   3. Runs a probe move to measure Hz/microstep; the operator confirms and the UI
      writes the value (to SCALE_CALC.B) via apply_hz_per_step.
   4. Gates on DF_COLD having been recorded, then moves to resonance in small
-     chunks, checking motor temperature before each chunk and pausing if the
-     temperature exceeds the limit.  After converging, writes the (signed)
+     chunks, checking motor temperature before each chunk.  There is no
+     automatic cool-down: if the temperature exceeds the limit the step fails
+     and the operator must investigate and re-run with an explicit
+     acknowledgement (over_temp_ack_c).  After converging, writes the (signed)
      return-trip step count to the NSTEPS_COLD PV and sets tune_config to
      RESONANCE.
   5. Runs a single-cavity FSCAN to find the 8π/9 and 7π/9 parasitic modes and
@@ -53,8 +55,6 @@ class FrequencyTuningLimits:
     move_speed: int = linac_utils.DEFAULT_STEPPER_SPEED
     temp_limit_c: float = linac_utils.STEPPER_TEMP_LIMIT
     max_total_steps: int = 10_000_000
-    cool_down_retries: int = 6
-    cool_down_interval: float = 5.0
     min_probe_delta_hz: float = 10.0
     pi_scan_freq_start: int = -3_500_000
     pi_scan_freq_stop: int = 50_000
@@ -89,6 +89,9 @@ class FrequencyTuningPhase(PhaseBase):
         self._step_signed_pv_obj: PV | None = None
         # Signed: positive means +steps increase cavity frequency (matches SCALE PV convention)
         self._hz_per_microstep: float | None = None
+        # Over-temperature breaches the operator acknowledged this run:
+        # list of (temp_c, operator) tuples.
+        self._over_temp_acks: list[tuple[float, str]] = []
 
     @property
     def phase_type(self) -> CommissioningPhase:
@@ -204,30 +207,6 @@ class FrequencyTuningPhase(PhaseBase):
                 self.cavity.stepper_tuner.steps_cold_landing_pv
             )
         self._nsteps_cold_pv_obj.put(steps)
-
-    def _check_temp_with_cooldown(self) -> tuple[bool, float, str]:
-        """
-        Read motor temperature and wait for cool-down if over the limit.
-
-        Returns (ok, temp_c, message).
-        """
-        temp = self._read_temp()
-        if temp <= self.limits.temp_limit_c:
-            return True, temp, f"Motor temp {temp:.1f} °C OK"
-
-        for _ in range(self.limits.cool_down_retries):
-            time.sleep(self.limits.cool_down_interval)
-            temp = self._read_temp()
-            if temp <= self.limits.temp_limit_c:
-                return True, temp, f"Motor cooled to {temp:.1f} °C"
-
-        return (
-            False,
-            temp,
-            f"Motor temp {temp:.1f} °C still above limit "
-            f"{self.limits.temp_limit_c} °C after "
-            f"{self.limits.cool_down_retries} retries",
-        )
 
     # ------------------------------------------------------------------
     # Step implementations
@@ -475,26 +454,51 @@ class FrequencyTuningPhase(PhaseBase):
     def _guard_temp(
         self, total_steps: int, peak_temp: float
     ) -> tuple[float, PhaseStepResult | None]:
-        """Check motor temperature and wait for cool-down if needed.
+        """Check motor temperature; fail on over-temp unless acknowledged.
+
+        There is no automatic cool-down.  If the motor exceeds the limit the
+        step fails and the operator must investigate and re-run, passing
+        ``over_temp_ack_c`` (a temperature ceiling they authorize) via
+        context.parameters.  A reading hotter than that ceiling re-arms the
+        gate and requires a fresh acknowledgement.
 
         Returns (updated_peak_temp, error_or_None).
         """
         try:
-            ok, temp, msg = self._check_temp_with_cooldown()
-            peak_temp = max(peak_temp, temp)
+            temp = self._read_temp()
         except Exception as exc:
             return peak_temp, PhaseStepResult(
                 result=PhaseResult.RETRY,
                 message=f"Could not read motor temperature: {exc}",
                 retry_delay_seconds=5.0,
             )
-        if not ok:
-            return peak_temp, PhaseStepResult(
-                result=PhaseResult.FAILED,
-                message=msg,
-                data={"total_steps": total_steps, "peak_temp_c": peak_temp},
-            )
-        return peak_temp, None
+        peak_temp = max(peak_temp, temp)
+
+        if temp <= self.limits.temp_limit_c:
+            return peak_temp, None
+
+        ack_ceiling = self.context.parameters.get("over_temp_ack_c")
+        if ack_ceiling is not None and temp <= ack_ceiling:
+            # Operator acknowledged proceeding up to this temperature.
+            self._over_temp_acks.append((temp, self.context.operator))
+            return peak_temp, None
+
+        return peak_temp, PhaseStepResult(
+            result=PhaseResult.FAILED,
+            message=(
+                f"Stepper motor temp {temp:.1f} °C exceeds limit "
+                f"{self.limits.temp_limit_c} °C after {total_steps} steps. "
+                "Investigate; to proceed, acknowledge and re-run with "
+                f"over_temp_ack_c ≥ {temp:.1f}."
+            ),
+            data={
+                "total_steps": total_steps,
+                "peak_temp_c": peak_temp,
+                "stepper_temp_c": temp,
+                "temp_limit_c": self.limits.temp_limit_c,
+                "requires_over_temp_ack": True,
+            },
+        )
 
     def _guard_detune(self) -> tuple[float, PhaseStepResult | None]:
         """Read chirp detune. Returns (detune_hz, error_or_None)."""
@@ -755,17 +759,29 @@ class FrequencyTuningPhase(PhaseBase):
         if err is not None:
             return err
 
+        return self._tuning_success_result(total_steps, signed_total)
+
+    def _tuning_success_result(
+        self, total_steps: int, signed_total: int
+    ) -> PhaseStepResult:
+        data = {
+            "total_steps": total_steps,
+            "cold_landing_steps": -signed_total,
+            "final_timestamp": datetime.now().isoformat(),
+        }
+        if self._over_temp_acks:
+            data["over_temp_acknowledged_c"] = max(
+                t for t, _ in self._over_temp_acks
+            )
+            data["over_temp_acknowledged_by"] = self.context.operator
+
         return PhaseStepResult(
             result=PhaseResult.SUCCESS,
             message=(
                 f"Reached resonance in {total_steps} steps. "
                 f"NSTEPS_COLD set to {-signed_total}. tune_config set to RESONANCE."
             ),
-            data={
-                "total_steps": total_steps,
-                "cold_landing_steps": -signed_total,
-                "final_timestamp": datetime.now().isoformat(),
-            },
+            data=data,
         )
 
     def _write_tune_config_resonance(self) -> "PhaseStepResult | None":

--- a/src/sc_linac_physics/applications/rf_commissioning/phases/frequency_tuning.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/phases/frequency_tuning.py
@@ -85,8 +85,8 @@ class FrequencyTuningPhase(PhaseBase):
         self._df_cold_pv_obj: PV | None = None
         self._nsteps_cold_pv_obj: PV | None = None
         self._step_signed_pv_obj: PV | None = None
+        # Signed: positive means +steps increase cavity frequency (matches SCALE PV convention)
         self._hz_per_microstep: float | None = None
-        self._signed_hz_per_microstep: float | None = None
 
     @property
     def phase_type(self) -> CommissioningPhase:
@@ -284,7 +284,7 @@ class FrequencyTuningPhase(PhaseBase):
                 data={"dry_run": True},
             )
 
-        if self._signed_hz_per_microstep is None:
+        if self._hz_per_microstep is None:
             return PhaseStepResult(
                 result=PhaseResult.FAILED,
                 message="Hz/step not measured — probe_stepper_direction must run first",
@@ -292,7 +292,7 @@ class FrequencyTuningPhase(PhaseBase):
 
         try:
             self.cavity.stepper_tuner.hz_per_microstep_pv_obj.put(
-                self._signed_hz_per_microstep
+                self._hz_per_microstep
             )
         except Exception as exc:
             return PhaseStepResult(
@@ -303,7 +303,7 @@ class FrequencyTuningPhase(PhaseBase):
 
         return PhaseStepResult(
             result=PhaseResult.SUCCESS,
-            message=f"Wrote {self._signed_hz_per_microstep:.4f} Hz/step to SCALE PV",
+            message=f"Wrote {self._hz_per_microstep:.4f} Hz/step to SCALE PV",
         )
 
     def _do_probe_move(
@@ -333,7 +333,6 @@ class FrequencyTuningPhase(PhaseBase):
     def _probe_stepper_direction(self) -> PhaseStepResult:
         if self.context.dry_run:
             self._hz_per_microstep = 1.0
-            self._signed_hz_per_microstep = 1.0
             return PhaseStepResult(
                 result=PhaseResult.SUCCESS,
                 message="Dry run: direction probe simulated",
@@ -341,7 +340,6 @@ class FrequencyTuningPhase(PhaseBase):
                     "d0_hz": 0.0,
                     "d1_hz": 0.0,
                     "delta_hz": 0.0,
-                    "positive_step_increases_frequency": False,
                     "hz_per_microstep": 1.0,
                     "dry_run": True,
                 },
@@ -381,17 +379,15 @@ class FrequencyTuningPhase(PhaseBase):
         # CHIRP:DF = ref_freq - cav_freq, so d(CHIRP:DF)/d(step) = -SCALE.
         # Positive SCALE → positive steps increase cavity frequency → CHIRP:DF decreases.
         signed_hz_per_step = -delta / probe
-        self._hz_per_microstep = abs(signed_hz_per_step)
-        self._signed_hz_per_microstep = signed_hz_per_step
-        positive_step_increases_frequency = signed_hz_per_step > 0
+        self._hz_per_microstep = signed_hz_per_step
 
         return PhaseStepResult(
             result=PhaseResult.SUCCESS,
             message=(
                 f"Direction probe: Δdetune={delta:+.0f} Hz for +{probe} steps. "
-                f"Measured {self._hz_per_microstep:.4f} Hz/step (confirm to write to SCALE PV). "
+                f"Measured {abs(self._hz_per_microstep):.4f} Hz/step (confirm to write to SCALE PV). "
                 f"move(+N) "
-                f"{'increases' if positive_step_increases_frequency else 'decreases'} frequency."
+                f"{'increases' if signed_hz_per_step > 0 else 'decreases'} frequency."
             ),
             data={
                 "d0_hz": d0,
@@ -399,7 +395,6 @@ class FrequencyTuningPhase(PhaseBase):
                 "s_d0": 0,
                 "s_d1": probe,
                 "delta_hz": delta,
-                "positive_step_increases_frequency": positive_step_increases_frequency,
                 "hz_per_microstep": self._hz_per_microstep,
                 "probe_steps": probe,
             },
@@ -585,11 +580,11 @@ class FrequencyTuningPhase(PhaseBase):
     ) -> tuple[int, int, "PhaseStepResult | None"]:
         """Compute step size, execute stepper move, and invoke the Hz/step callback."""
         hardware_max = self.cavity.stepper_tuner.max_steps
-        estimated = max(1, round(abs(detune) / hz_per_step))
+        estimated = max(1, round(abs(detune) / abs(hz_per_step)))
         magnitude = min(hardware_max, estimated)
         # Direction: steps_to_zero = detune / SCALE, so sign = sign(detune / signed_hz).
         # This handles motors wired in either direction (positive or negative SCALE).
-        signed_hz = self._signed_hz_per_microstep
+        signed_hz = self._hz_per_microstep
         if signed_hz:
             steps_this_move = int(math.copysign(magnitude, detune / signed_hz))
         else:
@@ -919,9 +914,6 @@ class FrequencyTuningPhase(PhaseBase):
             initial_timestamp=initial_ts,
             steps_to_resonance=tune.get("total_steps"),
             final_timestamp=final_ts,
-            positive_step_increases_frequency=probe.get(
-                "positive_step_increases_frequency"
-            ),
             hz_per_microstep=probe.get("hz_per_microstep"),
             cold_landing_steps=tune.get("cold_landing_steps"),
             mode_8pi_9_frequency=pi.get("mode_8pi_9_hz"),

--- a/src/sc_linac_physics/applications/rf_commissioning/phases/frequency_tuning.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/phases/frequency_tuning.py
@@ -89,8 +89,6 @@ class FrequencyTuningPhase(PhaseBase):
         self.cavity = None
         self._stepper_temp_pv_obj: PV | None = None
         self._df_cold_pv_obj: PV | None = None
-        self._nsteps_cold_pv_obj: PV | None = None
-        self._step_signed_pv_obj: PV | None = None
         # Signed: positive means +steps increase cavity frequency (matches SCALE PV convention)
         self._hz_per_microstep: float | None = None
         # Over-temperature breaches the operator acknowledged this run:
@@ -206,11 +204,7 @@ class FrequencyTuningPhase(PhaseBase):
         return None
 
     def _write_nsteps_cold(self, steps: int) -> None:
-        if self._nsteps_cold_pv_obj is None:
-            self._nsteps_cold_pv_obj = PV(
-                self.cavity.stepper_tuner.steps_cold_landing_pv
-            )
-        self._nsteps_cold_pv_obj.put(steps)
+        self.cavity.stepper_tuner.steps_cold_landing_pv_obj.put(steps)
 
     # ------------------------------------------------------------------
     # Step implementations
@@ -540,11 +534,9 @@ class FrequencyTuningPhase(PhaseBase):
         # 0 — that would silently corrupt the NSTEPS_COLD return trip — so we
         # surface a RETRY instead.
         try:
-            if self._step_signed_pv_obj is None:
-                self._step_signed_pv_obj = PV(
-                    self.cavity.stepper_tuner.step_signed_pv
-                )
-            signed_total = round(self._step_signed_pv_obj.get() or 0)
+            signed_total = round(
+                self.cavity.stepper_tuner.step_signed_pv_obj.get() or 0
+            )
         except Exception as exc:
             return (
                 total_steps,

--- a/src/sc_linac_physics/applications/rf_commissioning/phases/frequency_tuning.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/phases/frequency_tuning.py
@@ -54,7 +54,9 @@ class FrequencyTuningLimits:
 
     tolerance_hz: float = 50.0
     probe_steps: int = 50_000
-    move_speed: int = linac_utils.DEFAULT_STEPPER_SPEED
+    # Run commissioning moves at max speed; StepperTuner.move() restores the
+    # speed to DEFAULT_STEPPER_SPEED via restore_defaults() after each move.
+    move_speed: int = linac_utils.MAX_STEPPER_SPEED
     temp_limit_c: float = linac_utils.STEPPER_TEMP_LIMIT
     max_total_steps: int = 10_000_000
     # A healthy probe move (probe_steps microsteps at ~0.005 Hz/microstep)

--- a/src/sc_linac_physics/applications/rf_commissioning/phases/frequency_tuning.py
+++ b/src/sc_linac_physics/applications/rf_commissioning/phases/frequency_tuning.py
@@ -87,8 +87,6 @@ class FrequencyTuningPhase(PhaseBase):
         self.limits = limits or FrequencyTuningLimits()
         self._history_start = len(context.record.phase_history)
         self.cavity = None
-        self._stepper_temp_pv_obj: PV | None = None
-        self._df_cold_pv_obj: PV | None = None
         # Signed: positive means +steps increase cavity frequency (matches SCALE PV convention)
         self._hz_per_microstep: float | None = None
         # Over-temperature breaches the operator acknowledged this run:
@@ -153,16 +151,12 @@ class FrequencyTuningPhase(PhaseBase):
     # ------------------------------------------------------------------
 
     def _read_temp(self) -> float:
-        if self._stepper_temp_pv_obj is None:
-            self._stepper_temp_pv_obj = PV(self.cavity.stepper_temp_pv)
-        return self._stepper_temp_pv_obj.get()
+        return self.cavity.stepper_temp_pv_obj.get()
 
     def _read_df_cold(self) -> float:
         # DF_COLD is written by the operator via the UI after reviewing the
         # cold-landing frequency; the backend reads it back to gate tuning.
-        if self._df_cold_pv_obj is None:
-            self._df_cold_pv_obj = PV(self.cavity.pv_addr("DF_COLD"))
-        return self._df_cold_pv_obj.get()
+        return self.cavity.df_cold_pv_obj.get()
 
     _DF_COLD_MATCH_TOLERANCE_HZ = 1.0
 

--- a/src/sc_linac_physics/applications/tuning/tune_cavity.py
+++ b/src/sc_linac_physics/applications/tuning/tune_cavity.py
@@ -35,8 +35,6 @@ class TuneCavity(Cavity, ColdLinacObject):
             30000 if self.cryomodule.is_harmonic_linearizer else 10000
         )
 
-        self.df_cold_pv: str = self.pv_addr("DF_COLD")
-        self._df_cold_pv_obj: Optional[PV] = None
         self.use_rf_pv: str = self.auto_pv_addr("USE_RF")
         self._use_rf_pv_obj: Optional[PV] = None
 
@@ -73,12 +71,6 @@ class TuneCavity(Cavity, ColdLinacObject):
         if not self._hw_mode_pv_obj:
             self._hw_mode_pv_obj = PV(self.hw_mode_pv)
         return self._hw_mode_pv_obj.get(as_string=True)
-
-    @property
-    def df_cold_pv_obj(self) -> PV:
-        if not self._df_cold_pv_obj:
-            self._df_cold_pv_obj = PV(self.df_cold_pv)
-        return self._df_cold_pv_obj
 
     def park(self, reset_stepper_count: bool = True):
         if self.tune_config_pv_obj.get() == TUNE_CONFIG_PARKED_VALUE:

--- a/src/sc_linac_physics/applications/tuning/tune_stepper.py
+++ b/src/sc_linac_physics/applications/tuning/tune_stepper.py
@@ -14,12 +14,6 @@ class TuneStepper(StepperTuner):
         self.nsteps_park_pv: str = self.pv_addr("NSTEPS_PARK")
         self._nsteps_park_pv_obj: PV = None
 
-        self.nsteps_cold_pv: str = self.pv_addr("NSTEPS_COLD")
-        self._nsteps_cold_pv_obj: PV = None
-
-        self._step_signed_pv_obj: PV = None
-        self._steps_cold_landing_pv_obj: PV = None
-
         self._park_steps = None
 
     @property
@@ -29,31 +23,13 @@ class TuneStepper(StepperTuner):
         return self._park_steps
 
     @property
-    def steps_cold_landing_pv_obj(self) -> PV:
-        if not self._steps_cold_landing_pv_obj:
-            self._steps_cold_landing_pv_obj = PV(self.steps_cold_landing_pv)
-        return self._steps_cold_landing_pv_obj
-
-    @property
     def nsteps_park_pv_obj(self) -> PV:
         if not self._nsteps_park_pv_obj:
             self._nsteps_park_pv_obj = PV(self.nsteps_park_pv)
         return self._nsteps_park_pv_obj
 
-    @property
-    def nsteps_cold_pv_obj(self) -> PV:
-        if not self._nsteps_cold_pv_obj:
-            self._nsteps_cold_pv_obj = PV(self.nsteps_cold_pv)
-        return self._nsteps_cold_pv_obj
-
-    @property
-    def step_signed_pv_obj(self):
-        if not self._step_signed_pv_obj:
-            self._step_signed_pv_obj = PV(self.step_signed_pv)
-        return self._step_signed_pv_obj
-
     def move_to_cold_landing(self, check_detune: bool = False):
-        steps = self.nsteps_cold_pv_obj.get()
+        steps = self.steps_cold_landing_pv_obj.get()
         self.cavity.set_status_message(
             "Moving stepper to cold landing",
             logging.INFO,

--- a/src/sc_linac_physics/utils/sc_linac/cavity.py
+++ b/src/sc_linac_physics/utils/sc_linac/cavity.py
@@ -159,6 +159,10 @@ class Cavity(linac_utils.SCLinacObject):
         self.cav_waveform_pv: str = self.pv_addr("CAV:AWF")
 
         self.stepper_temp_pv: str = self.pv_addr("STEPTEMP")
+        self._stepper_temp_pv_obj: Optional[PV] = None
+
+        self.df_cold_pv: str = self.pv_addr("DF_COLD")
+        self._df_cold_pv_obj: Optional[PV] = None
 
         self.detune_best_pv: str = self.pv_addr("DFBEST")
         self._detune_best_pv_obj: Optional[PV] = None
@@ -741,6 +745,18 @@ class Cavity(linac_utils.SCLinacObject):
         if not self._detune_chirp_pv_obj:
             self._detune_chirp_pv_obj = PV(self.detune_chirp_pv)
         return self._detune_chirp_pv_obj
+
+    @property
+    def stepper_temp_pv_obj(self) -> PV:
+        if not self._stepper_temp_pv_obj:
+            self._stepper_temp_pv_obj = PV(self.stepper_temp_pv)
+        return self._stepper_temp_pv_obj
+
+    @property
+    def df_cold_pv_obj(self) -> PV:
+        if not self._df_cold_pv_obj:
+            self._df_cold_pv_obj = PV(self.df_cold_pv)
+        return self._df_cold_pv_obj
 
     @property
     def detune_best(self):

--- a/src/sc_linac_physics/utils/sc_linac/cavity.py
+++ b/src/sc_linac_physics/utils/sc_linac/cavity.py
@@ -164,6 +164,18 @@ class Cavity(linac_utils.SCLinacObject):
         self.df_cold_pv: str = self.pv_addr("DF_COLD")
         self._df_cold_pv_obj: Optional[PV] = None
 
+        # FSCAN (π-mode scan) cavity-level PVs.
+        self.fscan_sel_pv: str = self.pv_addr("FSCAN:SEL")
+        self._fscan_sel_pv_obj: Optional[PV] = None
+        self.fscan_8pi9_mode_pv: str = self.pv_addr("FSCAN:8PI9MODE")
+        self._fscan_8pi9_mode_pv_obj: Optional[PV] = None
+        self.fscan_7pi9_mode_pv: str = self.pv_addr("FSCAN:7PI9MODE")
+        self._fscan_7pi9_mode_pv_obj: Optional[PV] = None
+        self.fscan_push_8pi9_pv: str = self.pv_addr("FSCAN:PUSH_8PI9.PROC")
+        self._fscan_push_8pi9_pv_obj: Optional[PV] = None
+        self.fscan_push_7pi9_pv: str = self.pv_addr("FSCAN:PUSH_7PI9.PROC")
+        self._fscan_push_7pi9_pv_obj: Optional[PV] = None
+
         self.detune_best_pv: str = self.pv_addr("DFBEST")
         self._detune_best_pv_obj: Optional[PV] = None
 
@@ -757,6 +769,36 @@ class Cavity(linac_utils.SCLinacObject):
         if not self._df_cold_pv_obj:
             self._df_cold_pv_obj = PV(self.df_cold_pv)
         return self._df_cold_pv_obj
+
+    @property
+    def fscan_sel_pv_obj(self) -> PV:
+        if not self._fscan_sel_pv_obj:
+            self._fscan_sel_pv_obj = PV(self.fscan_sel_pv)
+        return self._fscan_sel_pv_obj
+
+    @property
+    def fscan_8pi9_mode_pv_obj(self) -> PV:
+        if not self._fscan_8pi9_mode_pv_obj:
+            self._fscan_8pi9_mode_pv_obj = PV(self.fscan_8pi9_mode_pv)
+        return self._fscan_8pi9_mode_pv_obj
+
+    @property
+    def fscan_7pi9_mode_pv_obj(self) -> PV:
+        if not self._fscan_7pi9_mode_pv_obj:
+            self._fscan_7pi9_mode_pv_obj = PV(self.fscan_7pi9_mode_pv)
+        return self._fscan_7pi9_mode_pv_obj
+
+    @property
+    def fscan_push_8pi9_pv_obj(self) -> PV:
+        if not self._fscan_push_8pi9_pv_obj:
+            self._fscan_push_8pi9_pv_obj = PV(self.fscan_push_8pi9_pv)
+        return self._fscan_push_8pi9_pv_obj
+
+    @property
+    def fscan_push_7pi9_pv_obj(self) -> PV:
+        if not self._fscan_push_7pi9_pv_obj:
+            self._fscan_push_7pi9_pv_obj = PV(self.fscan_push_7pi9_pv)
+        return self._fscan_push_7pi9_pv_obj
 
     @property
     def detune_best(self):

--- a/src/sc_linac_physics/utils/sc_linac/cavity.py
+++ b/src/sc_linac_physics/utils/sc_linac/cavity.py
@@ -785,6 +785,8 @@ class Cavity(linac_utils.SCLinacObject):
         delta_hz_func: Callable,
         tolerance: int = 50,
         reset_signed_steps: bool = False,
+        iteration_callback: Optional[Callable[[], None]] = None,
+        max_stepper_temp: Optional[float] = None,
     ):
         if self.detune_invalid:
             raise linac_utils.DetuneError(f"{self} detune invalid")
@@ -803,6 +805,21 @@ class Cavity(linac_utils.SCLinacObject):
 
         while abs(delta_hz) > tolerance:
             self.check_abort()
+
+            # Optional stepper motor temperature guard (no automatic cool-down;
+            # callers that pass a limit get a hard failure on breach).
+            if max_stepper_temp is not None:
+                temp = self.stepper_temp_pv_obj.get()
+                if temp > max_stepper_temp:
+                    raise linac_utils.StepperTempError(
+                        f"{self} stepper motor temp {temp:.1f} °C exceeds "
+                        f"limit {max_stepper_temp} °C"
+                    )
+
+            # Optional per-iteration hook (e.g. progress/telemetry).
+            if iteration_callback is not None:
+                iteration_callback()
+
             est_steps = int(0.9 * delta_hz * self.microsteps_per_hz)
 
             self.set_status_message(

--- a/src/sc_linac_physics/utils/sc_linac/cavity.py
+++ b/src/sc_linac_physics/utils/sc_linac/cavity.py
@@ -848,8 +848,11 @@ class Cavity(linac_utils.SCLinacObject):
         while abs(delta_hz) > tolerance:
             self.check_abort()
 
-            # Optional stepper motor temperature guard (no automatic cool-down;
-            # callers that pass a limit get a hard failure on breach).
+            # Optional stepper motor temperature guard: if a limit is passed
+            # and the stepper exceeds it, raise immediately and stop tuning
+            # rather than waiting/retrying — there is no automatic cool-down
+            # or wait-and-retry logic here, so the caller must intervene
+            # (e.g. pause and let the stepper cool) and re-run tuning.
             if max_stepper_temp is not None:
                 temp = self.stepper_temp_pv_obj.get()
                 if temp > max_stepper_temp:

--- a/src/sc_linac_physics/utils/sc_linac/linac_utils.py
+++ b/src/sc_linac_physics/utils/sc_linac/linac_utils.py
@@ -278,6 +278,12 @@ class StepperTempError(StepperError):
     pass
 
 
+class FSCANError(Exception):
+    """Exception thrown when a rack FSCAN scan fails or times out."""
+
+    pass
+
+
 class SSACalibrationError(Exception):
     """
     Exception thrown during cavity SSA calibration

--- a/src/sc_linac_physics/utils/sc_linac/linac_utils.py
+++ b/src/sc_linac_physics/utils/sc_linac/linac_utils.py
@@ -272,6 +272,12 @@ class StepperError(Exception):
     pass
 
 
+class StepperTempError(StepperError):
+    """Exception thrown when the stepper motor exceeds its temperature limit."""
+
+    pass
+
+
 class SSACalibrationError(Exception):
     """
     Exception thrown during cavity SSA calibration

--- a/src/sc_linac_physics/utils/sc_linac/rack.py
+++ b/src/sc_linac_physics/utils/sc_linac/rack.py
@@ -1,11 +1,28 @@
-from typing import Type, Dict, TYPE_CHECKING
+import time
+from typing import Type, Dict, Iterable, Optional, TYPE_CHECKING
 
+from sc_linac_physics.utils.epics import PV
+from sc_linac_physics.utils.sc_linac import linac_utils
 from sc_linac_physics.utils.sc_linac.linac_utils import SCLinacObject
 from sc_linac_physics.utils.sc_linac.rfstation import RFStation
 
 if TYPE_CHECKING:
     from cavity import Cavity
     from cryomodule import Cryomodule
+
+_FSCAN_STAT_SCAN_DONE = 5
+_FSCAN_STAT_SCAN_ABORTED = 6
+_FSCAN_STAT_FREQ_RESTORE_FAIL = 7
+_FSCAN_STATE_NAMES = {
+    0: "Await request",
+    1: "No cav selected",
+    2: "Bad range",
+    3: "Search in progress",
+    4: "Shift mode",
+    5: "Scan done",
+    6: "Scan aborted",
+    7: "Freq restore fail",
+}
 
 
 class Rack(SCLinacObject):
@@ -42,6 +59,20 @@ class Rack(SCLinacObject):
         self.rfs1 = RFStation(num=1, rack_object=self)
         self.rfs2 = RFStation(num=2, rack_object=self)
 
+        # FSCAN (π-mode scan) rack-level PVs.
+        self.fscan_freq_start_pv: str = self.pv_addr("FSCAN:FREQ_START")
+        self._fscan_freq_start_pv_obj: Optional[PV] = None
+        self.fscan_freq_stop_pv: str = self.pv_addr("FSCAN:FREQ_STOP")
+        self._fscan_freq_stop_pv_obj: Optional[PV] = None
+        self.fscan_rms_thresh_pv: str = self.pv_addr("FSCAN:RMS_THRESH")
+        self._fscan_rms_thresh_pv_obj: Optional[PV] = None
+        self.fscan_mode_overlap_pv: str = self.pv_addr("FSCAN:MODE_OVERLAP")
+        self._fscan_mode_overlap_pv_obj: Optional[PV] = None
+        self.fscan_start_pv: str = self.pv_addr("FSCAN:START")
+        self._fscan_start_pv_obj: Optional[PV] = None
+        self.fscan_stat_pv: str = self.pv_addr("FSCAN:STAT")
+        self._fscan_stat_pv_obj: Optional[PV] = None
+
         if rack_name == "A":
             # rack A always has cavities 1 - 4
             for cavityNum in range(1, 5):
@@ -62,6 +93,116 @@ class Rack(SCLinacObject):
     @property
     def pv_prefix(self):
         return self._pv_prefix
+
+    @property
+    def fscan_freq_start_pv_obj(self) -> PV:
+        if not self._fscan_freq_start_pv_obj:
+            self._fscan_freq_start_pv_obj = PV(self.fscan_freq_start_pv)
+        return self._fscan_freq_start_pv_obj
+
+    @property
+    def fscan_freq_stop_pv_obj(self) -> PV:
+        if not self._fscan_freq_stop_pv_obj:
+            self._fscan_freq_stop_pv_obj = PV(self.fscan_freq_stop_pv)
+        return self._fscan_freq_stop_pv_obj
+
+    @property
+    def fscan_rms_thresh_pv_obj(self) -> PV:
+        if not self._fscan_rms_thresh_pv_obj:
+            self._fscan_rms_thresh_pv_obj = PV(self.fscan_rms_thresh_pv)
+        return self._fscan_rms_thresh_pv_obj
+
+    @property
+    def fscan_mode_overlap_pv_obj(self) -> PV:
+        if not self._fscan_mode_overlap_pv_obj:
+            self._fscan_mode_overlap_pv_obj = PV(self.fscan_mode_overlap_pv)
+        return self._fscan_mode_overlap_pv_obj
+
+    @property
+    def fscan_start_pv_obj(self) -> PV:
+        if not self._fscan_start_pv_obj:
+            self._fscan_start_pv_obj = PV(self.fscan_start_pv)
+        return self._fscan_start_pv_obj
+
+    @property
+    def fscan_stat_pv_obj(self) -> PV:
+        if not self._fscan_stat_pv_obj:
+            self._fscan_stat_pv_obj = PV(self.fscan_stat_pv)
+        return self._fscan_stat_pv_obj
+
+    def run_fscan(
+        self,
+        cavities: "Iterable[Cavity]",
+        *,
+        freq_start: int,
+        freq_stop: int,
+        rms_thresh: float,
+        mode_overlap: int,
+        poll_interval: float = 2.0,
+        timeout_seconds: float = 300.0,
+        status_callback=None,
+        should_abort=None,
+    ) -> None:
+        """Configure and run an FSCAN on this rack over ``cavities``.
+
+        ``cavities`` is any combination of this rack's cavities to scan.
+        Selects exactly those (FSCAN:SEL), writes the scan parameters,
+        triggers the scan, polls FSCAN:STAT to completion, then pushes each
+        selected cavity's π-mode results.
+
+        Raises FSCANError on scan failure or timeout, and CavityAbortError if
+        ``should_abort`` returns True while polling.  Callers read the mode
+        frequencies off each cavity afterwards.
+        """
+        cavities = list(cavities)
+        selected_nums = {cav.number for cav in cavities}
+        for num, cav in self.cavities.items():
+            cav.fscan_sel_pv_obj.put(1 if num in selected_nums else 0)
+
+        self.fscan_freq_start_pv_obj.put(freq_start)
+        self.fscan_freq_stop_pv_obj.put(freq_stop)
+        self.fscan_rms_thresh_pv_obj.put(rms_thresh)
+        self.fscan_mode_overlap_pv_obj.put(mode_overlap)
+        self.fscan_start_pv_obj.put(1)
+
+        self._poll_fscan(
+            poll_interval, timeout_seconds, status_callback, should_abort
+        )
+
+        for cav in cavities:
+            cav.fscan_push_8pi9_pv_obj.put(1)
+            cav.fscan_push_7pi9_pv_obj.put(1)
+
+    def _poll_fscan(
+        self, poll_interval, timeout_seconds, status_callback, should_abort
+    ) -> None:
+        """Poll FSCAN:STAT until done; raise on failure/timeout/abort."""
+        scan_start = time.monotonic()
+        deadline = scan_start + timeout_seconds
+        while time.monotonic() < deadline:
+            if should_abort is not None and should_abort():
+                raise linac_utils.CavityAbortError(
+                    f"Abort requested while waiting for {self} FSCAN"
+                )
+            stat = int(self.fscan_stat_pv_obj.get())
+            if stat == _FSCAN_STAT_SCAN_DONE:
+                return
+            if stat in (
+                _FSCAN_STAT_SCAN_ABORTED,
+                _FSCAN_STAT_FREQ_RESTORE_FAIL,
+            ):
+                name = _FSCAN_STATE_NAMES.get(stat, str(stat))
+                raise linac_utils.FSCANError(
+                    f"{self} FSCAN failed: {name} (state {stat})"
+                )
+            if status_callback is not None:
+                elapsed = time.monotonic() - scan_start
+                name = _FSCAN_STATE_NAMES.get(stat, str(stat))
+                status_callback(f"FSCAN: {name} ({elapsed:.0f}s elapsed)")
+            time.sleep(poll_interval)
+        raise linac_utils.FSCANError(
+            f"{self} FSCAN did not complete within {timeout_seconds:.0f} s"
+        )
 
     def __str__(self):
         return f"{self.cryomodule} Rack {self.rack_name}"

--- a/src/sc_linac_physics/utils/sc_linac/stepper.py
+++ b/src/sc_linac_physics/utils/sc_linac/stepper.py
@@ -46,12 +46,14 @@ class StepperTuner(linac_utils.SCLinacObject):
 
         self.step_tot_pv: str = self.pv_addr("REG_TOTABS")
         self.step_signed_pv: str = self.pv_addr("REG_TOTSGN")
+        self._step_signed_pv_obj: Optional[PV] = None
         self.reset_tot_pv: str = self.pv_addr("TOTABS_RESET")
 
         self.reset_signed_pv: str = self.pv_addr("TOTSGN_RESET")
         self._reset_signed_pv_obj: Optional[PV] = None
 
         self.steps_cold_landing_pv: str = self.pv_addr("NSTEPS_COLD")
+        self._steps_cold_landing_pv_obj: Optional[PV] = None
         self.push_signed_cold_pv: str = self.pv_addr("PUSH_NSTEPS_COLD.PROC")
         self.push_signed_park_pv: str = self.pv_addr("PUSH_NSTEPS_PARK.PROC")
 
@@ -111,6 +113,18 @@ class StepperTuner(linac_utils.SCLinacObject):
         self.hz_per_step_calc_pv_obj.put(
             hz_per_microstep * linac_utils.MICROSTEPS_PER_STEP
         )
+
+    @property
+    def step_signed_pv_obj(self) -> PV:
+        if not self._step_signed_pv_obj:
+            self._step_signed_pv_obj = PV(self.step_signed_pv)
+        return self._step_signed_pv_obj
+
+    @property
+    def steps_cold_landing_pv_obj(self) -> PV:
+        if not self._steps_cold_landing_pv_obj:
+            self._steps_cold_landing_pv_obj = PV(self.steps_cold_landing_pv)
+        return self._steps_cold_landing_pv_obj
 
     def check_abort(self):
         """

--- a/src/sc_linac_physics/utils/sc_linac/stepper.py
+++ b/src/sc_linac_physics/utils/sc_linac/stepper.py
@@ -69,6 +69,12 @@ class StepperTuner(linac_utils.SCLinacObject):
         self.hz_per_microstep_pv: str = self.pv_addr("SCALE")
         self._hz_per_microstep_pv_obj: Optional[PV] = None
 
+        # SCALE is a derived, read-only calc-record output (SCALE = SCALE_CALC.B / 256).
+        # To persist a measured scale we write the Hz-per-full-step field and let the
+        # IOC recompute SCALE. See set_hz_per_microstep().
+        self.hz_per_step_calc_pv: str = self.pv_addr("SCALE_CALC.B")
+        self._hz_per_step_calc_pv_obj: Optional[PV] = None
+
         self.abort_flag: bool = False
 
     def __str__(self):
@@ -87,6 +93,24 @@ class StepperTuner(linac_utils.SCLinacObject):
     @property
     def hz_per_microstep(self):
         return abs(self.hz_per_microstep_pv_obj.get())
+
+    @property
+    def hz_per_step_calc_pv_obj(self) -> PV:
+        if not self._hz_per_step_calc_pv_obj:
+            self._hz_per_step_calc_pv_obj = PV(self.hz_per_step_calc_pv)
+        return self._hz_per_step_calc_pv_obj
+
+    def set_hz_per_microstep(self, hz_per_microstep: float) -> None:
+        """Persist a measured stepper scale.
+
+        STEP:SCALE is a derived, read-only calc-record output
+        (SCALE = SCALE_CALC.B / 256), so writing SCALE directly is silently
+        reverted by the IOC. Instead we write the Hz-per-full-step field
+        (SCALE_CALC.B) and let the IOC recompute SCALE.
+        """
+        self.hz_per_step_calc_pv_obj.put(
+            hz_per_microstep * linac_utils.MICROSTEPS_PER_STEP
+        )
 
     def check_abort(self):
         """

--- a/src/sc_linac_physics/utils/simulation/cavity_service.py
+++ b/src/sc_linac_physics/utils/simulation/cavity_service.py
@@ -203,7 +203,8 @@ class CavityPVGroup(PVGroup):
     )
     tune_config: PvpropertyEnum = pvproperty(
         name="TUNE_CONFIG",
-        value=0,
+        # Cavities launch at cold landing (index 1) before frequency tuning.
+        value=1,
         dtype=ChannelType.ENUM,
         enum_strings=("On resonance", "Cold landing", "Parked", "Other"),
     )

--- a/src/sc_linac_physics/utils/simulation/tuner_service.py
+++ b/src/sc_linac_physics/utils/simulation/tuner_service.py
@@ -110,6 +110,14 @@ class StepperPVGroup(PVGroup):
         )
         await instance.write(uniform(0.8 * nominal, 1.2 * nominal))
 
+    @hz_per_microstep.putter
+    async def hz_per_microstep(self, instance, value):
+        # SCALE is derived on real IOCs (SCALE = SCALE_CALC.B / 256), so
+        # direct client writes are silently reverted. Only hz_per_step_calc's
+        # putter (via instance.write(), which bypasses this putter) may
+        # update this value.
+        return instance.value
+
     # SCALE is derived on real IOCs: SCALE = SCALE_CALC.B / 256. Model that
     # dependency so SCALE is only updated by writing the (writable) calc field,
     # not by writing SCALE directly.

--- a/src/sc_linac_physics/utils/simulation/tuner_service.py
+++ b/src/sc_linac_physics/utils/simulation/tuner_service.py
@@ -14,6 +14,7 @@ from caproto.server import (
 from sc_linac_physics.utils.sc_linac.linac_utils import (
     ESTIMATED_MICROSTEPS_PER_HZ,
     ESTIMATED_MICROSTEPS_PER_HZ_HL,
+    MICROSTEPS_PER_STEP,
     PIEZO_HZ_PER_VOLT,
 )
 from sc_linac_physics.utils.simulation.cavity_service import CavityPVGroup
@@ -108,6 +109,20 @@ class StepperPVGroup(PVGroup):
             else 1 / ESTIMATED_MICROSTEPS_PER_HZ
         )
         await instance.write(uniform(0.8 * nominal, 1.2 * nominal))
+
+    # SCALE is derived on real IOCs: SCALE = SCALE_CALC.B / 256. Model that
+    # dependency so SCALE is only updated by writing the (writable) calc field,
+    # not by writing SCALE directly.
+    hz_per_step_calc = pvproperty(
+        value=0.0,
+        name="SCALE_CALC.B",
+        dtype=ChannelType.FLOAT,
+    )
+
+    @hz_per_step_calc.putter
+    async def hz_per_step_calc(self, instance, value):
+        await self.hz_per_microstep.write(value / MICROSTEPS_PER_STEP)
+        return value
 
     def __init__(self, prefix, cavity_group, piezo_group):
         super().__init__(prefix)

--- a/tests/applications/rf_commissioning/models/test_data_models.py
+++ b/tests/applications/rf_commissioning/models/test_data_models.py
@@ -339,7 +339,7 @@ class TestSerializationAndRegistry:
         freq_specs = get_phase_display_specs(FrequencyTuningData)
 
         assert [spec.widget_name for spec in freq_specs] == [
-            "freq_tuning_initial_detune",
+            "freq_tuning_df_cold",
             "freq_tuning_steps_to_resonance",
             "freq_tuning_hz_per_microstep",
             "freq_tuning_cold_steps",

--- a/tests/applications/rf_commissioning/phases/test_frequency_tuning.py
+++ b/tests/applications/rf_commissioning/phases/test_frequency_tuning.py
@@ -106,17 +106,15 @@ def _seed_cold_landing(phase, df_cold_hz=5000.0):
             measurements={"df_cold_hz": df_cold_hz},
         )
     )
-    phase._df_cold_pv_obj = Mock()
-    phase._df_cold_pv_obj.get.return_value = df_cold_hz
+    phase.cavity.df_cold_pv_obj.get.return_value = df_cold_hz
 
 
 def _setup_phase(phase, temp_c=25.0, initial_signed_steps=0, seed_cold=True):
     """Call validate_prerequisites and inject pre-built PV mocks."""
     phase.validate_prerequisites()
-    phase._stepper_temp_pv_obj = Mock()
-    phase._stepper_temp_pv_obj.get.return_value = temp_c
-    phase._df_cold_pv_obj = Mock()
-    # NSTEPS_COLD / signed-step PVs now come from the stepper accessors.
+    # STEPTEMP / DF_COLD / signed-step PVs now come from the cavity+stepper
+    # accessors (mock_cavity is a Mock, so these are auto-mocks).
+    phase.cavity.stepper_temp_pv_obj.get.return_value = temp_c
     stepper = phase.cavity.stepper_tuner
     stepper.step_signed_pv_obj.get.return_value = initial_signed_steps
     phase._hz_per_microstep = 2.0
@@ -234,7 +232,9 @@ def test_verify_initial_state_detune_invalid(phase, mock_cavity):
 
 def test_verify_initial_state_read_exception_retries(phase, mock_cavity):
     _setup_phase(phase, temp_c=25.0)
-    phase._stepper_temp_pv_obj.get.side_effect = RuntimeError("PV timeout")
+    phase.cavity.stepper_temp_pv_obj.get.side_effect = RuntimeError(
+        "PV timeout"
+    )
     result = phase._verify_initial_state()
     assert result.result == PhaseResult.RETRY
 
@@ -287,7 +287,7 @@ def test_record_cold_landing_success(phase, mock_cavity):
     assert result.data["df_cold_hz"] == 8000.0
     assert "initial_timestamp" in result.data
     # DF_COLD is written by the operator via the UI button, not auto-written here.
-    phase._df_cold_pv_obj.put.assert_not_called()
+    phase.cavity.df_cold_pv_obj.put.assert_not_called()
 
 
 def test_record_cold_landing_detune_read_error_retries(phase, mock_cavity):
@@ -499,7 +499,7 @@ def test_tune_to_resonance_fails_when_df_cold_mismatched(phase, mock_cavity):
     # Cold landing was recorded, but DF_COLD PV was never pushed to match it.
     _setup_phase(phase, seed_cold=False)
     _seed_cold_landing(phase, df_cold_hz=5000.0)
-    phase._df_cold_pv_obj.get.return_value = 0.0  # operator did not push
+    phase.cavity.df_cold_pv_obj.get.return_value = 0.0  # operator did not push
     mock_cavity.detune_chirp = 5000.0
     result = phase._tune_to_resonance()
     assert result.result == PhaseResult.FAILED
@@ -586,7 +586,7 @@ def test_tune_to_resonance_over_temp_fails_without_ack(phase, mock_cavity):
     # that an operator acknowledgement is required.
     _setup_phase(phase)
     phase.limits.temp_limit_c = 70.0
-    phase._stepper_temp_pv_obj.get.return_value = 85.0
+    phase.cavity.stepper_temp_pv_obj.get.return_value = 85.0
     mock_cavity.detune_chirp = 5000.0
 
     result = phase._tune_to_resonance()
@@ -605,7 +605,7 @@ def test_tune_to_resonance_over_temp_proceeds_with_ack(
     _setup_phase(phase)
     phase.limits.temp_limit_c = 70.0
     context.parameters["over_temp_ack_c"] = 90.0
-    phase._stepper_temp_pv_obj.get.return_value = 85.0
+    phase.cavity.stepper_temp_pv_obj.get.return_value = 85.0
     mock_cavity.detune_chirp = 1000.0
 
     def after_move(*args, **kwargs):
@@ -630,7 +630,7 @@ def test_tune_to_resonance_hotter_breach_requires_new_ack(
 
     # (1) init read OK, (2) iter-1 = 85 (acked, proceeds), (3) iter-2 = 95 (> ceiling → fail)
     temp_values = iter([25.0, 85.0, 95.0])
-    phase._stepper_temp_pv_obj.get.side_effect = lambda: next(temp_values)
+    phase.cavity.stepper_temp_pv_obj.get.side_effect = lambda: next(temp_values)
     mock_cavity.detune_chirp = 5000.0  # never converges, keeps looping
 
     def after_move(*args, **kwargs):
@@ -665,7 +665,9 @@ def test_tune_to_resonance_detune_read_error_retries(phase, mock_cavity):
     # Simulate PV read failure on temp: phase should return RETRY.
     _setup_phase(phase)
     # Initial read (before loop) silently swallows errors, loop read will RETRY.
-    phase._stepper_temp_pv_obj.get.side_effect = RuntimeError("PV timeout")
+    phase.cavity.stepper_temp_pv_obj.get.side_effect = RuntimeError(
+        "PV timeout"
+    )
     mock_cavity.detune_chirp = 5000.0
     result = phase._tune_to_resonance()
     assert result.result == PhaseResult.RETRY
@@ -698,7 +700,7 @@ def test_tune_to_resonance_tracks_peak_temp(phase, mock_cavity, mock_stepper):
     # Reads: (1) initial peak_temp, then one per loop iteration (3 iterations
     # before detune hits tolerance), plus one final read after last move.
     temp_values = iter([30.0, 55.0, 40.0, 25.0])
-    phase._stepper_temp_pv_obj.get.side_effect = lambda: next(temp_values)
+    phase.cavity.stepper_temp_pv_obj.get.side_effect = lambda: next(temp_values)
 
     detunes = [2000.0, 1000.0, 100.0]
     move_count = [0]

--- a/tests/applications/rf_commissioning/phases/test_frequency_tuning.py
+++ b/tests/applications/rf_commissioning/phases/test_frequency_tuning.py
@@ -103,7 +103,6 @@ def _setup_phase(phase, temp_c=25.0, initial_signed_steps=0):
     phase._step_signed_pv_obj = Mock()
     phase._step_signed_pv_obj.get.return_value = initial_signed_steps
     phase._hz_per_microstep = 2.0
-    phase._signed_hz_per_microstep = 2.0
     return phase
 
 
@@ -300,11 +299,9 @@ def test_probe_stepper_direction_positive_increases_frequency(
     result = phase._probe_stepper_direction()
 
     assert result.result == PhaseResult.SUCCESS
-    assert result.data["positive_step_increases_frequency"] is True
     # delta=-500, probe_steps=10 (fast_limits) → signed_hz=+50 Hz/step
     assert result.data["hz_per_microstep"] == pytest.approx(50.0)
     assert phase._hz_per_microstep == pytest.approx(50.0)
-    assert phase._signed_hz_per_microstep == pytest.approx(50.0)
     # SCALE PV is NOT written by the probe step — operator confirms via apply_hz_per_step
     mock_stepper.hz_per_microstep_pv_obj.put.assert_not_called()
     assert mock_stepper.move.call_count == 2
@@ -330,10 +327,9 @@ def test_probe_stepper_direction_positive_decreases_frequency(
     result = phase._probe_stepper_direction()
 
     assert result.result == PhaseResult.SUCCESS
-    assert result.data["positive_step_increases_frequency"] is False
     # delta=+200, probe_steps=10 → signed_hz=-20 Hz/step
-    assert result.data["hz_per_microstep"] == pytest.approx(20.0)
-    assert phase._signed_hz_per_microstep == pytest.approx(-20.0)
+    assert result.data["hz_per_microstep"] == pytest.approx(-20.0)
+    assert phase._hz_per_microstep == pytest.approx(-20.0)
     mock_stepper.hz_per_microstep_pv_obj.put.assert_not_called()
 
 
@@ -387,7 +383,6 @@ def test_apply_hz_per_step_dry_run(context, fast_limits):
 
 def test_apply_hz_per_step_not_measured(phase):
     phase.validate_prerequisites()
-    # _signed_hz_per_microstep is None by default
     result = phase._apply_hz_per_step()
     assert result.result == PhaseResult.FAILED
     assert "probe_stepper_direction" in result.message
@@ -395,7 +390,7 @@ def test_apply_hz_per_step_not_measured(phase):
 
 def test_apply_hz_per_step_writes_scale_pv(phase, mock_stepper):
     _setup_phase(phase)
-    phase._signed_hz_per_microstep = 42.5
+    phase._hz_per_microstep = 42.5
     result = phase._apply_hz_per_step()
     assert result.result == PhaseResult.SUCCESS
     mock_stepper.hz_per_microstep_pv_obj.put.assert_called_once_with(42.5)
@@ -403,7 +398,7 @@ def test_apply_hz_per_step_writes_scale_pv(phase, mock_stepper):
 
 def test_apply_hz_per_step_pv_error_retries(phase, mock_stepper):
     _setup_phase(phase)
-    phase._signed_hz_per_microstep = 10.0
+    phase._hz_per_microstep = 10.0
     mock_stepper.hz_per_microstep_pv_obj.put.side_effect = RuntimeError(
         "timeout"
     )
@@ -702,7 +697,6 @@ def test_finalize_phase_populates_frequency_tuning_data(phase, record):
                     "d0_hz": 8000.0,
                     "d1_hz": 8200.0,
                     "delta_hz": 200.0,
-                    "positive_step_increases_frequency": True,
                     "hz_per_microstep": 2.0,
                 },
             ),

--- a/tests/applications/rf_commissioning/phases/test_frequency_tuning.py
+++ b/tests/applications/rf_commissioning/phases/test_frequency_tuning.py
@@ -1,0 +1,1075 @@
+"""Tests for Frequency Tuning Phase."""
+
+import time
+from datetime import datetime
+from unittest.mock import Mock, patch
+
+import pytest
+
+from sc_linac_physics.applications.rf_commissioning.models.data_models import (
+    CommissioningPhase,
+    CommissioningRecord,
+    PhaseCheckpoint,
+)
+from sc_linac_physics.applications.rf_commissioning.phases.frequency_tuning import (
+    FrequencyTuningLimits,
+    FrequencyTuningPhase,
+)
+from sc_linac_physics.applications.rf_commissioning.phases.phase_base import (
+    PhaseContext,
+    PhaseResult,
+)
+from sc_linac_physics.utils.sc_linac.linac_utils import (
+    StepperError,
+)
+
+# ---------------------------------------------------------------------------
+# Autouse fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def no_sleep(monkeypatch):
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_stepper():
+    stepper = Mock()
+    stepper.motor_moving = False
+    stepper.on_limit_switch = False
+    stepper.hz_per_microstep = 2.0
+    stepper.max_steps = 50
+    stepper.steps_cold_landing_pv = "ACCL:L1B:0210:STEP:NSTEPS_COLD"
+    return stepper
+
+
+@pytest.fixture
+def mock_cavity(mock_stepper):
+    cavity = Mock()
+    cavity.stepper_tuner = mock_stepper
+    cavity.stepper_temp_pv = "ACCL:L1B:0210:STEPTEMP"
+    cavity.detune_invalid = False
+    cavity.detune_chirp = 5000.0
+    return cavity
+
+
+@pytest.fixture
+def record():
+    return CommissioningRecord(linac=1, cryomodule="02", cavity_number=1)
+
+
+@pytest.fixture
+def context(mock_cavity, record):
+    return PhaseContext(
+        record=record,
+        operator="test_op",
+        parameters={"cavity": mock_cavity},
+    )
+
+
+@pytest.fixture
+def fast_limits():
+    return FrequencyTuningLimits(
+        tolerance_hz=500.0,
+        probe_steps=10,
+        temp_limit_c=70.0,
+        max_total_steps=10_000,
+        cool_down_retries=2,
+        cool_down_interval=0.0,
+        motor_start_wait=0.0,
+        motor_poll_interval=0.0,
+    )
+
+
+@pytest.fixture
+def phase(context, fast_limits):
+    p = FrequencyTuningPhase(context, limits=fast_limits)
+    return p
+
+
+def _setup_phase(phase, temp_c=25.0, initial_signed_steps=0):
+    """Call validate_prerequisites and inject pre-built PV mocks."""
+    phase.validate_prerequisites()
+    phase._stepper_temp_pv_obj = Mock()
+    phase._stepper_temp_pv_obj.get.return_value = temp_c
+    phase._df_cold_pv_obj = Mock()
+    phase._nsteps_cold_pv_obj = Mock()
+    phase._step_signed_pv_obj = Mock()
+    phase._step_signed_pv_obj.get.return_value = initial_signed_steps
+    phase._hz_per_microstep = 2.0
+    phase._signed_hz_per_microstep = 2.0
+    return phase
+
+
+# ---------------------------------------------------------------------------
+# Metadata
+# ---------------------------------------------------------------------------
+
+
+def test_phase_type(phase):
+    assert phase.phase_type == CommissioningPhase.FREQUENCY_TUNING
+
+
+def test_get_phase_steps(phase):
+    assert phase.get_phase_steps() == [
+        "verify_initial_state",
+        "record_cold_landing",
+        "probe_stepper_direction",
+        "apply_hz_per_step",
+        "tune_to_resonance",
+        "measure_pi_modes",
+        "record_results",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# validate_prerequisites
+# ---------------------------------------------------------------------------
+
+
+def test_validate_prerequisites_success(phase, mock_cavity):
+    ok, _ = phase.validate_prerequisites()
+    assert ok is True
+    assert phase.cavity is mock_cavity
+
+
+def test_validate_prerequisites_no_cavity(context):
+    context.parameters["cavity"] = None
+    ok, msg = FrequencyTuningPhase(context).validate_prerequisites()
+    assert ok is False
+    assert "cavity" in msg.lower()
+
+
+def test_validate_prerequisites_no_stepper(context):
+    context.parameters["cavity"].stepper_tuner = None
+    ok, _ = FrequencyTuningPhase(context).validate_prerequisites()
+    assert ok is False
+
+
+def test_validate_prerequisites_no_temp_pv(context):
+    context.parameters["cavity"].stepper_temp_pv = ""
+    ok, _ = FrequencyTuningPhase(context).validate_prerequisites()
+    assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# execute_step dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_execute_step_unknown_step(phase):
+    _setup_phase(phase)
+    result = phase.execute_step("nonexistent_step")
+    assert result.result == PhaseResult.FAILED
+    assert "Unknown step" in result.message
+
+
+def test_execute_step_without_cavity_raises(phase):
+    with pytest.raises(Exception):
+        phase.execute_step("verify_initial_state")
+
+
+# ---------------------------------------------------------------------------
+# verify_initial_state
+# ---------------------------------------------------------------------------
+
+
+def test_verify_initial_state_dry_run(context, fast_limits):
+    context.dry_run = True
+    p = FrequencyTuningPhase(context, limits=fast_limits)
+    p.validate_prerequisites()
+    result = p._verify_initial_state()
+    assert result.result == PhaseResult.SUCCESS
+    assert result.data["dry_run"] is True
+
+
+def test_verify_initial_state_motor_already_moving(phase, mock_stepper):
+    _setup_phase(phase)
+    mock_stepper.motor_moving = True
+    result = phase._verify_initial_state()
+    assert result.result == PhaseResult.FAILED
+    assert "moving" in result.message.lower()
+
+
+def test_verify_initial_state_on_limit_switch(phase, mock_stepper):
+    _setup_phase(phase)
+    mock_stepper.on_limit_switch = True
+    result = phase._verify_initial_state()
+    assert result.result == PhaseResult.FAILED
+    assert "limit switch" in result.message.lower()
+
+
+def test_verify_initial_state_detune_invalid(phase, mock_cavity):
+    _setup_phase(phase)
+    mock_cavity.detune_invalid = True
+    result = phase._verify_initial_state()
+    assert result.result == PhaseResult.FAILED
+    assert "chirp" in result.message.lower()
+
+
+def test_verify_initial_state_read_exception_retries(phase, mock_cavity):
+    _setup_phase(phase, temp_c=25.0)
+    phase._stepper_temp_pv_obj.get.side_effect = RuntimeError("PV timeout")
+    result = phase._verify_initial_state()
+    assert result.result == PhaseResult.RETRY
+
+
+def test_verify_initial_state_success(phase):
+    _setup_phase(phase, temp_c=30.0)
+    result = phase._verify_initial_state()
+    assert result.result == PhaseResult.SUCCESS
+    assert result.data["initial_temp_c"] == 30.0
+    assert "initial_detune_hz" in result.data
+
+
+# ---------------------------------------------------------------------------
+# record_cold_landing
+# ---------------------------------------------------------------------------
+
+
+def test_record_cold_landing_dry_run(context, fast_limits):
+    context.dry_run = True
+    p = FrequencyTuningPhase(context, limits=fast_limits)
+    p.validate_prerequisites()
+    result = p._record_cold_landing()
+    assert result.result == PhaseResult.SUCCESS
+    assert result.data["dry_run"] is True
+
+
+def test_record_cold_landing_success(phase, mock_cavity):
+    _setup_phase(phase)
+    mock_cavity.detune_chirp = 8000.0
+    result = phase._record_cold_landing()
+    assert result.result == PhaseResult.SUCCESS
+    assert "hz_per_microstep" not in result.data
+    assert "cold_landing_steps" not in result.data
+    assert result.data["initial_detune_hz"] == 8000.0
+    assert "initial_timestamp" in result.data
+    # DF_COLD is written by the operator via the UI button, not auto-written here.
+    phase._df_cold_pv_obj.put.assert_not_called()
+
+
+def test_record_cold_landing_detune_read_error_retries(phase, mock_cavity):
+    _setup_phase(phase)
+    mock_cavity.detune_chirp = property(
+        Mock(side_effect=RuntimeError("PV timeout"))
+    )
+    # Simulate detune_chirp raising on access
+    type(phase.cavity).detune_chirp = property(
+        Mock(side_effect=RuntimeError("PV timeout"))
+    )
+    result = phase._record_cold_landing()
+    assert result.result == PhaseResult.RETRY
+
+
+# ---------------------------------------------------------------------------
+# probe_stepper_direction
+# ---------------------------------------------------------------------------
+
+
+def test_probe_stepper_direction_dry_run(context, fast_limits):
+    context.dry_run = True
+    p = FrequencyTuningPhase(context, limits=fast_limits)
+    p.validate_prerequisites()
+    result = p._probe_stepper_direction()
+    assert result.result == PhaseResult.SUCCESS
+    assert result.data["dry_run"] is True
+
+
+def test_probe_stepper_direction_positive_increases_frequency(
+    phase, mock_cavity, mock_stepper
+):
+    _setup_phase(phase)
+    mock_cavity.detune_chirp = 1000.0
+
+    def after_move(steps, *args, **kwargs):
+        if steps > 0:
+            # CHIRP:DF = ref − cav; freq increased → CHIRP:DF decreases
+            mock_cavity.detune_chirp = 500.0
+        else:
+            mock_cavity.detune_chirp = 1000.0  # restored
+
+    mock_stepper.move.side_effect = after_move
+
+    result = phase._probe_stepper_direction()
+
+    assert result.result == PhaseResult.SUCCESS
+    assert result.data["positive_step_increases_frequency"] is True
+    # delta=-500, probe_steps=10 (fast_limits) → signed_hz=+50 Hz/step
+    assert result.data["hz_per_microstep"] == pytest.approx(50.0)
+    assert phase._hz_per_microstep == pytest.approx(50.0)
+    assert phase._signed_hz_per_microstep == pytest.approx(50.0)
+    # SCALE PV is NOT written by the probe step — operator confirms via apply_hz_per_step
+    mock_stepper.hz_per_microstep_pv_obj.put.assert_not_called()
+    assert mock_stepper.move.call_count == 2
+    assert mock_stepper.move.call_args_list[0][0][0] > 0
+    assert mock_stepper.move.call_args_list[1][0][0] < 0
+
+
+def test_probe_stepper_direction_positive_decreases_frequency(
+    phase, mock_cavity, mock_stepper
+):
+    _setup_phase(phase)
+    mock_cavity.detune_chirp = 1000.0
+
+    def after_move(steps, *args, **kwargs):
+        if steps > 0:
+            # CHIRP:DF = ref − cav; freq decreased → CHIRP:DF increases
+            mock_cavity.detune_chirp = 1200.0
+        else:
+            mock_cavity.detune_chirp = 1000.0
+
+    mock_stepper.move.side_effect = after_move
+
+    result = phase._probe_stepper_direction()
+
+    assert result.result == PhaseResult.SUCCESS
+    assert result.data["positive_step_increases_frequency"] is False
+    # delta=+200, probe_steps=10 → signed_hz=-20 Hz/step
+    assert result.data["hz_per_microstep"] == pytest.approx(20.0)
+    assert phase._signed_hz_per_microstep == pytest.approx(-20.0)
+    mock_stepper.hz_per_microstep_pv_obj.put.assert_not_called()
+
+
+def test_probe_stepper_direction_delta_too_small(
+    phase, mock_cavity, mock_stepper
+):
+    _setup_phase(phase)
+    mock_cavity.detune_chirp = 1000.0
+
+    def after_move(steps, *args, **kwargs):
+        if steps > 0:
+            mock_cavity.detune_chirp = 1001.0  # barely any change
+
+    mock_stepper.move.side_effect = after_move
+
+    result = phase._probe_stepper_direction()
+
+    assert result.result == PhaseResult.FAILED
+    assert "minimum" in result.message.lower()
+    mock_stepper.hz_per_microstep_pv_obj.put.assert_not_called()
+
+
+def test_probe_stepper_direction_stepper_error(phase, mock_stepper):
+    _setup_phase(phase)
+    mock_stepper.move.side_effect = StepperError("limit switch")
+    result = phase._probe_stepper_direction()
+    assert result.result == PhaseResult.FAILED
+    assert "limit switch" in result.message.lower()
+
+
+def test_probe_stepper_direction_transient_error_retries(phase, mock_stepper):
+    _setup_phase(phase)
+    mock_stepper.move.side_effect = RuntimeError("transient")
+    result = phase._probe_stepper_direction()
+    assert result.result == PhaseResult.RETRY
+
+
+# ---------------------------------------------------------------------------
+# apply_hz_per_step
+# ---------------------------------------------------------------------------
+
+
+def test_apply_hz_per_step_dry_run(context, fast_limits):
+    context.dry_run = True
+    p = FrequencyTuningPhase(context, limits=fast_limits)
+    p.validate_prerequisites()
+    result = p._apply_hz_per_step()
+    assert result.result == PhaseResult.SUCCESS
+    assert result.data["dry_run"] is True
+
+
+def test_apply_hz_per_step_not_measured(phase):
+    phase.validate_prerequisites()
+    # _signed_hz_per_microstep is None by default
+    result = phase._apply_hz_per_step()
+    assert result.result == PhaseResult.FAILED
+    assert "probe_stepper_direction" in result.message
+
+
+def test_apply_hz_per_step_writes_scale_pv(phase, mock_stepper):
+    _setup_phase(phase)
+    phase._signed_hz_per_microstep = 42.5
+    result = phase._apply_hz_per_step()
+    assert result.result == PhaseResult.SUCCESS
+    mock_stepper.hz_per_microstep_pv_obj.put.assert_called_once_with(42.5)
+
+
+def test_apply_hz_per_step_pv_error_retries(phase, mock_stepper):
+    _setup_phase(phase)
+    phase._signed_hz_per_microstep = 10.0
+    mock_stepper.hz_per_microstep_pv_obj.put.side_effect = RuntimeError(
+        "timeout"
+    )
+    result = phase._apply_hz_per_step()
+    assert result.result == PhaseResult.RETRY
+    assert "SCALE PV" in result.message
+
+
+# ---------------------------------------------------------------------------
+# tune_to_resonance
+# ---------------------------------------------------------------------------
+
+
+def test_tune_to_resonance_dry_run(context, fast_limits):
+    context.dry_run = True
+    p = FrequencyTuningPhase(context, limits=fast_limits)
+    p.validate_prerequisites()
+    result = p._tune_to_resonance()
+    assert result.result == PhaseResult.SUCCESS
+    assert result.data["dry_run"] is True
+
+
+def test_tune_to_resonance_already_at_resonance(phase, mock_cavity):
+    _setup_phase(phase)
+    mock_cavity.detune_chirp = 100.0  # within tolerance
+    result = phase._tune_to_resonance()
+    assert result.result == PhaseResult.SUCCESS
+    assert result.data["total_steps"] == 0
+
+
+def test_tune_to_resonance_converges_one_iteration(
+    phase, mock_cavity, mock_stepper
+):
+    _setup_phase(phase)
+    mock_cavity.detune_chirp = 5000.0
+
+    def after_move(*args, **kwargs):
+        mock_cavity.detune_chirp = 100.0
+
+    mock_stepper.move.side_effect = after_move
+
+    result = phase._tune_to_resonance()
+
+    assert result.result == PhaseResult.SUCCESS
+    assert result.data["total_steps"] > 0
+    mock_stepper.move.assert_called_once()
+
+
+def test_tune_to_resonance_moves_positive_for_positive_detune(
+    phase, mock_cavity, mock_stepper
+):
+    _setup_phase(phase)
+    mock_cavity.detune_chirp = 1000.0
+
+    def after_move(*args, **kwargs):
+        mock_cavity.detune_chirp = 0.0
+
+    mock_stepper.move.side_effect = after_move
+
+    phase._tune_to_resonance()
+
+    first_step_arg = mock_stepper.move.call_args_list[0][0][0]
+    assert first_step_arg > 0
+
+
+def test_tune_to_resonance_moves_negative_for_negative_detune(
+    phase, mock_cavity, mock_stepper
+):
+    _setup_phase(phase)
+    mock_cavity.detune_chirp = -1000.0
+
+    def after_move(*args, **kwargs):
+        mock_cavity.detune_chirp = 0.0
+
+    mock_stepper.move.side_effect = after_move
+
+    phase._tune_to_resonance()
+
+    first_step_arg = mock_stepper.move.call_args_list[0][0][0]
+    assert first_step_arg < 0
+
+
+def test_tune_to_resonance_max_steps_exceeded(phase, mock_cavity):
+    _setup_phase(phase)
+    phase.limits.max_total_steps = 0
+    mock_cavity.detune_chirp = 5000.0
+    result = phase._tune_to_resonance()
+    assert result.result == PhaseResult.FAILED
+    assert "max step limit" in result.message.lower()
+
+
+def test_tune_to_resonance_temperature_over_limit_then_cools(
+    phase, mock_cavity, mock_stepper
+):
+    _setup_phase(phase)
+    phase.limits.temp_limit_c = 70.0
+
+    # Reads: (1) initial peak_temp, (2) loop-iter-1 first check = over limit,
+    # (3) cool-down retry = OK, (4) loop-iter-2 check after move resolves detune.
+    temp_values = iter([25.0, 80.0, 60.0, 25.0])
+    phase._stepper_temp_pv_obj.get.side_effect = lambda: next(temp_values)
+
+    mock_cavity.detune_chirp = 1000.0
+
+    def after_move(*args, **kwargs):
+        mock_cavity.detune_chirp = 0.0
+
+    mock_stepper.move.side_effect = after_move
+
+    result = phase._tune_to_resonance()
+    assert result.result == PhaseResult.SUCCESS
+
+
+def test_tune_to_resonance_temperature_never_cools(phase, mock_cavity):
+    _setup_phase(phase)
+    phase.limits.temp_limit_c = 70.0
+    phase.limits.cool_down_retries = 2
+
+    # Always over limit
+    phase._stepper_temp_pv_obj.get.return_value = 85.0
+    mock_cavity.detune_chirp = 5000.0
+
+    result = phase._tune_to_resonance()
+    assert result.result == PhaseResult.FAILED
+    assert "temp" in result.message.lower()
+
+
+def test_tune_to_resonance_abort_requested(phase, mock_cavity, context):
+    _setup_phase(phase)
+    context.request_abort()
+    mock_cavity.detune_chirp = 5000.0
+    result = phase._tune_to_resonance()
+    assert result.result == PhaseResult.FAILED
+    assert "abort" in result.message.lower()
+
+
+def test_tune_to_resonance_stepper_error(phase, mock_cavity, mock_stepper):
+    _setup_phase(phase)
+    mock_cavity.detune_chirp = 1000.0
+    mock_stepper.move.side_effect = StepperError("limit switch")
+    result = phase._tune_to_resonance()
+    assert result.result == PhaseResult.FAILED
+
+
+def test_tune_to_resonance_detune_read_error_retries(phase, mock_cavity):
+    # Simulate PV read failure on temp: phase should return RETRY.
+    _setup_phase(phase)
+    # Initial read (before loop) silently swallows errors, loop read will RETRY.
+    phase._stepper_temp_pv_obj.get.side_effect = RuntimeError("PV timeout")
+    mock_cavity.detune_chirp = 5000.0
+    result = phase._tune_to_resonance()
+    assert result.result == PhaseResult.RETRY
+
+
+def test_tune_to_resonance_missing_hz_per_microstep(phase, mock_cavity):
+    _setup_phase(phase)
+    phase._hz_per_microstep = None
+    result = phase._tune_to_resonance()
+    assert result.result == PhaseResult.FAILED
+    assert "probe_stepper_direction" in result.message
+
+
+def test_tune_to_resonance_tracks_peak_temp(phase, mock_cavity, mock_stepper):
+    _setup_phase(phase)
+    phase.limits.temp_limit_c = 100.0
+
+    # Reads: (1) initial peak_temp, then one per loop iteration (3 iterations
+    # before detune hits tolerance), plus one final read after last move.
+    temp_values = iter([30.0, 55.0, 40.0, 25.0])
+    phase._stepper_temp_pv_obj.get.side_effect = lambda: next(temp_values)
+
+    detunes = [2000.0, 1000.0, 100.0]
+    move_count = [0]
+
+    def after_move(*args, **kwargs):
+        move_count[0] += 1
+        mock_cavity.detune_chirp = detunes[move_count[0]]
+
+    mock_cavity.detune_chirp = detunes[0]
+    mock_stepper.move.side_effect = after_move
+
+    result = phase._tune_to_resonance()
+    assert result.result == PhaseResult.SUCCESS
+    assert "total_steps" in result.data
+
+
+def test_tune_to_resonance_writes_nsteps_cold(phase, mock_cavity, mock_stepper):
+    _setup_phase(phase)
+    mock_cavity.detune_chirp = 1000.0
+
+    def after_move(*args, **kwargs):
+        mock_cavity.detune_chirp = 0.0
+
+    mock_stepper.move.side_effect = after_move
+
+    result = phase._tune_to_resonance()
+
+    assert result.result == PhaseResult.SUCCESS
+    # cold_landing_steps in data should be the negated signed total
+    assert "cold_landing_steps" in result.data
+    assert result.data["cold_landing_steps"] == -result.data["total_steps"]
+    phase._nsteps_cold_pv_obj.put.assert_called_once_with(
+        result.data["cold_landing_steps"]
+    )
+
+
+def test_tune_to_resonance_accumulates_steps_across_restarts(
+    phase, mock_cavity, mock_stepper
+):
+    """NSTEPS_COLD must reflect total steps from cold landing, not just this run."""
+    prior_steps = -500_000
+    _setup_phase(phase, initial_signed_steps=prior_steps)
+    mock_cavity.detune_chirp = 1000.0
+
+    def after_move(*args, **kwargs):
+        mock_cavity.detune_chirp = 0.0
+
+    mock_stepper.move.side_effect = after_move
+
+    result = phase._tune_to_resonance()
+
+    assert result.result == PhaseResult.SUCCESS
+    cold_landing_steps = result.data["cold_landing_steps"]
+    total_steps_this_run = result.data["total_steps"]
+    # cold_landing_steps = -(prior_signed_offset + signed_steps_this_run).
+    # Its magnitude must exceed what this run contributed alone, proving the
+    # prior accumulated offset was preserved rather than reset to zero.
+    assert (
+        abs(cold_landing_steps) > total_steps_this_run
+    ), "cold_landing_steps must reflect steps from prior (aborted) runs"
+    phase._nsteps_cold_pv_obj.put.assert_called_once_with(cold_landing_steps)
+
+
+def test_tune_to_resonance_nsteps_cold_write_error(
+    phase, mock_cavity, mock_stepper
+):
+    _setup_phase(phase)
+    mock_cavity.detune_chirp = 1000.0
+
+    def after_move(*args, **kwargs):
+        mock_cavity.detune_chirp = 0.0
+
+    mock_stepper.move.side_effect = after_move
+    phase._nsteps_cold_pv_obj.put.side_effect = RuntimeError("PV timeout")
+
+    result = phase._tune_to_resonance()
+    assert result.result == PhaseResult.RETRY
+    assert "NSTEPS_COLD" in result.message
+
+
+# ---------------------------------------------------------------------------
+# record_results
+# ---------------------------------------------------------------------------
+
+
+def test_record_results_success(phase):
+    _setup_phase(phase)
+    result = phase._record_results()
+    assert result.result == PhaseResult.SUCCESS
+
+
+# ---------------------------------------------------------------------------
+# finalize_phase
+# ---------------------------------------------------------------------------
+
+
+def _make_checkpoint(phase_type, step_name, measurements):
+    return PhaseCheckpoint(
+        phase=phase_type,
+        timestamp=datetime.now(),
+        operator="op",
+        step_name=step_name,
+        success=True,
+        measurements=measurements,
+    )
+
+
+def test_finalize_phase_populates_frequency_tuning_data(phase, record):
+    _setup_phase(phase)
+    phase._history_start = 0
+
+    record.phase_history.extend(
+        [
+            _make_checkpoint(
+                CommissioningPhase.FREQUENCY_TUNING,
+                "record_cold_landing",
+                {
+                    "initial_detune_hz": 8000.0,
+                    "initial_timestamp": datetime.now().isoformat(),
+                },
+            ),
+            _make_checkpoint(
+                CommissioningPhase.FREQUENCY_TUNING,
+                "probe_stepper_direction",
+                {
+                    "d0_hz": 8000.0,
+                    "d1_hz": 8200.0,
+                    "delta_hz": 200.0,
+                    "positive_step_increases_frequency": True,
+                    "hz_per_microstep": 2.0,
+                },
+            ),
+            _make_checkpoint(
+                CommissioningPhase.FREQUENCY_TUNING,
+                "tune_to_resonance",
+                {
+                    "total_steps": 4000,
+                    "cold_landing_steps": -4000,
+                    "final_timestamp": datetime.now().isoformat(),
+                },
+            ),
+        ]
+    )
+
+    phase.finalize_phase()
+
+    ft = record.frequency_tuning
+    assert ft is not None
+    assert ft.initial_detune_hz == 8000.0
+    assert ft.steps_to_resonance == 4000
+    assert ft.positive_step_increases_frequency is True
+    assert ft.hz_per_microstep == 2.0
+    assert ft.cold_landing_steps == -4000
+    assert ft.initial_timestamp is not None
+    assert ft.final_timestamp is not None
+
+
+def test_finalize_phase_no_checkpoints_creates_defaults(phase, record):
+    _setup_phase(phase)
+    phase._history_start = 0
+
+    phase.finalize_phase()
+
+    ft = record.frequency_tuning
+    assert ft is not None
+    assert ft.initial_detune_hz is None
+    assert ft.steps_to_resonance is None
+    assert ft.positive_step_increases_frequency is None
+
+
+# ---------------------------------------------------------------------------
+# _do_probe_move — probe callback paths
+# ---------------------------------------------------------------------------
+
+_FT_MODULE = (
+    "sc_linac_physics.applications.rf_commissioning.phases.frequency_tuning.PV"
+)
+
+
+def test_do_probe_move_invokes_callbacks(phase, mock_cavity, mock_stepper):
+    """probe_cb must be called with (0, d0) before and (probe, d1) after move."""
+    _setup_phase(phase)
+    called_with = []
+    mock_cavity.detune_chirp = 1000.0
+
+    def probe_cb(steps, hz):
+        called_with.append((steps, hz))
+
+    phase._do_probe_move(10, probe_cb, speed=1000)
+
+    assert len(called_with) == 2
+    assert called_with[0] == (0, 1000.0)
+    assert called_with[1][0] == 10
+
+
+def test_do_probe_move_callback_exception_is_swallowed(
+    phase, mock_cavity, mock_stepper
+):
+    """A failing probe_cb must not propagate — the move should succeed."""
+    _setup_phase(phase)
+
+    def bad_cb(*_):
+        raise RuntimeError("callback error")
+
+    phase._do_probe_move(10, bad_cb)
+    assert mock_stepper.move.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# _measure_pi_modes — dry-run and live paths
+# ---------------------------------------------------------------------------
+
+
+def _make_rack(phase, fscan_stat_sequence):
+    """Build a mock rack and wire mock_cavity.rack to it."""
+    rack = Mock()
+    rack.pv_prefix = "ACCL:L1B:0210:"
+    rack.rack_name = "A"
+
+    cav2 = Mock()
+    cav2.pv_addr = lambda s: f"ACCL:L1B:0220:{s}"
+    rack.cavities = {
+        phase.cavity.number: phase.cavity,
+        phase.cavity.number + 1: cav2,
+    }
+
+    phase.cavity.rack = rack
+    phase.cavity.pv_addr = lambda s: f"ACCL:L1B:0210:{s}"
+    phase.cavity.number = 1
+
+    return rack, fscan_stat_sequence
+
+
+def _make_pv_factory(stat_sequence):
+    """Return a PV factory that replays stat_sequence on FSCAN:STAT reads."""
+    stat_iter = iter(stat_sequence)
+
+    def factory(addr):
+        pv = Mock()
+        if "FSCAN:STAT" in addr:
+            pv.get.side_effect = lambda: next(stat_iter)
+        elif "8PI9MODE" in addr:
+            pv.get.return_value = 1_400_000_000.0
+        elif "7PI9MODE" in addr:
+            pv.get.return_value = 1_399_000_000.0
+        else:
+            pv.get.return_value = 0
+        return pv
+
+    return factory
+
+
+def test_measure_pi_modes_dry_run(phase):
+    _setup_phase(phase)
+    phase.context.dry_run = True
+    result = phase._measure_pi_modes()
+    assert result.result == PhaseResult.SUCCESS
+    assert result.data["dry_run"] is True
+
+
+def test_measure_pi_modes_success(phase, mock_cavity):
+    _setup_phase(phase)
+    mock_cavity.number = 1
+    rack, _ = _make_rack(phase, [3, 5])  # 3=in-progress, 5=done
+
+    with patch(_FT_MODULE, side_effect=_make_pv_factory([3, 5])):
+        result = phase._measure_pi_modes()
+
+    assert result.result == PhaseResult.SUCCESS
+    assert "mode_8pi_9_hz" in result.data
+    assert "mode_7pi_9_hz" in result.data
+
+
+def test_measure_pi_modes_rack_check_blocks(phase, mock_cavity):
+    _setup_phase(phase)
+    mock_cavity.number = 1
+    _make_rack(phase, [])
+    phase.context.parameters["rack_check_callback"] = lambda rack: (
+        False,
+        "another cavity active",
+    )
+
+    with patch(_FT_MODULE, side_effect=_make_pv_factory([])):
+        result = phase._measure_pi_modes()
+
+    assert result.result == PhaseResult.FAILED
+    assert "rack" in result.message.lower()
+
+
+def test_measure_pi_modes_rack_check_callback_raises(phase, mock_cavity):
+    _setup_phase(phase)
+    mock_cavity.number = 1
+    _make_rack(phase, [])
+    phase.context.parameters["rack_check_callback"] = Mock(
+        side_effect=RuntimeError("unexpected")
+    )
+
+    with patch(_FT_MODULE, side_effect=_make_pv_factory([])):
+        result = phase._measure_pi_modes()
+
+    assert result.result == PhaseResult.RETRY
+
+
+def test_measure_pi_modes_fscan_aborted(phase, mock_cavity):
+    _setup_phase(phase)
+    mock_cavity.number = 1
+    _make_rack(phase, [6])  # 6=scan aborted
+
+    with patch(_FT_MODULE, side_effect=_make_pv_factory([6])):
+        result = phase._measure_pi_modes()
+
+    assert result.result == PhaseResult.FAILED
+    assert "aborted" in result.message.lower() or "FSCAN" in result.message
+
+
+def test_measure_pi_modes_fscan_timeout(phase, mock_cavity):
+    _setup_phase(phase)
+    mock_cavity.number = 1
+    phase.limits.pi_scan_timeout_seconds = 0.0  # expire immediately
+    _make_rack(phase, [])
+
+    with patch(_FT_MODULE, side_effect=_make_pv_factory([])):
+        result = phase._measure_pi_modes()
+
+    assert result.result == PhaseResult.FAILED
+    assert "did not complete" in result.message
+
+
+def test_measure_pi_modes_abort_during_wait(phase, mock_cavity):
+    _setup_phase(phase)
+    mock_cavity.number = 1
+    phase.limits.pi_scan_timeout_seconds = 60.0
+    _make_rack(phase, [3])  # stays in-progress
+
+    phase.context.abort_requested = True
+
+    with patch(_FT_MODULE, side_effect=_make_pv_factory([3])):
+        result = phase._measure_pi_modes()
+
+    assert result.result == PhaseResult.FAILED
+    assert "Abort" in result.message
+
+
+def test_measure_pi_modes_sel_pv_write_error(phase, mock_cavity):
+    _setup_phase(phase)
+    mock_cavity.number = 1
+    _make_rack(phase, [])
+
+    def pv_factory(addr):
+        pv = Mock()
+        if "FSCAN:SEL" in addr:
+            pv.put.side_effect = RuntimeError("write timeout")
+        return pv
+
+    with patch(_FT_MODULE, side_effect=pv_factory):
+        result = phase._measure_pi_modes()
+
+    assert result.result == PhaseResult.RETRY
+
+
+def test_measure_pi_modes_fscan_param_write_error(phase, mock_cavity):
+    _setup_phase(phase)
+    mock_cavity.number = 1
+    _make_rack(phase, [])
+
+    def pv_factory(addr):
+        pv = Mock()
+        if "FSCAN:FREQ_START" in addr:
+            pv.put.side_effect = RuntimeError("write timeout")
+        return pv
+
+    with patch(_FT_MODULE, side_effect=pv_factory):
+        result = phase._measure_pi_modes()
+
+    assert result.result == PhaseResult.RETRY
+
+
+def test_measure_pi_modes_start_write_error(phase, mock_cavity):
+    _setup_phase(phase)
+    mock_cavity.number = 1
+    _make_rack(phase, [])
+
+    def pv_factory(addr):
+        pv = Mock()
+        if "FSCAN:START" in addr:
+            pv.put.side_effect = RuntimeError("write timeout")
+        return pv
+
+    with patch(_FT_MODULE, side_effect=pv_factory):
+        result = phase._measure_pi_modes()
+
+    assert result.result == PhaseResult.RETRY
+
+
+def test_measure_pi_modes_stat_read_error(phase, mock_cavity):
+    _setup_phase(phase)
+    mock_cavity.number = 1
+    phase.limits.pi_scan_timeout_seconds = 60.0
+    _make_rack(phase, [])
+
+    def pv_factory(addr):
+        pv = Mock()
+        if "FSCAN:STAT" in addr:
+            pv.get.side_effect = RuntimeError("read timeout")
+        return pv
+
+    with patch(_FT_MODULE, side_effect=pv_factory):
+        result = phase._measure_pi_modes()
+
+    assert result.result == PhaseResult.RETRY
+
+
+def test_measure_pi_modes_status_callback_invoked(phase, mock_cavity):
+    _setup_phase(phase)
+    mock_cavity.number = 1
+    phase.limits.pi_scan_timeout_seconds = 60.0
+    _make_rack(phase, [3, 5])
+
+    status_msgs = []
+    phase.context.parameters["status_update_callback"] = status_msgs.append
+
+    with patch(_FT_MODULE, side_effect=_make_pv_factory([3, 5])):
+        result = phase._measure_pi_modes()
+
+    assert result.result == PhaseResult.SUCCESS
+    assert any("FSCAN" in m for m in status_msgs)
+
+
+def test_measure_pi_modes_push_results_error(phase, mock_cavity):
+    _setup_phase(phase)
+    mock_cavity.number = 1
+    _make_rack(phase, [5])
+
+    def pv_factory(addr):
+        pv = Mock()
+        if "FSCAN:STAT" in addr:
+            pv.get.return_value = 5
+        elif "PUSH_8PI9" in addr:
+            pv.put.side_effect = RuntimeError("put failed")
+        return pv
+
+    with patch(_FT_MODULE, side_effect=pv_factory):
+        result = phase._measure_pi_modes()
+
+    assert result.result == PhaseResult.RETRY
+
+
+def test_measure_pi_modes_read_frequency_error(phase, mock_cavity):
+    _setup_phase(phase)
+    mock_cavity.number = 1
+    _make_rack(phase, [5])
+
+    def pv_factory(addr):
+        pv = Mock()
+        if "FSCAN:STAT" in addr:
+            pv.get.return_value = 5
+        elif "8PI9MODE" in addr:
+            pv.get.side_effect = RuntimeError("read failed")
+        return pv
+
+    with patch(_FT_MODULE, side_effect=pv_factory):
+        result = phase._measure_pi_modes()
+
+    assert result.result == PhaseResult.RETRY
+
+
+# ---------------------------------------------------------------------------
+# _initialize_tuning_state — lazy PV init
+# ---------------------------------------------------------------------------
+
+
+def test_initialize_tuning_state_creates_pv_when_none(
+    phase, mock_cavity, mock_stepper
+):
+    """When _step_signed_pv_obj is None it should be lazily created."""
+    _setup_phase(phase)
+    phase._step_signed_pv_obj = None
+    mock_stepper.step_signed_pv = "ACCL:L1B:0210:STEP:REG_TOTSGN"
+
+    mock_pv = Mock()
+    mock_pv.get.return_value = -200_000
+
+    with patch(_FT_MODULE, return_value=mock_pv):
+        total, signed, peak = phase._initialize_tuning_state(None)
+
+    assert signed == -200_000
+    assert phase._step_signed_pv_obj is mock_pv
+
+
+def test_initialize_tuning_state_pv_read_error_defaults_zero(
+    phase, mock_cavity, mock_stepper
+):
+    """A PV read exception during init should silently yield signed_total=0."""
+    _setup_phase(phase)
+    phase._step_signed_pv_obj = Mock()
+    phase._step_signed_pv_obj.get.side_effect = RuntimeError("read error")
+
+    total, signed, peak = phase._initialize_tuning_state(None)
+    assert signed == 0

--- a/tests/applications/rf_commissioning/phases/test_frequency_tuning.py
+++ b/tests/applications/rf_commissioning/phases/test_frequency_tuning.py
@@ -84,8 +84,6 @@ def fast_limits():
         probe_steps=10,
         temp_limit_c=70.0,
         max_total_steps=10_000,
-        cool_down_retries=2,
-        cool_down_interval=0.0,
     )
 
 
@@ -580,17 +578,31 @@ def test_tune_to_resonance_max_steps_exceeded(phase, mock_cavity):
     assert "max step limit" in result.message.lower()
 
 
-def test_tune_to_resonance_temperature_over_limit_then_cools(
-    phase, mock_cavity, mock_stepper
-):
+def test_tune_to_resonance_over_temp_fails_without_ack(phase, mock_cavity):
+    # No automatic cool-down: an over-temp reading fails the step and flags
+    # that an operator acknowledgement is required.
     _setup_phase(phase)
     phase.limits.temp_limit_c = 70.0
+    phase._stepper_temp_pv_obj.get.return_value = 85.0
+    mock_cavity.detune_chirp = 5000.0
 
-    # Reads: (1) initial peak_temp, (2) loop-iter-1 first check = over limit,
-    # (3) cool-down retry = OK, (4) loop-iter-2 check after move resolves detune.
-    temp_values = iter([25.0, 80.0, 60.0, 25.0])
-    phase._stepper_temp_pv_obj.get.side_effect = lambda: next(temp_values)
+    result = phase._tune_to_resonance()
+    assert result.result == PhaseResult.FAILED
+    assert result.data["requires_over_temp_ack"] is True
+    assert result.data["stepper_temp_c"] == 85.0
+    assert result.data["temp_limit_c"] == 70.0
+    assert "85" in result.message
 
+
+def test_tune_to_resonance_over_temp_proceeds_with_ack(
+    phase, mock_cavity, mock_stepper, context
+):
+    # With an acknowledgement ceiling >= the reading, tuning proceeds and the
+    # acknowledging operator is recorded.
+    _setup_phase(phase)
+    phase.limits.temp_limit_c = 70.0
+    context.parameters["over_temp_ack_c"] = 90.0
+    phase._stepper_temp_pv_obj.get.return_value = 85.0
     mock_cavity.detune_chirp = 1000.0
 
     def after_move(*args, **kwargs):
@@ -600,20 +612,33 @@ def test_tune_to_resonance_temperature_over_limit_then_cools(
 
     result = phase._tune_to_resonance()
     assert result.result == PhaseResult.SUCCESS
+    assert result.data["over_temp_acknowledged_c"] == 85.0
+    assert result.data["over_temp_acknowledged_by"] == context.operator
 
 
-def test_tune_to_resonance_temperature_never_cools(phase, mock_cavity):
+def test_tune_to_resonance_hotter_breach_requires_new_ack(
+    phase, mock_cavity, mock_stepper, context
+):
+    # Ack ceiling authorizes up to 90 °C, but a later reading climbs above it
+    # → fail again for a fresh acknowledgement.
     _setup_phase(phase)
     phase.limits.temp_limit_c = 70.0
-    phase.limits.cool_down_retries = 2
+    context.parameters["over_temp_ack_c"] = 90.0
 
-    # Always over limit
-    phase._stepper_temp_pv_obj.get.return_value = 85.0
-    mock_cavity.detune_chirp = 5000.0
+    # (1) init read OK, (2) iter-1 = 85 (acked, proceeds), (3) iter-2 = 95 (> ceiling → fail)
+    temp_values = iter([25.0, 85.0, 95.0])
+    phase._stepper_temp_pv_obj.get.side_effect = lambda: next(temp_values)
+    mock_cavity.detune_chirp = 5000.0  # never converges, keeps looping
+
+    def after_move(*args, **kwargs):
+        pass  # detune unchanged → second iteration runs
+
+    mock_stepper.move.side_effect = after_move
 
     result = phase._tune_to_resonance()
     assert result.result == PhaseResult.FAILED
-    assert "temp" in result.message.lower()
+    assert result.data["requires_over_temp_ack"] is True
+    assert result.data["stepper_temp_c"] == 95.0
 
 
 def test_tune_to_resonance_abort_requested(phase, mock_cavity, context):

--- a/tests/applications/rf_commissioning/phases/test_frequency_tuning.py
+++ b/tests/applications/rf_commissioning/phases/test_frequency_tuning.py
@@ -116,9 +116,9 @@ def _setup_phase(phase, temp_c=25.0, initial_signed_steps=0, seed_cold=True):
     phase._stepper_temp_pv_obj = Mock()
     phase._stepper_temp_pv_obj.get.return_value = temp_c
     phase._df_cold_pv_obj = Mock()
-    phase._nsteps_cold_pv_obj = Mock()
-    phase._step_signed_pv_obj = Mock()
-    phase._step_signed_pv_obj.get.return_value = initial_signed_steps
+    # NSTEPS_COLD / signed-step PVs now come from the stepper accessors.
+    stepper = phase.cavity.stepper_tuner
+    stepper.step_signed_pv_obj.get.return_value = initial_signed_steps
     phase._hz_per_microstep = 2.0
     # Satisfy the DF_COLD gate for tune_to_resonance tests by default.
     if seed_cold:
@@ -684,7 +684,9 @@ def test_tune_to_resonance_signed_step_read_error_retries(phase, mock_cavity):
     # than silently resuming at 0 and corrupting NSTEPS_COLD.
     _setup_phase(phase)
     mock_cavity.detune_chirp = 5000.0
-    phase._step_signed_pv_obj.get.side_effect = RuntimeError("PV timeout")
+    phase.cavity.stepper_tuner.step_signed_pv_obj.get.side_effect = (
+        RuntimeError("PV timeout")
+    )
     result = phase._tune_to_resonance()
     assert result.result == PhaseResult.RETRY
 
@@ -728,7 +730,7 @@ def test_tune_to_resonance_writes_nsteps_cold(phase, mock_cavity, mock_stepper):
     # cold_landing_steps in data should be the negated signed total
     assert "cold_landing_steps" in result.data
     assert result.data["cold_landing_steps"] == -result.data["total_steps"]
-    phase._nsteps_cold_pv_obj.put.assert_called_once_with(
+    mock_stepper.steps_cold_landing_pv_obj.put.assert_called_once_with(
         result.data["cold_landing_steps"]
     )
 
@@ -757,7 +759,9 @@ def test_tune_to_resonance_accumulates_steps_across_restarts(
     assert (
         abs(cold_landing_steps) > total_steps_this_run
     ), "cold_landing_steps must reflect steps from prior (aborted) runs"
-    phase._nsteps_cold_pv_obj.put.assert_called_once_with(cold_landing_steps)
+    mock_stepper.steps_cold_landing_pv_obj.put.assert_called_once_with(
+        cold_landing_steps
+    )
 
 
 def test_tune_to_resonance_nsteps_cold_write_error(
@@ -770,7 +774,9 @@ def test_tune_to_resonance_nsteps_cold_write_error(
         mock_cavity.detune_chirp = 0.0
 
     mock_stepper.move.side_effect = after_move
-    phase._nsteps_cold_pv_obj.put.side_effect = RuntimeError("PV timeout")
+    mock_stepper.steps_cold_landing_pv_obj.put.side_effect = RuntimeError(
+        "PV timeout"
+    )
 
     result = phase._tune_to_resonance()
     assert result.result == PhaseResult.RETRY
@@ -1167,23 +1173,17 @@ def test_measure_pi_modes_read_frequency_error(phase, mock_cavity):
 # ---------------------------------------------------------------------------
 
 
-def test_initialize_tuning_state_creates_pv_when_none(
+def test_initialize_tuning_state_reads_stepper_signed_pv(
     phase, mock_cavity, mock_stepper
 ):
-    """When _step_signed_pv_obj is None it should be lazily created."""
+    """Signed step count is read from the stepper's step_signed_pv_obj."""
     _setup_phase(phase)
-    phase._step_signed_pv_obj = None
-    mock_stepper.step_signed_pv = "ACCL:L1B:0210:STEP:REG_TOTSGN"
+    mock_stepper.step_signed_pv_obj.get.return_value = -200_000
 
-    mock_pv = Mock()
-    mock_pv.get.return_value = -200_000
-
-    with patch(_FT_MODULE, return_value=mock_pv):
-        total, signed, peak, err = phase._initialize_tuning_state(None)
+    total, signed, peak, err = phase._initialize_tuning_state(None)
 
     assert signed == -200_000
     assert err is None
-    assert phase._step_signed_pv_obj is mock_pv
 
 
 def test_initialize_tuning_state_pv_read_error_returns_retry(
@@ -1194,8 +1194,7 @@ def test_initialize_tuning_state_pv_read_error_returns_retry(
     Silently resuming at 0 would corrupt the NSTEPS_COLD return-trip value.
     """
     _setup_phase(phase)
-    phase._step_signed_pv_obj = Mock()
-    phase._step_signed_pv_obj.get.side_effect = RuntimeError("read error")
+    mock_stepper.step_signed_pv_obj.get.side_effect = RuntimeError("read error")
 
     total, signed, peak, err = phase._initialize_tuning_state(None)
     assert signed == 0

--- a/tests/applications/rf_commissioning/phases/test_frequency_tuning.py
+++ b/tests/applications/rf_commissioning/phases/test_frequency_tuning.py
@@ -2,7 +2,7 @@
 
 import time
 from datetime import datetime
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 
@@ -23,6 +23,7 @@ from sc_linac_physics.utils.sc_linac.linac_utils import (
     CavityAbortError,
     CavityFaultError,
     DetuneError,
+    FSCANError,
     StepperError,
     StepperTempError,
     TUNE_CONFIG_COLD_VALUE,
@@ -725,10 +726,6 @@ def test_finalize_phase_no_checkpoints_creates_defaults(phase, record):
 # _do_probe_move — probe callback paths
 # ---------------------------------------------------------------------------
 
-_FT_MODULE = (
-    "sc_linac_physics.applications.rf_commissioning.phases.frequency_tuning.PV"
-)
-
 
 def test_do_probe_move_invokes_callbacks(phase, mock_cavity, mock_stepper):
     """probe_cb must be called with (0, d0) before and (probe, d1) after move."""
@@ -764,45 +761,6 @@ def test_do_probe_move_callback_exception_is_swallowed(
 # ---------------------------------------------------------------------------
 
 
-def _make_rack(phase, fscan_stat_sequence):
-    """Build a mock rack and wire mock_cavity.rack to it."""
-    rack = Mock()
-    rack.pv_prefix = "ACCL:L1B:0210:"
-    rack.rack_name = "A"
-
-    cav2 = Mock()
-    cav2.pv_addr = lambda s: f"ACCL:L1B:0220:{s}"
-    rack.cavities = {
-        phase.cavity.number: phase.cavity,
-        phase.cavity.number + 1: cav2,
-    }
-
-    phase.cavity.rack = rack
-    phase.cavity.pv_addr = lambda s: f"ACCL:L1B:0210:{s}"
-    phase.cavity.number = 1
-
-    return rack, fscan_stat_sequence
-
-
-def _make_pv_factory(stat_sequence):
-    """Return a PV factory that replays stat_sequence on FSCAN:STAT reads."""
-    stat_iter = iter(stat_sequence)
-
-    def factory(addr):
-        pv = Mock()
-        if "FSCAN:STAT" in addr:
-            pv.get.side_effect = lambda: next(stat_iter)
-        elif "8PI9MODE" in addr:
-            pv.get.return_value = 1_400_000_000.0
-        elif "7PI9MODE" in addr:
-            pv.get.return_value = 1_399_000_000.0
-        else:
-            pv.get.return_value = 0
-        return pv
-
-    return factory
-
-
 def test_measure_pi_modes_dry_run(phase):
     _setup_phase(phase)
     phase.context.dry_run = True
@@ -811,207 +769,85 @@ def test_measure_pi_modes_dry_run(phase):
     assert result.data["dry_run"] is True
 
 
-def test_measure_pi_modes_success(phase, mock_cavity):
+def test_measure_pi_modes_delegates_to_run_fscan(phase, mock_cavity):
+    # Phase delegates the scan to rack.run_fscan, then reads modes off the
+    # cavity accessors.
     _setup_phase(phase)
-    mock_cavity.number = 1
-    rack, _ = _make_rack(phase, [3, 5])  # 3=in-progress, 5=done
+    mock_cavity.rack.run_fscan = Mock()
+    mock_cavity.fscan_8pi9_mode_pv_obj.get.return_value = 1_400_000_000.0
+    mock_cavity.fscan_7pi9_mode_pv_obj.get.return_value = 1_399_000_000.0
 
-    with patch(_FT_MODULE, side_effect=_make_pv_factory([3, 5])):
-        result = phase._measure_pi_modes()
+    result = phase._measure_pi_modes()
 
     assert result.result == PhaseResult.SUCCESS
-    assert "mode_8pi_9_hz" in result.data
-    assert "mode_7pi_9_hz" in result.data
+    mock_cavity.rack.run_fscan.assert_called_once()
+    call = mock_cavity.rack.run_fscan.call_args
+    assert call.args[0] == [mock_cavity]  # scans just this cavity
+    assert call.kwargs["freq_start"] == phase.limits.pi_scan_freq_start
+    assert result.data["mode_8pi_9_hz"] == 1_400_000_000.0
+    assert result.data["mode_7pi_9_hz"] == 1_399_000_000.0
 
 
 def test_measure_pi_modes_rack_check_blocks(phase, mock_cavity):
     _setup_phase(phase)
-    mock_cavity.number = 1
-    _make_rack(phase, [])
+    mock_cavity.rack.run_fscan = Mock()
     phase.context.parameters["rack_check_callback"] = lambda rack: (
         False,
         "another cavity active",
     )
 
-    with patch(_FT_MODULE, side_effect=_make_pv_factory([])):
-        result = phase._measure_pi_modes()
+    result = phase._measure_pi_modes()
 
     assert result.result == PhaseResult.FAILED
     assert "rack" in result.message.lower()
+    # Exclusivity gate fails before any scan.
+    mock_cavity.rack.run_fscan.assert_not_called()
 
 
 def test_measure_pi_modes_rack_check_callback_raises(phase, mock_cavity):
     _setup_phase(phase)
-    mock_cavity.number = 1
-    _make_rack(phase, [])
+    mock_cavity.rack.run_fscan = Mock()
     phase.context.parameters["rack_check_callback"] = Mock(
         side_effect=RuntimeError("unexpected")
     )
 
-    with patch(_FT_MODULE, side_effect=_make_pv_factory([])):
-        result = phase._measure_pi_modes()
+    result = phase._measure_pi_modes()
 
     assert result.result == PhaseResult.RETRY
+    mock_cavity.rack.run_fscan.assert_not_called()
 
 
-def test_measure_pi_modes_fscan_aborted(phase, mock_cavity):
+def test_measure_pi_modes_fscan_error_fails(phase, mock_cavity):
     _setup_phase(phase)
-    mock_cavity.number = 1
-    _make_rack(phase, [6])  # 6=scan aborted
-
-    with patch(_FT_MODULE, side_effect=_make_pv_factory([6])):
-        result = phase._measure_pi_modes()
-
+    mock_cavity.rack.run_fscan = Mock(
+        side_effect=FSCANError("scan aborted (state 6)")
+    )
+    result = phase._measure_pi_modes()
     assert result.result == PhaseResult.FAILED
-    assert "aborted" in result.message.lower() or "FSCAN" in result.message
+    assert "FSCAN" in result.message
 
 
-def test_measure_pi_modes_fscan_timeout(phase, mock_cavity):
+def test_measure_pi_modes_abort_fails(phase, mock_cavity):
     _setup_phase(phase)
-    mock_cavity.number = 1
-    phase.limits.pi_scan_timeout_seconds = 0.0  # expire immediately
-    _make_rack(phase, [])
-
-    with patch(_FT_MODULE, side_effect=_make_pv_factory([])):
-        result = phase._measure_pi_modes()
-
+    mock_cavity.rack.run_fscan = Mock(
+        side_effect=CavityAbortError("abort requested")
+    )
+    result = phase._measure_pi_modes()
     assert result.result == PhaseResult.FAILED
-    assert "did not complete" in result.message
 
 
-def test_measure_pi_modes_abort_during_wait(phase, mock_cavity):
+def test_measure_pi_modes_transient_error_retries(phase, mock_cavity):
     _setup_phase(phase)
-    mock_cavity.number = 1
-    phase.limits.pi_scan_timeout_seconds = 60.0
-    _make_rack(phase, [3])  # stays in-progress
-
-    phase.context.abort_requested = True
-
-    with patch(_FT_MODULE, side_effect=_make_pv_factory([3])):
-        result = phase._measure_pi_modes()
-
-    assert result.result == PhaseResult.FAILED
-    assert "Abort" in result.message
-
-
-def test_measure_pi_modes_sel_pv_write_error(phase, mock_cavity):
-    _setup_phase(phase)
-    mock_cavity.number = 1
-    _make_rack(phase, [])
-
-    def pv_factory(addr):
-        pv = Mock()
-        if "FSCAN:SEL" in addr:
-            pv.put.side_effect = RuntimeError("write timeout")
-        return pv
-
-    with patch(_FT_MODULE, side_effect=pv_factory):
-        result = phase._measure_pi_modes()
-
-    assert result.result == PhaseResult.RETRY
-
-
-def test_measure_pi_modes_fscan_param_write_error(phase, mock_cavity):
-    _setup_phase(phase)
-    mock_cavity.number = 1
-    _make_rack(phase, [])
-
-    def pv_factory(addr):
-        pv = Mock()
-        if "FSCAN:FREQ_START" in addr:
-            pv.put.side_effect = RuntimeError("write timeout")
-        return pv
-
-    with patch(_FT_MODULE, side_effect=pv_factory):
-        result = phase._measure_pi_modes()
-
-    assert result.result == PhaseResult.RETRY
-
-
-def test_measure_pi_modes_start_write_error(phase, mock_cavity):
-    _setup_phase(phase)
-    mock_cavity.number = 1
-    _make_rack(phase, [])
-
-    def pv_factory(addr):
-        pv = Mock()
-        if "FSCAN:START" in addr:
-            pv.put.side_effect = RuntimeError("write timeout")
-        return pv
-
-    with patch(_FT_MODULE, side_effect=pv_factory):
-        result = phase._measure_pi_modes()
-
-    assert result.result == PhaseResult.RETRY
-
-
-def test_measure_pi_modes_stat_read_error(phase, mock_cavity):
-    _setup_phase(phase)
-    mock_cavity.number = 1
-    phase.limits.pi_scan_timeout_seconds = 60.0
-    _make_rack(phase, [])
-
-    def pv_factory(addr):
-        pv = Mock()
-        if "FSCAN:STAT" in addr:
-            pv.get.side_effect = RuntimeError("read timeout")
-        return pv
-
-    with patch(_FT_MODULE, side_effect=pv_factory):
-        result = phase._measure_pi_modes()
-
-    assert result.result == PhaseResult.RETRY
-
-
-def test_measure_pi_modes_status_callback_invoked(phase, mock_cavity):
-    _setup_phase(phase)
-    mock_cavity.number = 1
-    phase.limits.pi_scan_timeout_seconds = 60.0
-    _make_rack(phase, [3, 5])
-
-    status_msgs = []
-    phase.context.parameters["status_update_callback"] = status_msgs.append
-
-    with patch(_FT_MODULE, side_effect=_make_pv_factory([3, 5])):
-        result = phase._measure_pi_modes()
-
-    assert result.result == PhaseResult.SUCCESS
-    assert any("FSCAN" in m for m in status_msgs)
-
-
-def test_measure_pi_modes_push_results_error(phase, mock_cavity):
-    _setup_phase(phase)
-    mock_cavity.number = 1
-    _make_rack(phase, [5])
-
-    def pv_factory(addr):
-        pv = Mock()
-        if "FSCAN:STAT" in addr:
-            pv.get.return_value = 5
-        elif "PUSH_8PI9" in addr:
-            pv.put.side_effect = RuntimeError("put failed")
-        return pv
-
-    with patch(_FT_MODULE, side_effect=pv_factory):
-        result = phase._measure_pi_modes()
-
+    mock_cavity.rack.run_fscan = Mock(side_effect=RuntimeError("PV timeout"))
+    result = phase._measure_pi_modes()
     assert result.result == PhaseResult.RETRY
 
 
 def test_measure_pi_modes_read_frequency_error(phase, mock_cavity):
     _setup_phase(phase)
-    mock_cavity.number = 1
-    _make_rack(phase, [5])
-
-    def pv_factory(addr):
-        pv = Mock()
-        if "FSCAN:STAT" in addr:
-            pv.get.return_value = 5
-        elif "8PI9MODE" in addr:
-            pv.get.side_effect = RuntimeError("read failed")
-        return pv
-
-    with patch(_FT_MODULE, side_effect=pv_factory):
-        result = phase._measure_pi_modes()
-
+    mock_cavity.rack.run_fscan = Mock()
+    mock_cavity.fscan_8pi9_mode_pv_obj.get.side_effect = RuntimeError(
+        "read failed"
+    )
+    result = phase._measure_pi_modes()
     assert result.result == PhaseResult.RETRY

--- a/tests/applications/rf_commissioning/phases/test_frequency_tuning.py
+++ b/tests/applications/rf_commissioning/phases/test_frequency_tuning.py
@@ -386,23 +386,23 @@ def test_apply_hz_per_step_not_measured(phase):
     assert "probe_stepper_direction" in result.message
 
 
-def test_apply_hz_per_step_writes_scale_pv(phase, mock_stepper):
+def test_apply_hz_per_step_writes_scale_calc_pv(phase, mock_stepper):
     _setup_phase(phase)
     phase._hz_per_microstep = 42.5
     result = phase._apply_hz_per_step()
     assert result.result == PhaseResult.SUCCESS
-    mock_stepper.hz_per_microstep_pv_obj.put.assert_called_once_with(42.5)
+    # SCALE is derived (read-only); the phase must write SCALE_CALC.B, not SCALE.
+    mock_stepper.set_hz_per_microstep.assert_called_once_with(42.5)
+    mock_stepper.hz_per_microstep_pv_obj.put.assert_not_called()
 
 
 def test_apply_hz_per_step_pv_error_retries(phase, mock_stepper):
     _setup_phase(phase)
     phase._hz_per_microstep = 10.0
-    mock_stepper.hz_per_microstep_pv_obj.put.side_effect = RuntimeError(
-        "timeout"
-    )
+    mock_stepper.set_hz_per_microstep.side_effect = RuntimeError("timeout")
     result = phase._apply_hz_per_step()
     assert result.result == PhaseResult.RETRY
-    assert "SCALE PV" in result.message
+    assert "SCALE_CALC.B" in result.message
 
 
 # ---------------------------------------------------------------------------

--- a/tests/applications/rf_commissioning/phases/test_frequency_tuning.py
+++ b/tests/applications/rf_commissioning/phases/test_frequency_tuning.py
@@ -20,9 +20,11 @@ from sc_linac_physics.applications.rf_commissioning.phases.phase_base import (
     PhaseResult,
 )
 from sc_linac_physics.utils.sc_linac.linac_utils import (
+    CavityAbortError,
     CavityFaultError,
     DetuneError,
     StepperError,
+    StepperTempError,
     TUNE_CONFIG_COLD_VALUE,
     TUNE_CONFIG_RESONANCE_VALUE,
 )
@@ -488,39 +490,38 @@ def test_tune_to_resonance_dry_run(context, fast_limits):
     assert result.data["dry_run"] is True
 
 
-def test_tune_to_resonance_already_at_resonance(phase, mock_cavity):
-    _setup_phase(phase)
-    mock_cavity.detune_chirp = 100.0  # within tolerance
-    result = phase._tune_to_resonance()
-    assert result.result == PhaseResult.SUCCESS
-    assert result.data["total_steps"] == 0
-
-
-def test_tune_to_resonance_converges_one_iteration(
+def test_tune_to_resonance_delegates_to_auto_tune(
     phase, mock_cavity, mock_stepper
 ):
+    # Happy path: the phase delegates the loop to Cavity._auto_tune, then
+    # reads REG_TOTSGN for NSTEPS_COLD and sets tune_config=RESONANCE.
     _setup_phase(phase)
-    mock_cavity.detune_chirp = 5000.0
-
-    def after_move(*args, **kwargs):
-        mock_cavity.detune_chirp = 100.0
-
-    mock_stepper.move.side_effect = after_move
+    mock_cavity.stepper_tuner.step_signed_pv_obj.get.return_value = 4000
 
     result = phase._tune_to_resonance()
 
     assert result.result == PhaseResult.SUCCESS
-    assert result.data["total_steps"] > 0
-    mock_stepper.move.assert_called_once()
+    mock_cavity._auto_tune.assert_called_once()
+    # max_stepper_temp defaults to the plain limit, and an iteration_callback
+    # is supplied for abort + live plot.
+    kwargs = mock_cavity._auto_tune.call_args.kwargs
+    assert kwargs["max_stepper_temp"] == phase.limits.temp_limit_c
+    assert callable(kwargs["iteration_callback"])
+    # NSTEPS_COLD = negation of the accumulated signed steps.
+    assert result.data["cold_landing_steps"] == -4000
+    mock_stepper.steps_cold_landing_pv_obj.put.assert_called_once_with(-4000)
+    mock_cavity.tune_config_pv_obj.put.assert_called_once_with(
+        TUNE_CONFIG_RESONANCE_VALUE
+    )
 
 
 def test_tune_to_resonance_fails_when_df_cold_not_recorded(phase, mock_cavity):
     # No record_cold_landing checkpoint at all.
     _setup_phase(phase, seed_cold=False)
-    mock_cavity.detune_chirp = 5000.0
     result = phase._tune_to_resonance()
     assert result.result == PhaseResult.FAILED
     assert "record_cold_landing" in result.message
+    mock_cavity._auto_tune.assert_not_called()
 
 
 def test_tune_to_resonance_fails_when_df_cold_mismatched(phase, mock_cavity):
@@ -528,175 +529,63 @@ def test_tune_to_resonance_fails_when_df_cold_mismatched(phase, mock_cavity):
     _setup_phase(phase, seed_cold=False)
     _seed_cold_landing(phase, df_cold_hz=5000.0)
     phase.cavity.df_cold_pv_obj.get.return_value = 0.0  # operator did not push
-    mock_cavity.detune_chirp = 5000.0
     result = phase._tune_to_resonance()
     assert result.result == PhaseResult.FAILED
     assert "DF_COLD not recorded" in result.message
+    mock_cavity._auto_tune.assert_not_called()
 
 
-def test_tune_to_resonance_proceeds_when_df_cold_matches(
-    phase, mock_cavity, mock_stepper
-):
-    _setup_phase(phase, seed_cold=False)
-    _seed_cold_landing(phase, df_cold_hz=5000.0)
-    mock_cavity.detune_chirp = 5000.0
-
-    def after_move(*args, **kwargs):
-        mock_cavity.detune_chirp = 100.0
-
-    mock_stepper.move.side_effect = after_move
-    result = phase._tune_to_resonance()
-    assert result.result == PhaseResult.SUCCESS
-
-
-def test_tune_to_resonance_sets_tune_config_resonance(
-    phase, mock_cavity, mock_stepper
-):
-    _setup_phase(phase)
-    mock_cavity.detune_chirp = 5000.0
-
-    def after_move(*args, **kwargs):
-        mock_cavity.detune_chirp = 100.0
-
-    mock_stepper.move.side_effect = after_move
-    result = phase._tune_to_resonance()
-    assert result.result == PhaseResult.SUCCESS
-    mock_cavity.tune_config_pv_obj.put.assert_called_once_with(
-        TUNE_CONFIG_RESONANCE_VALUE
-    )
-
-
-def test_tune_to_resonance_moves_positive_for_positive_detune(
-    phase, mock_cavity, mock_stepper
-):
-    _setup_phase(phase)
-    mock_cavity.detune_chirp = 1000.0
-
-    def after_move(*args, **kwargs):
-        mock_cavity.detune_chirp = 0.0
-
-    mock_stepper.move.side_effect = after_move
-
-    phase._tune_to_resonance()
-
-    first_step_arg = mock_stepper.move.call_args_list[0][0][0]
-    assert first_step_arg > 0
-
-
-def test_tune_to_resonance_moves_negative_for_negative_detune(
-    phase, mock_cavity, mock_stepper
-):
-    _setup_phase(phase)
-    mock_cavity.detune_chirp = -1000.0
-
-    def after_move(*args, **kwargs):
-        mock_cavity.detune_chirp = 0.0
-
-    mock_stepper.move.side_effect = after_move
-
-    phase._tune_to_resonance()
-
-    first_step_arg = mock_stepper.move.call_args_list[0][0][0]
-    assert first_step_arg < 0
-
-
-def test_tune_to_resonance_max_steps_exceeded(phase, mock_cavity):
-    _setup_phase(phase)
-    phase.limits.max_total_steps = 0
-    mock_cavity.detune_chirp = 5000.0
-    result = phase._tune_to_resonance()
-    assert result.result == PhaseResult.FAILED
-    assert "max step limit" in result.message.lower()
-
-
-def test_tune_to_resonance_over_temp_fails_without_ack(phase, mock_cavity):
-    # No automatic cool-down: an over-temp reading fails the step and flags
-    # that an operator acknowledgement is required.
+def test_tune_to_resonance_over_temp_fails_with_ack_flag(phase, mock_cavity):
+    # _auto_tune raises StepperTempError on an over-temp breach; the phase
+    # maps it to FAILED + requires_over_temp_ack for the UI to prompt.
     _setup_phase(phase)
     phase.limits.temp_limit_c = 70.0
     phase.cavity.stepper_temp_pv_obj.get.return_value = 85.0
-    mock_cavity.detune_chirp = 5000.0
+    mock_cavity._auto_tune.side_effect = StepperTempError(
+        "stepper motor temp 85.0 °C exceeds limit 70 °C"
+    )
 
     result = phase._tune_to_resonance()
     assert result.result == PhaseResult.FAILED
     assert result.data["requires_over_temp_ack"] is True
     assert result.data["stepper_temp_c"] == 85.0
     assert result.data["temp_limit_c"] == 70.0
-    assert "85" in result.message
 
 
-def test_tune_to_resonance_over_temp_proceeds_with_ack(
-    phase, mock_cavity, mock_stepper, context
+def test_tune_to_resonance_passes_ack_ceiling_and_records(
+    phase, mock_cavity, context
 ):
-    # With an acknowledgement ceiling >= the reading, tuning proceeds and the
-    # acknowledging operator is recorded.
+    # Operator-supplied over_temp_ack_c raises the ceiling passed to _auto_tune
+    # and is recorded (with the operator) on success.
     _setup_phase(phase)
     phase.limits.temp_limit_c = 70.0
     context.parameters["over_temp_ack_c"] = 90.0
-    phase.cavity.stepper_temp_pv_obj.get.return_value = 85.0
-    mock_cavity.detune_chirp = 1000.0
-
-    def after_move(*args, **kwargs):
-        mock_cavity.detune_chirp = 0.0
-
-    mock_stepper.move.side_effect = after_move
+    mock_cavity.stepper_tuner.step_signed_pv_obj.get.return_value = 1000
 
     result = phase._tune_to_resonance()
     assert result.result == PhaseResult.SUCCESS
-    assert result.data["over_temp_acknowledged_c"] == 85.0
+    assert mock_cavity._auto_tune.call_args.kwargs["max_stepper_temp"] == 90.0
+    assert result.data["over_temp_acknowledged_c"] == 90.0
     assert result.data["over_temp_acknowledged_by"] == context.operator
 
 
-def test_tune_to_resonance_hotter_breach_requires_new_ack(
-    phase, mock_cavity, mock_stepper, context
-):
-    # Ack ceiling authorizes up to 90 °C, but a later reading climbs above it
-    # → fail again for a fresh acknowledgement.
+def test_tune_to_resonance_detune_error_fails(phase, mock_cavity):
     _setup_phase(phase)
-    phase.limits.temp_limit_c = 70.0
-    context.parameters["over_temp_ack_c"] = 90.0
-
-    # (1) init read OK, (2) iter-1 = 85 (acked, proceeds), (3) iter-2 = 95 (> ceiling → fail)
-    temp_values = iter([25.0, 85.0, 95.0])
-    phase.cavity.stepper_temp_pv_obj.get.side_effect = lambda: next(temp_values)
-    mock_cavity.detune_chirp = 5000.0  # never converges, keeps looping
-
-    def after_move(*args, **kwargs):
-        pass  # detune unchanged → second iteration runs
-
-    mock_stepper.move.side_effect = after_move
-
-    result = phase._tune_to_resonance()
-    assert result.result == PhaseResult.FAILED
-    assert result.data["requires_over_temp_ack"] is True
-    assert result.data["stepper_temp_c"] == 95.0
-
-
-def test_tune_to_resonance_abort_requested(phase, mock_cavity, context):
-    _setup_phase(phase)
-    context.request_abort()
-    mock_cavity.detune_chirp = 5000.0
-    result = phase._tune_to_resonance()
-    assert result.result == PhaseResult.FAILED
-    assert "abort" in result.message.lower()
-
-
-def test_tune_to_resonance_stepper_error(phase, mock_cavity, mock_stepper):
-    _setup_phase(phase)
-    mock_cavity.detune_chirp = 1000.0
-    mock_stepper.move.side_effect = StepperError("limit switch")
+    mock_cavity._auto_tune.side_effect = DetuneError("motor moved too far")
     result = phase._tune_to_resonance()
     assert result.result == PhaseResult.FAILED
 
 
-def test_tune_to_resonance_detune_read_error_retries(phase, mock_cavity):
-    # Simulate PV read failure on temp: phase should return RETRY.
+def test_tune_to_resonance_abort_fails(phase, mock_cavity):
     _setup_phase(phase)
-    # Initial read (before loop) silently swallows errors, loop read will RETRY.
-    phase.cavity.stepper_temp_pv_obj.get.side_effect = RuntimeError(
-        "PV timeout"
-    )
-    mock_cavity.detune_chirp = 5000.0
+    mock_cavity._auto_tune.side_effect = CavityAbortError("aborted")
+    result = phase._tune_to_resonance()
+    assert result.result == PhaseResult.FAILED
+
+
+def test_tune_to_resonance_transient_error_retries(phase, mock_cavity):
+    _setup_phase(phase)
+    mock_cavity._auto_tune.side_effect = RuntimeError("PV timeout")
     result = phase._tune_to_resonance()
     assert result.result == PhaseResult.RETRY
 
@@ -707,13 +596,13 @@ def test_tune_to_resonance_missing_hz_per_microstep(phase, mock_cavity):
     result = phase._tune_to_resonance()
     assert result.result == PhaseResult.FAILED
     assert "probe_stepper_direction" in result.message
+    mock_cavity._auto_tune.assert_not_called()
 
 
 def test_tune_to_resonance_signed_step_read_error_retries(phase, mock_cavity):
-    # A failure reading the resume step count must abort with RETRY rather
-    # than silently resuming at 0 and corrupting NSTEPS_COLD.
+    # A failure reading REG_TOTSGN after tuning must RETRY rather than silently
+    # writing a corrupt NSTEPS_COLD.
     _setup_phase(phase)
-    mock_cavity.detune_chirp = 5000.0
     phase.cavity.stepper_tuner.step_signed_pv_obj.get.side_effect = (
         RuntimeError("PV timeout")
     )
@@ -721,96 +610,26 @@ def test_tune_to_resonance_signed_step_read_error_retries(phase, mock_cavity):
     assert result.result == PhaseResult.RETRY
 
 
-def test_tune_to_resonance_tracks_peak_temp(phase, mock_cavity, mock_stepper):
-    _setup_phase(phase)
-    phase.limits.temp_limit_c = 100.0
-
-    # Reads: (1) initial peak_temp, then one per loop iteration (3 iterations
-    # before detune hits tolerance), plus one final read after last move.
-    temp_values = iter([30.0, 55.0, 40.0, 25.0])
-    phase.cavity.stepper_temp_pv_obj.get.side_effect = lambda: next(temp_values)
-
-    detunes = [2000.0, 1000.0, 100.0]
-    move_count = [0]
-
-    def after_move(*args, **kwargs):
-        move_count[0] += 1
-        mock_cavity.detune_chirp = detunes[move_count[0]]
-
-    mock_cavity.detune_chirp = detunes[0]
-    mock_stepper.move.side_effect = after_move
-
-    result = phase._tune_to_resonance()
-    assert result.result == PhaseResult.SUCCESS
-    assert "total_steps" in result.data
-
-
-def test_tune_to_resonance_writes_nsteps_cold(phase, mock_cavity, mock_stepper):
-    _setup_phase(phase)
-    mock_cavity.detune_chirp = 1000.0
-
-    def after_move(*args, **kwargs):
-        mock_cavity.detune_chirp = 0.0
-
-    mock_stepper.move.side_effect = after_move
-
-    result = phase._tune_to_resonance()
-
-    assert result.result == PhaseResult.SUCCESS
-    # cold_landing_steps in data should be the negated signed total
-    assert "cold_landing_steps" in result.data
-    assert result.data["cold_landing_steps"] == -result.data["total_steps"]
-    mock_stepper.steps_cold_landing_pv_obj.put.assert_called_once_with(
-        result.data["cold_landing_steps"]
-    )
-
-
-def test_tune_to_resonance_accumulates_steps_across_restarts(
-    phase, mock_cavity, mock_stepper
-):
-    """NSTEPS_COLD must reflect total steps from cold landing, not just this run."""
-    prior_steps = -500_000
-    _setup_phase(phase, initial_signed_steps=prior_steps)
-    mock_cavity.detune_chirp = 1000.0
-
-    def after_move(*args, **kwargs):
-        mock_cavity.detune_chirp = 0.0
-
-    mock_stepper.move.side_effect = after_move
-
-    result = phase._tune_to_resonance()
-
-    assert result.result == PhaseResult.SUCCESS
-    cold_landing_steps = result.data["cold_landing_steps"]
-    total_steps_this_run = result.data["total_steps"]
-    # cold_landing_steps = -(prior_signed_offset + signed_steps_this_run).
-    # Its magnitude must exceed what this run contributed alone, proving the
-    # prior accumulated offset was preserved rather than reset to zero.
-    assert (
-        abs(cold_landing_steps) > total_steps_this_run
-    ), "cold_landing_steps must reflect steps from prior (aborted) runs"
-    mock_stepper.steps_cold_landing_pv_obj.put.assert_called_once_with(
-        cold_landing_steps
-    )
-
-
 def test_tune_to_resonance_nsteps_cold_write_error(
     phase, mock_cavity, mock_stepper
 ):
     _setup_phase(phase)
-    mock_cavity.detune_chirp = 1000.0
-
-    def after_move(*args, **kwargs):
-        mock_cavity.detune_chirp = 0.0
-
-    mock_stepper.move.side_effect = after_move
+    mock_cavity.stepper_tuner.step_signed_pv_obj.get.return_value = 4000
     mock_stepper.steps_cold_landing_pv_obj.put.side_effect = RuntimeError(
         "PV timeout"
     )
-
     result = phase._tune_to_resonance()
     assert result.result == PhaseResult.RETRY
     assert "NSTEPS_COLD" in result.message
+
+
+def test_tuning_iteration_hook_raises_on_abort(phase, mock_cavity, context):
+    # The per-iteration hook surfaces the abort flag as an exception so
+    # _auto_tune's loop unwinds.
+    _setup_phase(phase)
+    context.request_abort()
+    with pytest.raises(CavityAbortError):
+        phase._tuning_iteration_hook()
 
 
 # ---------------------------------------------------------------------------
@@ -1196,37 +1015,3 @@ def test_measure_pi_modes_read_frequency_error(phase, mock_cavity):
         result = phase._measure_pi_modes()
 
     assert result.result == PhaseResult.RETRY
-
-
-# ---------------------------------------------------------------------------
-# _initialize_tuning_state — lazy PV init
-# ---------------------------------------------------------------------------
-
-
-def test_initialize_tuning_state_reads_stepper_signed_pv(
-    phase, mock_cavity, mock_stepper
-):
-    """Signed step count is read from the stepper's step_signed_pv_obj."""
-    _setup_phase(phase)
-    mock_stepper.step_signed_pv_obj.get.return_value = -200_000
-
-    total, signed, peak, err = phase._initialize_tuning_state(None)
-
-    assert signed == -200_000
-    assert err is None
-
-
-def test_initialize_tuning_state_pv_read_error_returns_retry(
-    phase, mock_cavity, mock_stepper
-):
-    """A PV read exception during init must surface a RETRY, not default to 0.
-
-    Silently resuming at 0 would corrupt the NSTEPS_COLD return-trip value.
-    """
-    _setup_phase(phase)
-    mock_stepper.step_signed_pv_obj.get.side_effect = RuntimeError("read error")
-
-    total, signed, peak, err = phase._initialize_tuning_state(None)
-    assert signed == 0
-    assert err is not None
-    assert err.result == PhaseResult.RETRY

--- a/tests/applications/rf_commissioning/phases/test_frequency_tuning.py
+++ b/tests/applications/rf_commissioning/phases/test_frequency_tuning.py
@@ -82,8 +82,6 @@ def fast_limits():
         max_total_steps=10_000,
         cool_down_retries=2,
         cool_down_interval=0.0,
-        motor_start_wait=0.0,
-        motor_poll_interval=0.0,
     )
 
 
@@ -559,6 +557,16 @@ def test_tune_to_resonance_missing_hz_per_microstep(phase, mock_cavity):
     result = phase._tune_to_resonance()
     assert result.result == PhaseResult.FAILED
     assert "probe_stepper_direction" in result.message
+
+
+def test_tune_to_resonance_signed_step_read_error_retries(phase, mock_cavity):
+    # A failure reading the resume step count must abort with RETRY rather
+    # than silently resuming at 0 and corrupting NSTEPS_COLD.
+    _setup_phase(phase)
+    mock_cavity.detune_chirp = 5000.0
+    phase._step_signed_pv_obj.get.side_effect = RuntimeError("PV timeout")
+    result = phase._tune_to_resonance()
+    assert result.result == PhaseResult.RETRY
 
 
 def test_tune_to_resonance_tracks_peak_temp(phase, mock_cavity, mock_stepper):
@@ -1051,19 +1059,25 @@ def test_initialize_tuning_state_creates_pv_when_none(
     mock_pv.get.return_value = -200_000
 
     with patch(_FT_MODULE, return_value=mock_pv):
-        total, signed, peak = phase._initialize_tuning_state(None)
+        total, signed, peak, err = phase._initialize_tuning_state(None)
 
     assert signed == -200_000
+    assert err is None
     assert phase._step_signed_pv_obj is mock_pv
 
 
-def test_initialize_tuning_state_pv_read_error_defaults_zero(
+def test_initialize_tuning_state_pv_read_error_returns_retry(
     phase, mock_cavity, mock_stepper
 ):
-    """A PV read exception during init should silently yield signed_total=0."""
+    """A PV read exception during init must surface a RETRY, not default to 0.
+
+    Silently resuming at 0 would corrupt the NSTEPS_COLD return-trip value.
+    """
     _setup_phase(phase)
     phase._step_signed_pv_obj = Mock()
     phase._step_signed_pv_obj.get.side_effect = RuntimeError("read error")
 
-    total, signed, peak = phase._initialize_tuning_state(None)
+    total, signed, peak, err = phase._initialize_tuning_state(None)
     assert signed == 0
+    assert err is not None
+    assert err.result == PhaseResult.RETRY

--- a/tests/applications/rf_commissioning/phases/test_frequency_tuning.py
+++ b/tests/applications/rf_commissioning/phases/test_frequency_tuning.py
@@ -20,6 +20,8 @@ from sc_linac_physics.applications.rf_commissioning.phases.phase_base import (
     PhaseResult,
 )
 from sc_linac_physics.utils.sc_linac.linac_utils import (
+    CavityFaultError,
+    DetuneError,
     StepperError,
     TUNE_CONFIG_COLD_VALUE,
     TUNE_CONFIG_RESONANCE_VALUE,
@@ -58,6 +60,7 @@ def mock_cavity(mock_stepper):
     cavity.stepper_temp_pv = "ACCL:L1B:0210:STEPTEMP"
     cavity.detune_invalid = False
     cavity.detune_chirp = 5000.0
+    cavity.is_online = True
     # Cavities launch at cold landing (COLD == 1).
     cavity.tune_config_pv_obj.get.return_value = TUNE_CONFIG_COLD_VALUE
     return cavity
@@ -212,6 +215,8 @@ def test_verify_initial_state_motor_already_moving(phase, mock_stepper):
     result = phase._verify_initial_state()
     assert result.result == PhaseResult.FAILED
     assert "moving" in result.message.lower()
+    # Guard fails before any cavity preparation.
+    phase.cavity.setup_tuning.assert_not_called()
 
 
 def test_verify_initial_state_on_limit_switch(phase, mock_stepper):
@@ -220,14 +225,32 @@ def test_verify_initial_state_on_limit_switch(phase, mock_stepper):
     result = phase._verify_initial_state()
     assert result.result == PhaseResult.FAILED
     assert "limit switch" in result.message.lower()
+    phase.cavity.setup_tuning.assert_not_called()
 
 
-def test_verify_initial_state_detune_invalid(phase, mock_cavity):
+def test_verify_initial_state_offline_fails(phase, mock_cavity):
     _setup_phase(phase)
-    mock_cavity.detune_invalid = True
+    mock_cavity.is_online = False
     result = phase._verify_initial_state()
     assert result.result == PhaseResult.FAILED
-    assert "chirp" in result.message.lower()
+    assert "online" in result.message.lower()
+    mock_cavity.setup_tuning.assert_not_called()
+
+
+def test_verify_initial_state_detune_error_fails(phase, mock_cavity):
+    _setup_phase(phase)
+    mock_cavity.setup_tuning.side_effect = DetuneError("no valid detune")
+    result = phase._verify_initial_state()
+    assert result.result == PhaseResult.FAILED
+    assert "detune" in result.message.lower()
+
+
+def test_verify_initial_state_fault_error_fails(phase, mock_cavity):
+    _setup_phase(phase)
+    mock_cavity.reset_interlocks.side_effect = CavityFaultError("still faulted")
+    result = phase._verify_initial_state()
+    assert result.result == PhaseResult.FAILED
+    assert "fault" in result.message.lower()
 
 
 def test_verify_initial_state_read_exception_retries(phase, mock_cavity):
@@ -246,6 +269,11 @@ def test_verify_initial_state_success(phase, mock_cavity):
     assert result.result == PhaseResult.SUCCESS
     assert result.data["initial_temp_c"] == 30.0
     assert "initial_detune_hz" in result.data
+    # The cavity was prepared for tuning (production sequence).
+    mock_cavity.turn_off.assert_called_once()
+    mock_cavity.ssa.turn_on.assert_called_once()
+    mock_cavity.reset_interlocks.assert_called_once()
+    mock_cavity.setup_tuning.assert_called_once()
     # COLD start → no warning
     assert result.data["tune_config_warning"] is None
     assert "WARNING" not in result.message

--- a/tests/applications/rf_commissioning/phases/test_frequency_tuning.py
+++ b/tests/applications/rf_commissioning/phases/test_frequency_tuning.py
@@ -372,12 +372,15 @@ def test_probe_stepper_direction_positive_decreases_frequency(
 def test_probe_stepper_direction_delta_too_small(
     phase, mock_cavity, mock_stepper
 ):
+    # A change below min_probe_delta_hz (default 100 Hz) fails — a 50 Hz probe
+    # response is treated as a degraded/uncoupled stepper, not a valid measurement.
+    assert phase.limits.min_probe_delta_hz == 100.0
     _setup_phase(phase)
     mock_cavity.detune_chirp = 1000.0
 
     def after_move(steps, *args, **kwargs):
         if steps > 0:
-            mock_cavity.detune_chirp = 1001.0  # barely any change
+            mock_cavity.detune_chirp = 1050.0  # only 50 Hz — below the floor
 
     mock_stepper.move.side_effect = after_move
 

--- a/tests/applications/rf_commissioning/phases/test_frequency_tuning.py
+++ b/tests/applications/rf_commissioning/phases/test_frequency_tuning.py
@@ -532,7 +532,7 @@ def test_tune_to_resonance_fails_when_df_cold_mismatched(phase, mock_cavity):
     phase.cavity.df_cold_pv_obj.get.return_value = 0.0  # operator did not push
     result = phase._tune_to_resonance()
     assert result.result == PhaseResult.FAILED
-    assert "DF_COLD not recorded" in result.message
+    assert "DF_COLD does not match" in result.message
     mock_cavity._auto_tune.assert_not_called()
 
 

--- a/tests/applications/rf_commissioning/phases/test_frequency_tuning.py
+++ b/tests/applications/rf_commissioning/phases/test_frequency_tuning.py
@@ -21,6 +21,8 @@ from sc_linac_physics.applications.rf_commissioning.phases.phase_base import (
 )
 from sc_linac_physics.utils.sc_linac.linac_utils import (
     StepperError,
+    TUNE_CONFIG_COLD_VALUE,
+    TUNE_CONFIG_RESONANCE_VALUE,
 )
 
 # ---------------------------------------------------------------------------
@@ -56,6 +58,8 @@ def mock_cavity(mock_stepper):
     cavity.stepper_temp_pv = "ACCL:L1B:0210:STEPTEMP"
     cavity.detune_invalid = False
     cavity.detune_chirp = 5000.0
+    # Cavities launch at cold landing (COLD == 1).
+    cavity.tune_config_pv_obj.get.return_value = TUNE_CONFIG_COLD_VALUE
     return cavity
 
 
@@ -91,7 +95,24 @@ def phase(context, fast_limits):
     return p
 
 
-def _setup_phase(phase, temp_c=25.0, initial_signed_steps=0):
+def _seed_cold_landing(phase, df_cold_hz=5000.0):
+    """Record a cold-landing checkpoint and make DF_COLD read back matching it,
+    so the DF_COLD gate in _tune_to_resonance is satisfied."""
+    phase.context.record.phase_history.append(
+        PhaseCheckpoint(
+            phase=phase.phase_type,
+            timestamp=datetime.now(),
+            operator="test_op",
+            step_name="record_cold_landing",
+            success=True,
+            measurements={"df_cold_hz": df_cold_hz},
+        )
+    )
+    phase._df_cold_pv_obj = Mock()
+    phase._df_cold_pv_obj.get.return_value = df_cold_hz
+
+
+def _setup_phase(phase, temp_c=25.0, initial_signed_steps=0, seed_cold=True):
     """Call validate_prerequisites and inject pre-built PV mocks."""
     phase.validate_prerequisites()
     phase._stepper_temp_pv_obj = Mock()
@@ -101,6 +122,9 @@ def _setup_phase(phase, temp_c=25.0, initial_signed_steps=0):
     phase._step_signed_pv_obj = Mock()
     phase._step_signed_pv_obj.get.return_value = initial_signed_steps
     phase._hz_per_microstep = 2.0
+    # Satisfy the DF_COLD gate for tune_to_resonance tests by default.
+    if seed_cold:
+        _seed_cold_landing(phase)
     return phase
 
 
@@ -217,12 +241,28 @@ def test_verify_initial_state_read_exception_retries(phase, mock_cavity):
     assert result.result == PhaseResult.RETRY
 
 
-def test_verify_initial_state_success(phase):
+def test_verify_initial_state_success(phase, mock_cavity):
     _setup_phase(phase, temp_c=30.0)
+    mock_cavity.tune_config_pv_obj.get.return_value = TUNE_CONFIG_COLD_VALUE
     result = phase._verify_initial_state()
     assert result.result == PhaseResult.SUCCESS
     assert result.data["initial_temp_c"] == 30.0
     assert "initial_detune_hz" in result.data
+    # COLD start → no warning
+    assert result.data["tune_config_warning"] is None
+    assert "WARNING" not in result.message
+
+
+def test_verify_initial_state_warns_when_not_cold(phase, mock_cavity):
+    _setup_phase(phase, temp_c=30.0)
+    mock_cavity.tune_config_pv_obj.get.return_value = (
+        TUNE_CONFIG_RESONANCE_VALUE
+    )
+    result = phase._verify_initial_state()
+    # Not fatal — still SUCCESS, but flagged.
+    assert result.result == PhaseResult.SUCCESS
+    assert result.data["tune_config_warning"] is not None
+    assert "WARNING" in result.message
 
 
 # ---------------------------------------------------------------------------
@@ -246,7 +286,7 @@ def test_record_cold_landing_success(phase, mock_cavity):
     assert result.result == PhaseResult.SUCCESS
     assert "hz_per_microstep" not in result.data
     assert "cold_landing_steps" not in result.data
-    assert result.data["initial_detune_hz"] == 8000.0
+    assert result.data["df_cold_hz"] == 8000.0
     assert "initial_timestamp" in result.data
     # DF_COLD is written by the operator via the UI button, not auto-written here.
     phase._df_cold_pv_obj.put.assert_not_called()
@@ -443,6 +483,58 @@ def test_tune_to_resonance_converges_one_iteration(
     assert result.result == PhaseResult.SUCCESS
     assert result.data["total_steps"] > 0
     mock_stepper.move.assert_called_once()
+
+
+def test_tune_to_resonance_fails_when_df_cold_not_recorded(phase, mock_cavity):
+    # No record_cold_landing checkpoint at all.
+    _setup_phase(phase, seed_cold=False)
+    mock_cavity.detune_chirp = 5000.0
+    result = phase._tune_to_resonance()
+    assert result.result == PhaseResult.FAILED
+    assert "record_cold_landing" in result.message
+
+
+def test_tune_to_resonance_fails_when_df_cold_mismatched(phase, mock_cavity):
+    # Cold landing was recorded, but DF_COLD PV was never pushed to match it.
+    _setup_phase(phase, seed_cold=False)
+    _seed_cold_landing(phase, df_cold_hz=5000.0)
+    phase._df_cold_pv_obj.get.return_value = 0.0  # operator did not push
+    mock_cavity.detune_chirp = 5000.0
+    result = phase._tune_to_resonance()
+    assert result.result == PhaseResult.FAILED
+    assert "DF_COLD not recorded" in result.message
+
+
+def test_tune_to_resonance_proceeds_when_df_cold_matches(
+    phase, mock_cavity, mock_stepper
+):
+    _setup_phase(phase, seed_cold=False)
+    _seed_cold_landing(phase, df_cold_hz=5000.0)
+    mock_cavity.detune_chirp = 5000.0
+
+    def after_move(*args, **kwargs):
+        mock_cavity.detune_chirp = 100.0
+
+    mock_stepper.move.side_effect = after_move
+    result = phase._tune_to_resonance()
+    assert result.result == PhaseResult.SUCCESS
+
+
+def test_tune_to_resonance_sets_tune_config_resonance(
+    phase, mock_cavity, mock_stepper
+):
+    _setup_phase(phase)
+    mock_cavity.detune_chirp = 5000.0
+
+    def after_move(*args, **kwargs):
+        mock_cavity.detune_chirp = 100.0
+
+    mock_stepper.move.side_effect = after_move
+    result = phase._tune_to_resonance()
+    assert result.result == PhaseResult.SUCCESS
+    mock_cavity.tune_config_pv_obj.put.assert_called_once_with(
+        TUNE_CONFIG_RESONANCE_VALUE
+    )
 
 
 def test_tune_to_resonance_moves_positive_for_positive_detune(
@@ -685,7 +777,7 @@ def _make_checkpoint(phase_type, step_name, measurements):
 
 
 def test_finalize_phase_populates_frequency_tuning_data(phase, record):
-    _setup_phase(phase)
+    _setup_phase(phase, seed_cold=False)
     phase._history_start = 0
 
     record.phase_history.extend(
@@ -694,7 +786,7 @@ def test_finalize_phase_populates_frequency_tuning_data(phase, record):
                 CommissioningPhase.FREQUENCY_TUNING,
                 "record_cold_landing",
                 {
-                    "initial_detune_hz": 8000.0,
+                    "df_cold_hz": 8000.0,
                     "initial_timestamp": datetime.now().isoformat(),
                 },
             ),
@@ -724,7 +816,7 @@ def test_finalize_phase_populates_frequency_tuning_data(phase, record):
 
     ft = record.frequency_tuning
     assert ft is not None
-    assert ft.initial_detune_hz == 8000.0
+    assert ft.df_cold_hz == 8000.0
     assert ft.steps_to_resonance == 4000
     assert ft.positive_step_increases_frequency is True
     assert ft.hz_per_microstep == 2.0
@@ -734,14 +826,14 @@ def test_finalize_phase_populates_frequency_tuning_data(phase, record):
 
 
 def test_finalize_phase_no_checkpoints_creates_defaults(phase, record):
-    _setup_phase(phase)
+    _setup_phase(phase, seed_cold=False)
     phase._history_start = 0
 
     phase.finalize_phase()
 
     ft = record.frequency_tuning
     assert ft is not None
-    assert ft.initial_detune_hz is None
+    assert ft.df_cold_hz is None
     assert ft.steps_to_resonance is None
     assert ft.positive_step_increases_frequency is None
 

--- a/tests/applications/tuning/test_tune_stepper.py
+++ b/tests/applications/tuning/test_tune_stepper.py
@@ -26,7 +26,6 @@ def stepper(mock_cavity):
         stepper_instance.cavity = mock_cavity
         stepper_instance._steps_cold_landing_pv_obj = None
         stepper_instance._nsteps_park_pv_obj = None
-        stepper_instance._nsteps_cold_pv_obj = None
         stepper_instance._step_signed_pv_obj = None
         stepper_instance._park_steps = None
         # Mock the hz_per_microstep PV object with a default value
@@ -35,83 +34,34 @@ def stepper(mock_cavity):
 
 
 class TestPropertyLazyLoading:
-    """Test lazy loading of PV objects."""
+    """Test lazy loading of TuneStepper-specific PV objects.
 
-    def test_steps_cold_landing_pv_obj_lazy_load(self, stepper):
-        """Test that steps_cold_landing_pv_obj is created on first access."""
+    (steps_cold_landing_pv_obj and step_signed_pv_obj are inherited from the
+    base StepperTuner and covered in tests/utils/sc_linac/test_stepper.py.)
+    """
+
+    def test_nsteps_park_pv_obj_lazy_load(self, stepper):
+        """Test that nsteps_park_pv_obj is created on first access."""
         with patch(
             "sc_linac_physics.applications.tuning.tune_stepper.PV"
         ) as mock_pv:
             mock_pv_instance = make_mock_pv()
             mock_pv.return_value = mock_pv_instance
-            stepper.steps_cold_landing_pv = "TEST:STEPS:COLD"
-            stepper._steps_cold_landing_pv_obj = (
-                None  # Reset to test lazy loading
-            )
+            stepper.nsteps_park_pv = "TEST:NSTEPS:PARK"
+            stepper._nsteps_park_pv_obj = None  # Reset to test lazy loading
 
-            result = stepper.steps_cold_landing_pv_obj
+            result = stepper.nsteps_park_pv_obj
 
-            mock_pv.assert_called_once_with("TEST:STEPS:COLD")
+            mock_pv.assert_called_once_with("TEST:NSTEPS:PARK")
             assert result == mock_pv_instance
 
-    def test_steps_cold_landing_pv_obj_cached(self, stepper):
-        """Test that subsequent accesses use cached PV object."""
+    def test_nsteps_park_pv_obj_cached(self, stepper):
+        """Test that nsteps_park_pv_obj is cached."""
         mock_pv = make_mock_pv()
-        stepper._steps_cold_landing_pv_obj = mock_pv
+        stepper._nsteps_park_pv_obj = mock_pv
 
-        result1 = stepper.steps_cold_landing_pv_obj
-        result2 = stepper.steps_cold_landing_pv_obj
-
-        assert result1 is result2
-        assert result1 == mock_pv
-
-    def test_nsteps_cold_pv_obj_lazy_load(self, stepper):
-        """Test that nsteps_cold_pv_obj is created on first access."""
-        with patch(
-            "sc_linac_physics.applications.tuning.tune_stepper.PV"
-        ) as mock_pv:
-            mock_pv_instance = make_mock_pv()
-            mock_pv.return_value = mock_pv_instance
-            stepper.nsteps_cold_pv = "TEST:NSTEPS:COLD"
-            stepper._nsteps_cold_pv_obj = None  # Reset to test lazy loading
-
-            result = stepper.nsteps_cold_pv_obj
-
-            mock_pv.assert_called_once_with("TEST:NSTEPS:COLD")
-            assert result == mock_pv_instance
-
-    def test_nsteps_cold_pv_obj_cached(self, stepper):
-        """Test that nsteps_cold_pv_obj is cached."""
-        mock_pv = make_mock_pv()
-        stepper._nsteps_cold_pv_obj = mock_pv
-
-        result1 = stepper.nsteps_cold_pv_obj
-        result2 = stepper.nsteps_cold_pv_obj
-
-        assert result1 is result2
-
-    def test_step_signed_pv_obj_lazy_load(self, stepper):
-        """Test that step_signed_pv_obj is created on first access."""
-        with patch(
-            "sc_linac_physics.applications.tuning.tune_stepper.PV"
-        ) as mock_pv:
-            mock_pv_instance = make_mock_pv()
-            mock_pv.return_value = mock_pv_instance
-            stepper.step_signed_pv = "TEST:STEP:SIGNED"
-            stepper._step_signed_pv_obj = None  # Reset to test lazy loading
-
-            result = stepper.step_signed_pv_obj
-
-            mock_pv.assert_called_once_with("TEST:STEP:SIGNED")
-            assert result == mock_pv_instance
-
-    def test_step_signed_pv_obj_cached(self, stepper):
-        """Test that step_signed_pv_obj is cached."""
-        mock_pv = make_mock_pv()
-        stepper._step_signed_pv_obj = mock_pv
-
-        result1 = stepper.step_signed_pv_obj
-        result2 = stepper.step_signed_pv_obj
+        result1 = stepper.nsteps_park_pv_obj
+        result2 = stepper.nsteps_park_pv_obj
 
         assert result1 is result2
 
@@ -164,7 +114,9 @@ class TestMoveToColdLanding:
     def test_move_to_cold_landing_positive_steps(self, stepper):
         """Test moving to cold landing with positive steps."""
         expected_steps = randint(1000, 50000)
-        stepper._nsteps_cold_pv_obj = make_mock_pv(get_val=expected_steps)
+        stepper._steps_cold_landing_pv_obj = make_mock_pv(
+            get_val=expected_steps
+        )
         stepper.move = MagicMock()
 
         stepper.move_to_cold_landing()
@@ -179,7 +131,9 @@ class TestMoveToColdLanding:
     def test_move_to_cold_landing_negative_steps(self, stepper):
         """Test moving to cold landing with negative steps."""
         expected_steps = randint(-50000, -1000)
-        stepper._nsteps_cold_pv_obj = make_mock_pv(get_val=expected_steps)
+        stepper._steps_cold_landing_pv_obj = make_mock_pv(
+            get_val=expected_steps
+        )
         stepper.move = MagicMock()
 
         stepper.move_to_cold_landing()
@@ -194,7 +148,9 @@ class TestMoveToColdLanding:
     def test_move_to_cold_landing_with_check_detune(self, stepper):
         """Test that check_detune parameter is passed correctly."""
         expected_steps = 5000
-        stepper._nsteps_cold_pv_obj = make_mock_pv(get_val=expected_steps)
+        stepper._steps_cold_landing_pv_obj = make_mock_pv(
+            get_val=expected_steps
+        )
         stepper.move = MagicMock()
 
         stepper.move_to_cold_landing(check_detune=True)
@@ -209,7 +165,9 @@ class TestMoveToColdLanding:
     def test_move_to_cold_landing_logs_status(self, stepper, mock_cavity):
         """Test that status message is logged."""
         expected_steps = 5000
-        stepper._nsteps_cold_pv_obj = make_mock_pv(get_val=expected_steps)
+        stepper._steps_cold_landing_pv_obj = make_mock_pv(
+            get_val=expected_steps
+        )
         stepper.move = MagicMock()
 
         stepper.move_to_cold_landing(check_detune=True)
@@ -311,7 +269,7 @@ class TestEdgeCases:
 
     def test_move_to_cold_landing_with_zero_steps(self, stepper):
         """Test moving to cold landing with zero steps."""
-        stepper._nsteps_cold_pv_obj = make_mock_pv(get_val=0)
+        stepper._steps_cold_landing_pv_obj = make_mock_pv(get_val=0)
         stepper.move = MagicMock()
 
         stepper.move_to_cold_landing()

--- a/tests/utils/sc_linac/test_cavity.py
+++ b/tests/utils/sc_linac/test_cavity.py
@@ -101,6 +101,32 @@ def test_microsteps_per_hz(cavity):
     assert cavity.microsteps_per_hz == 1 / cavity.stepper_tuner.hz_per_microstep
 
 
+def test_stepper_temp_pv_obj_lazy_and_cached(cavity):
+    assert cavity._stepper_temp_pv_obj is None
+    mock_pv = make_mock_pv()
+    with patch(
+        "sc_linac_physics.utils.sc_linac.cavity.PV", return_value=mock_pv
+    ) as pv_ctor:
+        first = cavity.stepper_temp_pv_obj
+        second = cavity.stepper_temp_pv_obj
+    assert first is mock_pv
+    assert second is mock_pv
+    pv_ctor.assert_called_once_with(cavity.stepper_temp_pv)
+
+
+def test_df_cold_pv_obj_lazy_and_cached(cavity):
+    assert cavity._df_cold_pv_obj is None
+    mock_pv = make_mock_pv()
+    with patch(
+        "sc_linac_physics.utils.sc_linac.cavity.PV", return_value=mock_pv
+    ) as pv_ctor:
+        first = cavity.df_cold_pv_obj
+        second = cavity.df_cold_pv_obj
+    assert first is mock_pv
+    assert second is mock_pv
+    pv_ctor.assert_called_once_with(cavity.df_cold_pv)
+
+
 def test_start_characterization(cavity):
     cavity._characterization_start_pv_obj = make_mock_pv()
     cavity.start_characterization()

--- a/tests/utils/sc_linac/test_cavity.py
+++ b/tests/utils/sc_linac/test_cavity.py
@@ -128,6 +128,29 @@ def test_df_cold_pv_obj_lazy_and_cached(cavity):
     pv_ctor.assert_called_once_with(cavity.df_cold_pv)
 
 
+@pytest.mark.parametrize(
+    "prop_name, addr_attr",
+    [
+        ("fscan_sel_pv_obj", "fscan_sel_pv"),
+        ("fscan_8pi9_mode_pv_obj", "fscan_8pi9_mode_pv"),
+        ("fscan_7pi9_mode_pv_obj", "fscan_7pi9_mode_pv"),
+        ("fscan_push_8pi9_pv_obj", "fscan_push_8pi9_pv"),
+        ("fscan_push_7pi9_pv_obj", "fscan_push_7pi9_pv"),
+    ],
+)
+def test_cavity_fscan_pv_obj_lazy_and_cached(cavity, prop_name, addr_attr):
+    assert getattr(cavity, f"_{prop_name}") is None
+    mock_pv = make_mock_pv()
+    with patch(
+        "sc_linac_physics.utils.sc_linac.cavity.PV", return_value=mock_pv
+    ) as pv_ctor:
+        first = getattr(cavity, prop_name)
+        second = getattr(cavity, prop_name)
+    assert first is mock_pv
+    assert second is mock_pv
+    pv_ctor.assert_called_once_with(getattr(cavity, addr_attr))
+
+
 def test_start_characterization(cavity):
     cavity._characterization_start_pv_obj = make_mock_pv()
     cavity.start_characterization()

--- a/tests/utils/sc_linac/test_cavity.py
+++ b/tests/utils/sc_linac/test_cavity.py
@@ -40,6 +40,7 @@ from sc_linac_physics.utils.sc_linac.linac_utils import (
     CavityCharacterizationError,
     QuenchError,
     ALL_CRYOMODULES,
+    StepperTempError,
 )
 from sc_linac_physics.utils.sc_linac.piezo import Piezo
 from tests.mock_utils import mock_func
@@ -564,6 +565,36 @@ def test__auto_tune_out_of_tol(cavity):
     cavity._auto_tune(delta_hz_func=mock_detune.mock_detune)
     cavity.stepper_tuner.move.assert_called()
     assert mock_detune.num_calls == 2
+
+
+def test__auto_tune_over_temp_raises(cavity):
+    cavity._rf_mode_pv_obj = make_mock_pv(get_val=RF_MODE_CHIRP)
+    cavity._detune_chirp_pv_obj = make_mock_pv(severity=EPICS_NO_ALARM_VAL)
+    cavity._tune_config_pv_obj = make_mock_pv(get_val=HW_MODE_ONLINE_VALUE)
+    cavity.stepper_tuner.move = MagicMock()
+    cavity._stepper_temp_pv_obj = make_mock_pv(get_val=85.0)
+
+    with pytest.raises(StepperTempError):
+        cavity._auto_tune(delta_hz_func=lambda: 5000, max_stepper_temp=70)
+    # Over-temp caught before moving.
+    cavity.stepper_tuner.move.assert_not_called()
+
+
+def test__auto_tune_iteration_callback_invoked(cavity):
+    cavity._rf_mode_pv_obj = make_mock_pv(get_val=RF_MODE_CHIRP)
+    cavity._detune_chirp_pv_obj = make_mock_pv(severity=EPICS_NO_ALARM_VAL)
+    cavity._tune_config_pv_obj = make_mock_pv(get_val=HW_MODE_ONLINE_VALUE)
+    cavity.stepper_tuner.move = MagicMock()
+    cavity._stepper_temp_pv_obj = make_mock_pv(get_val=25.0)
+    mock_detune = MockDetune()
+    calls = []
+
+    cavity._auto_tune(
+        delta_hz_func=mock_detune.mock_detune,
+        iteration_callback=lambda: calls.append(1),
+        max_stepper_temp=70,
+    )
+    assert len(calls) >= 1
 
 
 def test_check_detune(cavity):

--- a/tests/utils/sc_linac/test_rack.py
+++ b/tests/utils/sc_linac/test_rack.py
@@ -1,0 +1,159 @@
+from unittest.mock import Mock, patch
+
+import pytest
+from lcls_tools.common.controls.pyepics.utils import make_mock_pv
+
+from sc_linac_physics.utils.sc_linac.linac import MACHINE
+from sc_linac_physics.utils.sc_linac.linac_utils import (
+    CavityAbortError,
+    FSCANError,
+)
+
+_FSCAN_STAT_DONE = 5
+_FSCAN_STAT_ABORTED = 6
+_FSCAN_STAT_RESTORE_FAIL = 7
+
+
+@pytest.fixture
+def rack():
+    # Rack A of CM01 (cavities 1-4).
+    return MACHINE.cryomodules["01"].cavities[1].rack
+
+
+@pytest.mark.parametrize(
+    "prop_name, addr_attr",
+    [
+        ("fscan_freq_start_pv_obj", "fscan_freq_start_pv"),
+        ("fscan_freq_stop_pv_obj", "fscan_freq_stop_pv"),
+        ("fscan_rms_thresh_pv_obj", "fscan_rms_thresh_pv"),
+        ("fscan_mode_overlap_pv_obj", "fscan_mode_overlap_pv"),
+        ("fscan_start_pv_obj", "fscan_start_pv"),
+        ("fscan_stat_pv_obj", "fscan_stat_pv"),
+    ],
+)
+def test_rack_fscan_pv_obj_lazy_and_cached(rack, prop_name, addr_attr):
+    setattr(rack, f"_{prop_name}", None)
+    mock_pv = make_mock_pv()
+    with patch(
+        "sc_linac_physics.utils.sc_linac.rack.PV", return_value=mock_pv
+    ) as pv_ctor:
+        first = getattr(rack, prop_name)
+        second = getattr(rack, prop_name)
+    assert first is mock_pv
+    assert second is mock_pv
+    pv_ctor.assert_called_once_with(getattr(rack, addr_attr))
+
+
+def _wire_fscan_pvs(rack, stat_sequence):
+    """Give the rack mock FSCAN PVs; STAT replays stat_sequence."""
+    stat_iter = iter(stat_sequence)
+    rack._fscan_freq_start_pv_obj = make_mock_pv()
+    rack._fscan_freq_stop_pv_obj = make_mock_pv()
+    rack._fscan_rms_thresh_pv_obj = make_mock_pv()
+    rack._fscan_mode_overlap_pv_obj = make_mock_pv()
+    rack._fscan_start_pv_obj = make_mock_pv()
+    stat_pv = make_mock_pv()
+    stat_pv.get.side_effect = lambda: next(stat_iter)
+    rack._fscan_stat_pv_obj = stat_pv
+
+
+def _mock_cavity(number):
+    cav = Mock()
+    cav.number = number
+    cav.fscan_sel_pv_obj = make_mock_pv()
+    cav.fscan_push_8pi9_pv_obj = make_mock_pv()
+    cav.fscan_push_7pi9_pv_obj = make_mock_pv()
+    return cav
+
+
+def _params():
+    return dict(
+        freq_start=-3_500_000,
+        freq_stop=50_000,
+        rms_thresh=10.0,
+        mode_overlap=1_000,
+        poll_interval=0.0,
+        timeout_seconds=60.0,
+    )
+
+
+def test_run_fscan_success_selects_and_pushes(rack, monkeypatch):
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+    _wire_fscan_pvs(rack, [3, _FSCAN_STAT_DONE])  # in-progress, then done
+    target = _mock_cavity(1)
+    other = _mock_cavity(2)
+    rack.cavities = {1: target, 2: other}
+
+    rack.run_fscan([target], **_params())
+
+    target.fscan_sel_pv_obj.put.assert_called_once_with(1)
+    other.fscan_sel_pv_obj.put.assert_called_once_with(0)
+    rack._fscan_start_pv_obj.put.assert_called_once_with(1)
+    target.fscan_push_8pi9_pv_obj.put.assert_called_once_with(1)
+    target.fscan_push_7pi9_pv_obj.put.assert_called_once_with(1)
+    other.fscan_push_8pi9_pv_obj.put.assert_not_called()
+
+
+def test_run_fscan_multiple_cavities(rack, monkeypatch):
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+    _wire_fscan_pvs(rack, [_FSCAN_STAT_DONE])
+    c1, c2, c3 = _mock_cavity(1), _mock_cavity(2), _mock_cavity(3)
+    rack.cavities = {1: c1, 2: c2, 3: c3}
+
+    rack.run_fscan([c1, c3], **_params())
+
+    c1.fscan_sel_pv_obj.put.assert_called_once_with(1)
+    c3.fscan_sel_pv_obj.put.assert_called_once_with(1)
+    c2.fscan_sel_pv_obj.put.assert_called_once_with(0)
+    for cav in (c1, c3):
+        cav.fscan_push_8pi9_pv_obj.put.assert_called_once_with(1)
+        cav.fscan_push_7pi9_pv_obj.put.assert_called_once_with(1)
+    c2.fscan_push_8pi9_pv_obj.put.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "bad_stat", [_FSCAN_STAT_ABORTED, _FSCAN_STAT_RESTORE_FAIL]
+)
+def test_run_fscan_scan_failure_raises(rack, monkeypatch, bad_stat):
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+    _wire_fscan_pvs(rack, [bad_stat])
+    target = _mock_cavity(1)
+    rack.cavities = {1: target}
+
+    with pytest.raises(FSCANError):
+        rack.run_fscan([target], **_params())
+    target.fscan_push_8pi9_pv_obj.put.assert_not_called()
+
+
+def test_run_fscan_timeout_raises(rack, monkeypatch):
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+    _wire_fscan_pvs(rack, [3, 3, 3, 3])  # never done
+    target = _mock_cavity(1)
+    rack.cavities = {1: target}
+
+    params = _params()
+    params["timeout_seconds"] = 0.0  # expire immediately
+    with pytest.raises(FSCANError):
+        rack.run_fscan([target], **params)
+
+
+def test_run_fscan_abort_raises(rack, monkeypatch):
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+    _wire_fscan_pvs(rack, [3, 3])
+    target = _mock_cavity(1)
+    rack.cavities = {1: target}
+
+    with pytest.raises(CavityAbortError):
+        rack.run_fscan([target], should_abort=lambda: True, **_params())
+
+
+def test_run_fscan_status_callback_invoked(rack, monkeypatch):
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+    _wire_fscan_pvs(rack, [3, _FSCAN_STAT_DONE])
+    target = _mock_cavity(1)
+    rack.cavities = {1: target}
+    msgs = []
+
+    rack.run_fscan([target], status_callback=msgs.append, **_params())
+
+    assert any("FSCAN" in m for m in msgs)

--- a/tests/utils/sc_linac/test_stepper.py
+++ b/tests/utils/sc_linac/test_stepper.py
@@ -38,6 +38,21 @@ def test_hz_per_microstep(stepper):
     assert stepper.hz_per_microstep == abs(step_scale)
 
 
+def test_set_hz_per_microstep_writes_calc_pv(stepper):
+    # SCALE is derived (SCALE = SCALE_CALC.B / 256) and read-only, so the
+    # writer must put Hz-per-full-step (value * 256) to SCALE_CALC.B and must
+    # NOT write SCALE directly.
+    calc_pv = make_mock_pv()
+    scale_pv = make_mock_pv()
+    stepper._hz_per_step_calc_pv_obj = calc_pv
+    stepper._hz_per_microstep_pv_obj = scale_pv
+
+    stepper.set_hz_per_microstep(0.005)
+
+    calc_pv.put.assert_called_once_with(0.005 * 256)
+    scale_pv.put.assert_not_called()
+
+
 def test_check_abort(stepper):
     stepper.cavity.check_abort = MagicMock()
 

--- a/tests/utils/sc_linac/test_stepper.py
+++ b/tests/utils/sc_linac/test_stepper.py
@@ -1,5 +1,5 @@
 from random import randint, choice
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from lcls_tools.common.controls.pyepics.utils import make_mock_pv
@@ -51,6 +51,32 @@ def test_set_hz_per_microstep_writes_calc_pv(stepper):
 
     calc_pv.put.assert_called_once_with(0.005 * 256)
     scale_pv.put.assert_not_called()
+
+
+def test_step_signed_pv_obj_lazy_and_cached(stepper):
+    assert stepper._step_signed_pv_obj is None
+    mock_pv = make_mock_pv()
+    with patch(
+        "sc_linac_physics.utils.sc_linac.stepper.PV", return_value=mock_pv
+    ) as pv_ctor:
+        first = stepper.step_signed_pv_obj
+        second = stepper.step_signed_pv_obj
+    assert first is mock_pv
+    assert second is mock_pv
+    pv_ctor.assert_called_once_with(stepper.step_signed_pv)
+
+
+def test_steps_cold_landing_pv_obj_lazy_and_cached(stepper):
+    assert stepper._steps_cold_landing_pv_obj is None
+    mock_pv = make_mock_pv()
+    with patch(
+        "sc_linac_physics.utils.sc_linac.stepper.PV", return_value=mock_pv
+    ) as pv_ctor:
+        first = stepper.steps_cold_landing_pv_obj
+        second = stepper.steps_cold_landing_pv_obj
+    assert first is mock_pv
+    assert second is mock_pv
+    pv_ctor.assert_called_once_with(stepper.steps_cold_landing_pv)
 
 
 def test_check_abort(stepper):


### PR DESCRIPTION
## Summary

Adds the backend logic for the frequency tuning phase of the RF commissioning workflow, building on the tuning infrastructure landed in #263.

- `phases/frequency_tuning.py` — frequency tuning phase implementation (~840 lines)
- Full test coverage in `phases/test_frequency_tuning.py` (~850 lines)
- `hz_per_microstep` stored as a signed value (positive = +microsteps increase cavity frequency), removing the redundant separate direction field
- Tuning loop delegates to `Cavity._auto_tune` (with a per-iteration stepper temperature guard) rather than duplicating the move loop in the phase
- Single-cavity FSCAN promoted onto `Rack.run_fscan` + `Rack`/`Cavity` PVs, reused by this phase to measure the 8π/9 and 7π/9 parasitic modes

## Stack

This is the **base** of a two-PR stack:
1. **this PR** — backend phase logic → `main`
2. `feat/tuning-ui` — frequency tuning UI (builders, controller, displays), depends on this

## Testing

- `pytest tests/applications/rf_commissioning/phases/test_frequency_tuning.py` — 56 passed
- black + flake8 clean

Generated with AI

Co-Authored-By: SLAC AI
