### PR TITLE
fix(auto-setup): off-thread EPICS dispatch, PV error handling, and simulation correctness

### DIFF
--- a/src/sc_linac_physics/applications/auto_setup/backend/setup_cavity.py
+++ b/src/sc_linac_physics/applications/auto_setup/backend/setup_cavity.py
@@ -1,4 +1,6 @@
 import logging
+import sys
+import traceback
 from time import sleep
 
 from epics.ca import CASeverityException
@@ -158,6 +160,8 @@ class SetupCavity(Cavity, SetupLinacObject):
             self.progress = 100
             self.status = STATUS_READY_VALUE
         except Exception as e:
+            print(f"[setup] {self} FAILED: {e}", file=sys.stderr, flush=True)
+            traceback.print_exc(file=sys.stderr)
             self.status = STATUS_ERROR_VALUE
             self.clear_abort()
             self.set_status_message(str(e), logging.ERROR)

--- a/src/sc_linac_physics/applications/auto_setup/frontend/gui_cavity.py
+++ b/src/sc_linac_physics/applications/auto_setup/frontend/gui_cavity.py
@@ -365,6 +365,12 @@ class GUICavity:
 
         def _run():
             try:
+                import epics
+
+                epics.ca.use_initial_context()
+            except Exception:
+                pass
+            try:
                 if cav.script_is_running:
                     cav.status_message = f"{cav} script already running"
                     return
@@ -387,6 +393,12 @@ class GUICavity:
         cav = self.cavity
 
         def _run():
+            try:
+                import epics
+
+                epics.ca.use_initial_context()
+            except Exception:
+                pass
             try:
                 if cav.script_is_running:
                     cav.status_message = f"{cav} script already running"

--- a/src/sc_linac_physics/applications/auto_setup/frontend/gui_cavity.py
+++ b/src/sc_linac_physics/applications/auto_setup/frontend/gui_cavity.py
@@ -1,4 +1,6 @@
 import dataclasses
+import os
+from concurrent.futures import ThreadPoolExecutor
 from typing import Optional, Callable
 
 from PyQt5.QtCore import Qt
@@ -26,14 +28,22 @@ from sc_linac_physics.applications.auto_setup.frontend.style import (
     CARD_TEXT,
     MUTED_TEXT,
     NOTE_TEXT,
+    abort_button_stylesheet,
     card_stylesheet,
     status_icon,
     status_text_color,
     step_label_for_progress,
 )
 from sc_linac_physics.applications.auto_setup.frontend.utils import Settings
+from sc_linac_physics.utils.epics.exceptions import (
+    PVConnectionError,
+    PVGetError,
+    PVPutError,
+)
 from sc_linac_physics.utils.qt import make_sanity_check_popup
 from sc_linac_physics.utils.sc_linac.linac_utils import STATUS_RUNNING_VALUE
+
+_executor = ThreadPoolExecutor(max_workers=os.cpu_count() or 4)
 
 
 class _ChannelWatcher(PyDMLabel):
@@ -160,8 +170,11 @@ class GUICavity:
         title_row.addWidget(self.expert_screen_button)
         layout.addLayout(title_row)
 
+        _field_label_style = f"color: {MUTED_TEXT}; font-size: 10px; font-weight: 600; border: none;"
         amp_row = QHBoxLayout()
-        amp_row.addWidget(QLabel("ACON"))
+        acon_lbl = QLabel("ACON")
+        acon_lbl.setStyleSheet(_field_label_style)
+        amp_row.addWidget(acon_lbl)
         self.acon_edit = PyDMSpinbox(init_channel=self.prefix + "ACON")
         self.acon_edit.showStepExponent = False
         self.acon_edit.alarmSensitiveBorder = False
@@ -178,7 +191,9 @@ class GUICavity:
         self.aact_label.precisionFromPV = False
         self.aact_label.precision = 2
         amp_row.addWidget(self.acon_edit)
-        amp_row.addWidget(QLabel("AACT"))
+        aact_lbl = QLabel("AACT")
+        aact_lbl.setStyleSheet(_field_label_style)
+        amp_row.addWidget(aact_lbl)
         amp_row.addWidget(self.aact_label)
         amp_row.addStretch()
         layout.addLayout(amp_row)
@@ -236,7 +251,7 @@ class GUICavity:
         self.shutdown_button = QPushButton("Turn Off")
         self.shutdown_button.clicked.connect(self.trigger_shutdown)
         self.abort_button = QPushButton("Abort")
-        self.abort_button.setStyleSheet("color: #e08090;")
+        self.abort_button.setStyleSheet(abort_button_stylesheet())
         self.abort_button.clicked.connect(self.request_abort)
         btn_row.addWidget(self.setup_button)
         btn_row.addWidget(self.shutdown_button)
@@ -341,33 +356,46 @@ class GUICavity:
     def trigger_setup(self):
         if self.locked:
             return
-        if self.cavity.script_is_running:
-            self.cavity.status_message = f"{self.cavity} script already running"
-            return
-        if not self.cavity.is_online:
-            self.cavity.status_message = f"{self.cavity} not online, skipping"
-            return
-        self.cavity.ssa_cal_requested = (
-            self.settings.ssa_cal_checkbox.isChecked()
-        )
-        self.cavity.auto_tune_requested = (
-            self.settings.auto_tune_checkbox.isChecked()
-        )
-        self.cavity.cav_char_requested = (
-            self.settings.cav_char_checkbox.isChecked()
-        )
-        self.cavity.rf_ramp_requested = (
-            self.settings.rf_ramp_checkbox.isChecked()
-        )
-        self.cavity.trigger_start()
+        # Read checkbox state now on the main thread; EPICS I/O runs off it.
+        ssa_cal = self.settings.ssa_cal_checkbox.isChecked()
+        auto_tune = self.settings.auto_tune_checkbox.isChecked()
+        cav_char = self.settings.cav_char_checkbox.isChecked()
+        rf_ramp = self.settings.rf_ramp_checkbox.isChecked()
+        cav = self.cavity
+
+        def _run():
+            try:
+                if cav.script_is_running:
+                    cav.status_message = f"{cav} script already running"
+                    return
+                if not cav.is_online:
+                    cav.status_message = f"{cav} not online, skipping"
+                    return
+                cav.ssa_cal_requested = ssa_cal
+                cav.auto_tune_requested = auto_tune
+                cav.cav_char_requested = cav_char
+                cav.rf_ramp_requested = rf_ramp
+                cav.trigger_start()
+            except (PVConnectionError, PVGetError, PVPutError) as e:
+                cav.status_message = f"PV error: {e}"
+
+        _executor.submit(_run)
 
     def trigger_shutdown(self):
         if self.locked:
             return
-        if self.cavity.script_is_running:
-            self.cavity.status_message = f"{self.cavity} script already running"
-            return
-        self.cavity.trigger_shutdown()
+        cav = self.cavity
+
+        def _run():
+            try:
+                if cav.script_is_running:
+                    cav.status_message = f"{cav} script already running"
+                    return
+                cav.trigger_shutdown()
+            except (PVConnectionError, PVGetError, PVPutError) as e:
+                cav.status_message = f"PV error: {e}"
+
+        _executor.submit(_run)
 
     def request_abort(self):
-        self.cavity.trigger_abort()
+        _executor.submit(self.cavity.trigger_abort)

--- a/src/sc_linac_physics/applications/auto_setup/frontend/gui_cryomodule.py
+++ b/src/sc_linac_physics/applications/auto_setup/frontend/gui_cryomodule.py
@@ -26,6 +26,7 @@ from sc_linac_physics.applications.auto_setup.frontend.style import (
     CARD_TEXT,
     ACCENT_BORDER,
     LINAC_COLORS,
+    abort_button_stylesheet,
     button_stylesheet,
     card_stylesheet,
     dot_stylesheet,
@@ -120,7 +121,7 @@ class GUICryomodule:
         self.shutdown_all_button = QPushButton("Shut Down All")
         self.shutdown_all_button.clicked.connect(self.trigger_shutdown_all)
         self.abort_all_button = QPushButton("Abort All")
-        self.abort_all_button.setStyleSheet("color: #e08090;")
+        self.abort_all_button.setStyleSheet(abort_button_stylesheet())
         self.abort_all_button.clicked.connect(self.trigger_abort_all)
         self.lock_cm_button = QPushButton("\U0001f512 Lock CM")
         self.lock_cm_button.setCheckable(True)

--- a/src/sc_linac_physics/applications/auto_setup/frontend/gui_linac.py
+++ b/src/sc_linac_physics/applications/auto_setup/frontend/gui_linac.py
@@ -18,6 +18,7 @@ from sc_linac_physics.applications.auto_setup.frontend.style import (
     CARD_BG,
     ACCENT_TEXT,
     LINAC_COLORS,
+    abort_button_stylesheet,
     button_stylesheet,
     card_stylesheet,
     chip_stylesheet,
@@ -133,7 +134,7 @@ class GUILinac:
         self.shutdown_button = QPushButton("Shut Down")
         self.shutdown_button.clicked.connect(self.trigger_shutdown)
         self.abort_button = QPushButton("Abort")
-        self.abort_button.setStyleSheet("color: #e08090;")
+        self.abort_button.setStyleSheet(abort_button_stylesheet())
         self.abort_button.clicked.connect(self.trigger_abort)
         self.lock_linac_button = QPushButton("\U0001f512 Lock")
         self.lock_linac_button.setCheckable(True)

--- a/src/sc_linac_physics/applications/auto_setup/frontend/style.py
+++ b/src/sc_linac_physics/applications/auto_setup/frontend/style.py
@@ -114,6 +114,27 @@ def button_stylesheet() -> str:
     )
 
 
+def abort_button_stylesheet() -> str:
+    return (
+        f"QPushButton {{ background: {CARD_BG}; color: #e08090; "
+        f"border: 1px solid {CARD_BORDER}; border-radius: 4px; "
+        f"padding: 3px 10px; font-size: 11px; }}"
+        f"QPushButton:hover {{ border-color: #e08090; }}"
+        f"QPushButton:pressed {{ background: {CARD_BORDER}; }}"
+    )
+
+
+def checkbox_stylesheet() -> str:
+    return (
+        f"QCheckBox {{ color: {CARD_TEXT}; font-size: 11px; spacing: 5px; }}"
+        f"QCheckBox::indicator {{ width: 13px; height: 13px; "
+        f"border: 1px solid {CARD_BORDER}; border-radius: 2px; background: {PAGE_BG}; }}"
+        f"QCheckBox::indicator:checked {{ background: {ACCENT_BORDER}; "
+        f"border-color: {ACCENT_BORDER}; }}"
+        f"QCheckBox::indicator:hover {{ border-color: {ACCENT_BORDER}; }}"
+    )
+
+
 def chip_frame_stylesheet(status: int, locked: bool = False) -> str:
     bg, border, _ = _tokens(status, locked)
     return (

--- a/src/sc_linac_physics/applications/auto_setup/setup_gui.py
+++ b/src/sc_linac_physics/applications/auto_setup/setup_gui.py
@@ -21,13 +21,14 @@ from sc_linac_physics.applications.auto_setup.frontend.style import (
     PAGE_BG,
     CARD_BG,
     CARD_BORDER,
-    CARD_TEXT,
     MUTED_TEXT,
     NOTE_TEXT,
     ACCENT_BORDER,
     ACCENT_TEXT,
     LINAC_COLORS,
+    abort_button_stylesheet,
     button_stylesheet,
+    checkbox_stylesheet,
     chip_frame_stylesheet,
     dot_stylesheet,
     dot_text,
@@ -62,7 +63,7 @@ class SetupGUI(Display):
         top_bar.setStyleSheet(
             f"QFrame#topBar {{ background: {CARD_BG}; border-bottom: 1px solid {CARD_BORDER}; }}"
             + button_stylesheet()
-            + f"QCheckBox {{ color: {CARD_TEXT}; font-size: 11px; }}"
+            + checkbox_stylesheet()
         )
         top_bar_layout = QVBoxLayout(top_bar)
         top_bar_layout.setContentsMargins(12, 10, 12, 10)
@@ -73,9 +74,7 @@ class SetupGUI(Display):
         self.machine_setup_button = QPushButton("Set Up Machine")
         self.machine_shutdown_button = QPushButton("Shut Down Machine")
         self.machine_abort_button = QPushButton("Abort Machine")
-        self.machine_abort_button.setStyleSheet(
-            "QPushButton { color: #e08090; }"
-        )
+        self.machine_abort_button.setStyleSheet(abort_button_stylesheet())
 
         self.machine_setup_popup = make_sanity_check_popup(
             "Set up all unlocked cavities across the entire machine?"

--- a/src/sc_linac_physics/utils/sc_linac/rfstation.py
+++ b/src/sc_linac_physics/utils/sc_linac/rfstation.py
@@ -1,3 +1,4 @@
+import threading
 from typing import TYPE_CHECKING, Optional
 
 from sc_linac_physics.utils.epics import PV
@@ -22,6 +23,9 @@ class RFStation(SCLinacObject):
 
         self.dac_amp_pv: str = self.pv_addr("DAC_AMPLITUDE")
         self._dac_amp_pv_obj: Optional[PV] = None
+        # Serializes lazy init and concurrent puts: multiple cavity threads share
+        # the same RFStation when running SSA cal in parallel on the same rack.
+        self._dac_lock = threading.RLock()
 
     @property
     def pv_prefix(self):
@@ -30,7 +34,9 @@ class RFStation(SCLinacObject):
     @property
     def dac_amp_pv_obj(self) -> PV:
         if not self._dac_amp_pv_obj:
-            self._dac_amp_pv_obj = PV(self.dac_amp_pv)
+            with self._dac_lock:
+                if not self._dac_amp_pv_obj:
+                    self._dac_amp_pv_obj = PV(self.dac_amp_pv)
         return self._dac_amp_pv_obj
 
     @property
@@ -39,4 +45,5 @@ class RFStation(SCLinacObject):
 
     @dac_amp.setter
     def dac_amp(self, value: float):
-        self.dac_amp_pv_obj.put(value)
+        with self._dac_lock:
+            self.dac_amp_pv_obj.put(value)

--- a/src/sc_linac_physics/utils/simulation/cavity_service.py
+++ b/src/sc_linac_physics/utils/simulation/cavity_service.py
@@ -249,6 +249,15 @@ class CavityPVGroup(PVGroup):
     qloaded = pvproperty(name="QLOADED", value=4e7)
     qloaded_new = pvproperty(name="QLOADED_NEW", value=4e7)
 
+    @qloaded_new.startup
+    async def qloaded_new(self, instance, async_lib):
+        # HL tolerance [1.5e7, 3.5e7]; regular [2.5e7, 5.1e7]
+        initial_q = 2.5e7 if self.is_hl else 4e7
+        await self.qloaded_new.write(initial_q)
+        await self.qloaded.write(initial_q)
+        # HL scale tolerance [5, 25]; regular [10, 125]
+        await self.scale_new.write(15.0 if self.is_hl else 30.0)
+
     scale_new = pvproperty(name="CAV:CAL_SCALEB_NEW", value=30)
     quench_bypass: PvpropertyEnum = pvproperty(
         name="QUENCH_BYP",
@@ -436,42 +445,14 @@ class CavityPVGroup(PVGroup):
 
     @quench_latch.putter
     async def quench_latch(self, instance, value):
-        """Handle quench latch - capture waveforms then drop amplitude."""
-        import sys
-
-        print(
-            f"DEBUG: quench_latch putter called! value={value}",
-            file=sys.stderr,
-            flush=True,
-        )
-        print(f"DEBUG: value type: {type(value)}", file=sys.stderr, flush=True)
-        print(
-            f"DEBUG: Current amplitude: {self.aact.value}",
-            file=sys.stderr,
-            flush=True,
-        )
-
+        """Handle quench latch - capture waveforms then drop amplitude on fault only."""
         # Enum values come through as strings, not integers
         if value == "Fault" or value == 1:
             quench_type = self._determine_quench_type()
-            print(
-                f"DEBUG: Generating {quench_type} quench",
-                file=sys.stderr,
-                flush=True,
-            )
             await self._capture_quench_waveforms(quench_type)
-            print("DEBUG: Waveforms captured", file=sys.stderr, flush=True)
-        else:
-            print(
-                f"DEBUG: Not a fault trigger (value={value})",
-                file=sys.stderr,
-                flush=True,
-            )
-
-        await self.aact.write(0)
-        await self.amean.write(0)
-        await self._update_amplitude_alarm()
-        print("DEBUG: Amplitude set to 0", file=sys.stderr, flush=True)
+            await self.aact.write(0)
+            await self.amean.write(0)
+            await self._update_amplitude_alarm()
 
     def _determine_quench_type(self) -> str:
         """Determine what type of quench to simulate."""
@@ -622,7 +603,9 @@ class CavityPVGroup(PVGroup):
         gradient = value / self.length
         await self.gdes.write(gradient, verify_value=False)  # Skip the putter
 
-        if self.cm_group.heater.mode.value == 2:  # SEQUENCER
+        if (
+            self.cm_group.heater.mode.value == 0
+        ):  # MANUAL only — no-op in SEQUENCER
             await self.cm_group.heater.setpoint.write(
                 self.cm_group.heater.setpoint.value + delta
             )

--- a/src/sc_linac_physics/utils/simulation/launcher_service.py
+++ b/src/sc_linac_physics/utils/simulation/launcher_service.py
@@ -1,6 +1,11 @@
 import asyncio
+import concurrent.futures
+import functools
+import os
+import threading
 from asyncio import create_subprocess_exec
 from datetime import datetime
+from time import sleep
 
 from caproto import ChannelType
 from caproto.server import (
@@ -14,6 +19,220 @@ from caproto.server import (
 from caproto.server.server import PVGroupMeta
 
 from sc_linac_physics.utils.simulation.severity_prop import SeverityProp
+
+# ca_attach_context in libca is not thread-safe: concurrent calls from
+# multiple executor threads segfault.  This lock serialises our
+# use_initial_context() calls so each thread attaches cleanly in turn.
+# After attachment, PV.context == initial_context, so _ensure_context
+# never needs to re-attach and there are no further concurrent calls.
+_ca_init_lock = threading.Lock()
+
+
+def _epics_thread(fn):
+    """Attach the main EPICS CA context before calling fn, detach after.
+
+    ThreadPoolExecutor workers are non-EPICS threads.  If they call into
+    pyepics without attaching the initial context first, libCom creates a
+    per-thread context; when the thread exits libCom's TLS destructor fires
+    and panics with "free_threadInfo … can't proceed".  Attaching the shared
+    initial context avoids both the implicit context creation and the noisy
+    shutdown crash.
+
+    Attachment is serialised via _ca_init_lock because ca_attach_context is
+    not safe to call from multiple threads simultaneously.
+    """
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        import epics.ca
+
+        with _ca_init_lock:
+            epics.ca.use_initial_context()
+        try:
+            return fn(*args, **kwargs)
+        finally:
+            epics.ca.detach_context()
+
+    return wrapper
+
+
+# Cavity setups are long-running (minutes). Cap at cpu_count so a full CM (8 cavities)
+# can run concurrently on most machines without spawning more threads than cores.
+_CAVITY_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
+    max_workers=os.cpu_count(), thread_name_prefix="cavity-setup"
+)
+
+# Orchestrators (CM/Linac/Global/Rack) just propagate flags and fire STRT PV writes;
+# they finish in seconds, so a larger pool is fine.
+_ORCHESTRATOR_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
+    max_workers=16, thread_name_prefix="setup-orch"
+)
+
+
+# ---------------------------------------------------------------------------
+# In-process cavity functions
+# ---------------------------------------------------------------------------
+
+
+@_epics_thread
+def _run_setup_cavity(cm_name: str, cav_num: int) -> None:
+    from sc_linac_physics.applications.auto_setup.backend.setup_machine import (
+        SETUP_MACHINE,
+    )
+
+    SETUP_MACHINE.cryomodules[cm_name].cavities[cav_num].setup()
+
+
+@_epics_thread
+def _run_shutdown_cavity(cm_name: str, cav_num: int) -> None:
+    from sc_linac_physics.applications.auto_setup.backend.setup_machine import (
+        SETUP_MACHINE,
+    )
+
+    SETUP_MACHINE.cryomodules[cm_name].cavities[cav_num].shut_down()
+
+
+# ---------------------------------------------------------------------------
+# In-process CM functions
+# ---------------------------------------------------------------------------
+
+
+@_epics_thread
+def _run_setup_cm(cm_name: str) -> None:
+    from sc_linac_physics.applications.auto_setup.backend.setup_machine import (
+        SETUP_MACHINE,
+    )
+
+    cm = SETUP_MACHINE.cryomodules[cm_name]
+    for cavity in cm.cavities.values():
+        cavity.ssa_cal_requested = cm.ssa_cal_requested
+        cavity.auto_tune_requested = cm.auto_tune_requested
+        cavity.cav_char_requested = cm.cav_char_requested
+        cavity.rf_ramp_requested = cm.rf_ramp_requested
+        cavity.trigger_start()
+        sleep(0.1)
+
+
+@_epics_thread
+def _run_shutdown_cm(cm_name: str) -> None:
+    from sc_linac_physics.applications.auto_setup.backend.setup_machine import (
+        SETUP_MACHINE,
+    )
+
+    for cavity in SETUP_MACHINE.cryomodules[cm_name].cavities.values():
+        cavity.trigger_shutdown()
+        sleep(0.1)
+
+
+# ---------------------------------------------------------------------------
+# In-process Rack functions (no sc-setup-rack script exists)
+# Flag values are read from the PVGroup in the async context and passed in.
+# ---------------------------------------------------------------------------
+
+
+@_epics_thread
+def _run_setup_rack(
+    cm_name: str,
+    rack_name: str,
+    ssa_cal: bool,
+    auto_tune: bool,
+    cav_char: bool,
+    rf_ramp: bool,
+) -> None:
+    from sc_linac_physics.applications.auto_setup.backend.setup_machine import (
+        SETUP_MACHINE,
+    )
+
+    cm = SETUP_MACHINE.cryomodules[cm_name]
+    cav_range = range(1, 5) if rack_name == "A" else range(5, 9)
+    for cav_num in cav_range:
+        cavity = cm.cavities[cav_num]
+        cavity.ssa_cal_requested = ssa_cal
+        cavity.auto_tune_requested = auto_tune
+        cavity.cav_char_requested = cav_char
+        cavity.rf_ramp_requested = rf_ramp
+        cavity.trigger_start()
+        sleep(0.1)
+
+
+@_epics_thread
+def _run_shutdown_rack(cm_name: str, rack_name: str) -> None:
+    from sc_linac_physics.applications.auto_setup.backend.setup_machine import (
+        SETUP_MACHINE,
+    )
+
+    cm = SETUP_MACHINE.cryomodules[cm_name]
+    cav_range = range(1, 5) if rack_name == "A" else range(5, 9)
+    for cav_num in cav_range:
+        cm.cavities[cav_num].trigger_shutdown()
+        sleep(0.1)
+
+
+# ---------------------------------------------------------------------------
+# In-process Linac functions
+# ---------------------------------------------------------------------------
+
+
+@_epics_thread
+def _run_setup_linac(linac_idx: int) -> None:
+    from sc_linac_physics.applications.auto_setup.backend.setup_machine import (
+        SETUP_MACHINE,
+    )
+    from sc_linac_physics.utils.sc_linac.linac_utils import LINAC_CM_DICT
+
+    linac = SETUP_MACHINE.linacs[linac_idx]
+    for cm_name in LINAC_CM_DICT[linac_idx]:
+        cm = SETUP_MACHINE.cryomodules[cm_name]
+        cm.ssa_cal_requested = linac.ssa_cal_requested
+        cm.auto_tune_requested = linac.auto_tune_requested
+        cm.cav_char_requested = linac.cav_char_requested
+        cm.rf_ramp_requested = linac.rf_ramp_requested
+        cm.trigger_start()
+        sleep(0.5)
+
+
+@_epics_thread
+def _run_shutdown_linac(linac_idx: int) -> None:
+    from sc_linac_physics.applications.auto_setup.backend.setup_machine import (
+        SETUP_MACHINE,
+    )
+    from sc_linac_physics.utils.sc_linac.linac_utils import LINAC_CM_DICT
+
+    for cm_name in LINAC_CM_DICT[linac_idx]:
+        SETUP_MACHINE.cryomodules[cm_name].trigger_shutdown()
+        sleep(0.5)
+
+
+# ---------------------------------------------------------------------------
+# In-process Global functions
+# ---------------------------------------------------------------------------
+
+
+@_epics_thread
+def _run_setup_global() -> None:
+    from sc_linac_physics.applications.auto_setup.backend.setup_machine import (
+        SETUP_MACHINE,
+    )
+    from sc_linac_physics.utils.sc_linac.linac_utils import ALL_CRYOMODULES
+
+    for cm_name in ALL_CRYOMODULES:
+        cm = SETUP_MACHINE.cryomodules[cm_name]
+        cm.ssa_cal_requested = SETUP_MACHINE.ssa_cal_requested
+        cm.auto_tune_requested = SETUP_MACHINE.auto_tune_requested
+        cm.cav_char_requested = SETUP_MACHINE.cav_char_requested
+        cm.rf_ramp_requested = SETUP_MACHINE.rf_ramp_requested
+        cm.trigger_start()
+
+
+@_epics_thread
+def _run_shutdown_global() -> None:
+    from sc_linac_physics.applications.auto_setup.backend.setup_machine import (
+        SETUP_MACHINE,
+    )
+    from sc_linac_physics.utils.sc_linac.linac_utils import ALL_CRYOMODULES
+
+    for cm_name in ALL_CRYOMODULES:
+        SETUP_MACHINE.cryomodules[cm_name].trigger_shutdown()
 
 
 class LauncherPVGroupMeta(PVGroupMeta):
@@ -167,6 +386,7 @@ class BaseScriptPVGroup(LauncherPVGroup):
         self.script_args = script_args
         self.extra_flags = []
         self.process = None
+        self._future = None
 
     def get_command_args(self):
         """Build command arguments from script name, args, and extra flags"""
@@ -176,18 +396,38 @@ class BaseScriptPVGroup(LauncherPVGroup):
         args.extend(self.extra_flags)
         return args
 
-    async def trigger_start(self):
-        if self.process and self.process.returncode is None:
-            await self.status.write("Already running")
-            return
+    def _get_run_fn(self):
+        """Return a no-arg callable for in-process execution, or None to use subprocess."""
+        return None
 
-        args = self.get_command_args()
-        self.process = await create_subprocess_exec(*args)
-        await self.timestamp.write(
-            datetime.now().strftime("%m/%d/%y %H:%M:%S.%f")
-        )
-        await self.status.write("Running")
-        asyncio.create_task(self._monitor_process())
+    def _get_executor(self):
+        return _ORCHESTRATOR_EXECUTOR
+
+    async def trigger_start(self):
+        run_fn = self._get_run_fn()
+        if run_fn is not None:
+            if self._future is not None and not self._future.done():
+                await self.status.write("Already running")
+                return
+            await self.timestamp.write(
+                datetime.now().strftime("%m/%d/%y %H:%M:%S.%f")
+            )
+            await self.status.write("Running")
+            self._future = asyncio.get_running_loop().run_in_executor(
+                self._get_executor(), run_fn
+            )
+            asyncio.create_task(self._monitor_future())
+        else:
+            if self.process and self.process.returncode is None:
+                await self.status.write("Already running")
+                return
+            args = self.get_command_args()
+            self.process = await create_subprocess_exec(*args)
+            await self.timestamp.write(
+                datetime.now().strftime("%m/%d/%y %H:%M:%S.%f")
+            )
+            await self.status.write("Running")
+            asyncio.create_task(self._monitor_process())
 
     async def trigger_stop(self):
         if self.process:
@@ -209,6 +449,19 @@ class BaseScriptPVGroup(LauncherPVGroup):
                 await self.status.write("Completed")
             else:
                 await self.status.write(f"Failed (exit code: {returncode})")
+
+    async def _monitor_future(self):
+        try:
+            await self._future
+            await self.timestamp.write(
+                datetime.now().strftime("%m/%d/%y %H:%M:%S.%f")
+            )
+            await self.status.write("Completed")
+        except Exception as e:
+            await self.timestamp.write(
+                datetime.now().strftime("%m/%d/%y %H:%M:%S.%f")
+            )
+            await self.status.write(f"Failed: {type(e).__name__}")
 
 
 class BaseCMPVGroup(BaseScriptPVGroup):
@@ -304,8 +557,10 @@ class BaseCavityPVGroup(BaseScriptPVGroup):
         super().__init__(prefix, script_name, cm=cm_name, cav=cav_num)
         self.cm_name = cm_name
         self.cav_num = cav_num
-        # Cavities don't have subgroups
         self.subgroups = []
+
+    def _get_executor(self):
+        return _CAVITY_EXECUTOR
 
     @status_enum.putter
     async def _status_enum_putter(self, instance, value):
@@ -326,21 +581,49 @@ class BaseCavityPVGroup(BaseScriptPVGroup):
 class SetupCMPVGroup(BaseCMPVGroup):
     LAUNCHER_NAME = "SETUP"
 
+    def _get_run_fn(self):
+        return functools.partial(_run_setup_cm, self.cm_name)
+
 
 class SetupLinacPVGroup(BaseLinacPVGroup):
     LAUNCHER_NAME = "SETUP"
+
+    def _get_run_fn(self):
+        return functools.partial(_run_setup_linac, self.linac_idx)
 
 
 class SetupGlobalPVGroup(BaseGlobalPVGroup):
     LAUNCHER_NAME = "SETUP"
 
+    def _get_run_fn(self):
+        return _run_setup_global
+
 
 class SetupCavityPVGroup(BaseCavityPVGroup):
+    """In-process setup simulation: runs as an asyncio coroutine instead of
+    spawning a subprocess, so hundreds of cavities can run concurrently on the
+    single caproto event loop without overwhelming the server.
+    """
+
     LAUNCHER_NAME = "SETUP"
+
+    def _get_run_fn(self):
+        return functools.partial(_run_setup_cavity, self.cm_name, self.cav_num)
 
 
 class SetupRackPVGroup(BaseRackPVGroup):
     LAUNCHER_NAME = "SETUP"
+
+    def _get_run_fn(self):
+        return functools.partial(
+            _run_setup_rack,
+            self.cm_name,
+            self.rack_name,
+            bool(self.ssa_cal.value),
+            bool(self.tune.value),
+            bool(self.cav_char.value),
+            bool(self.ramp.value),
+        )
 
 
 # ============================================================================
@@ -351,21 +634,42 @@ class SetupRackPVGroup(BaseRackPVGroup):
 class OffCMPVGroup(BaseCMPVGroup):
     LAUNCHER_NAME = "OFF"
 
+    def _get_run_fn(self):
+        return functools.partial(_run_shutdown_cm, self.cm_name)
+
 
 class OffLinacPVGroup(BaseLinacPVGroup):
     LAUNCHER_NAME = "OFF"
+
+    def _get_run_fn(self):
+        return functools.partial(_run_shutdown_linac, self.linac_idx)
 
 
 class OffGlobalPVGroup(BaseGlobalPVGroup):
     LAUNCHER_NAME = "OFF"
 
+    def _get_run_fn(self):
+        return _run_shutdown_global
+
 
 class OffCavityPVGroup(BaseCavityPVGroup):
+    """In-process shutdown simulation — mirrors SetupCavityPVGroup."""
+
     LAUNCHER_NAME = "OFF"
+
+    def _get_run_fn(self):
+        return functools.partial(
+            _run_shutdown_cavity, self.cm_name, self.cav_num
+        )
 
 
 class OffRackPVGroup(BaseRackPVGroup):
     LAUNCHER_NAME = "OFF"
+
+    def _get_run_fn(self):
+        return functools.partial(
+            _run_shutdown_rack, self.cm_name, self.rack_name
+        )
 
 
 # ============================================================================

--- a/src/sc_linac_physics/utils/simulation/sc_linac_physics_service.py
+++ b/src/sc_linac_physics/utils/simulation/sc_linac_physics_service.py
@@ -1,3 +1,4 @@
+import io
 import os
 import shutil
 import socket
@@ -476,6 +477,12 @@ _REPEATER_POLL_S = 0.05
 
 
 def main():
+    import faulthandler
+
+    try:
+        faulthandler.enable()
+    except io.UnsupportedOperation:
+        pass  # pytest in-process runner captures stderr without a real fd
     os.environ.setdefault("EPICS_CAS_AUTO_BEACON_ADDR_LIST", "no")
     os.environ.setdefault("EPICS_CAS_BEACON_ADDR_LIST", "127.0.0.1")
     service = SCLinacPhysicsService()

--- a/src/sc_linac_physics/utils/simulation/ssa_service.py
+++ b/src/sc_linac_physics/utils/simulation/ssa_service.py
@@ -100,6 +100,12 @@ class SSAPVGroup(PVGroup):
     power: PvpropertyFloat = pvproperty(
         name="CALPWR", value=4000, dtype=ChannelType.FLOAT
     )
+    ps_volt_setpt1: PvpropertyFloat = pvproperty(
+        name="PSVoltSetpt1", value=2500.0, dtype=ChannelType.FLOAT
+    )
+    ps_volt_setpt2: PvpropertyFloat = pvproperty(
+        name="PSVoltSetpt2", value=2500.0, dtype=ChannelType.FLOAT
+    )
 
     nirp: PvpropertyEnum = pvproperty(
         value=1,

--- a/src/sc_linac_physics/utils/simulation/tuner_service.py
+++ b/src/sc_linac_physics/utils/simulation/tuner_service.py
@@ -116,22 +116,28 @@ class StepperPVGroup(PVGroup):
 
     async def move(self, move_sign_des: int):
         await self.motor_moving.write("Moving")
+        # Snapshot speed and step_des once — restore_defaults() on the hardware
+        # thread can overwrite these PVs while this coroutine is suspended at
+        # each `await sleep(1)`, causing the loop to run with the wrong speed
+        # and accumulate excess detune updates that trip _auto_tune's tolerance.
+        speed_val = int(self.speed.value)
+        step_des_val = int(self.step_des.value)
         steps = 0
-        step_change = move_sign_des * self.speed.value
+        step_change = move_sign_des * speed_val
+        freq_move_sign = (
+            move_sign_des if self.cavity_group.is_hl else -move_sign_des
+        )
         starting_detune = self.cavity_group.detune.value
 
-        while (
-            self.step_des.value - steps >= self.speed.value
-            and self.abort.value != 1
-        ):
-            await self.step_tot.write(self.step_tot.value + self.speed.value)
+        while step_des_val - steps >= speed_val and self.abort.value != 1:
+            await self.step_tot.write(self.step_tot.value + speed_val)
             await self.step_signed.write(self.step_signed.value + step_change)
 
-            steps += self.speed.value
-            delta = (
-                move_sign_des * self.speed.value * self.hz_per_microstep.value
+            steps += speed_val
+            delta = speed_val * self.hz_per_microstep.value
+            new_detune = round(
+                self.cavity_group.detune.value + freq_move_sign * delta
             )
-            new_detune = round(self.cavity_group.detune.value + delta)
 
             await self.cavity_group.detune.write(new_detune)
             await self.cavity_group.detune_rfs.write(new_detune)
@@ -143,13 +149,15 @@ class StepperPVGroup(PVGroup):
             await self.abort.write(0)
             return
 
-        remainder = self.step_des.value - steps
+        remainder = step_des_val - steps
         await self.step_tot.write(self.step_tot.value + remainder)
         step_change = move_sign_des * remainder
         await self.step_signed.write(self.step_signed.value + step_change)
 
-        delta = move_sign_des * remainder * self.hz_per_microstep.value
-        new_detune = round(self.cavity_group.detune.value + delta)
+        delta = remainder * self.hz_per_microstep.value
+        new_detune = round(
+            self.cavity_group.detune.value + freq_move_sign * delta
+        )
 
         enable_int = _enum_to_int(
             self.piezo_group.enable_stat.value,
@@ -161,6 +169,10 @@ class StepperPVGroup(PVGroup):
         )
         if enable_int == 1 and feedback_int == 1:
             freq_change = new_detune - starting_detune
+            # HL: issue_move_command inverts steps (tuner moves opposite direction),
+            # so the SELA feedback voltage response is also opposite to freq_change.
+            if self.cavity_group.is_hl:
+                freq_change = -freq_change
             voltage_change = freq_change * (1 / PIEZO_HZ_PER_VOLT)
             await self.piezo_group.voltage.write(
                 self.piezo_group.voltage.value + voltage_change

--- a/tests/applications/auto_setup/conftest.py
+++ b/tests/applications/auto_setup/conftest.py
@@ -1,0 +1,15 @@
+import pytest
+
+from sc_linac_physics.applications.auto_setup.frontend import gui_cavity as _gc
+
+
+class _SyncExecutor:
+    """Executes submitted callables synchronously so tests can assert results."""
+
+    def submit(self, fn, *args, **kwargs):
+        fn(*args, **kwargs)
+
+
+@pytest.fixture(autouse=True)
+def sync_cavity_executor(monkeypatch):
+    monkeypatch.setattr(_gc, "_executor", _SyncExecutor())

--- a/tests/utils/simulation/test_launcher_service.py
+++ b/tests/utils/simulation/test_launcher_service.py
@@ -1,4 +1,3 @@
-import asyncio
 from unittest.mock import patch
 
 import pytest
@@ -122,7 +121,7 @@ class TestCMPVGroups:
         ) as mock_run:
             mock_run.return_value = None
             await group.trigger_start()
-            await asyncio.sleep(0.05)  # let the executor thread call the fn
+            await group._future
             mock_run.assert_called_once_with("CM01")
 
 
@@ -298,6 +297,8 @@ class TestStartStopPVs:
         ) as mock_run:
             mock_run.return_value = None
             await group.trigger_start()
+            await group._future
+            mock_run.assert_called_once_with("CM01")
 
 
 class TestCommonPVs:

--- a/tests/utils/simulation/test_launcher_service.py
+++ b/tests/utils/simulation/test_launcher_service.py
@@ -1,4 +1,5 @@
-from unittest.mock import patch, AsyncMock
+import asyncio
+from unittest.mock import patch
 
 import pytest
 from caproto import ChannelType
@@ -112,17 +113,17 @@ class TestCMPVGroups:
         assert args == ["sc-setup-cm", "-cm=CM02", "-off"]
 
     @pytest.mark.asyncio
-    async def test_trigger_start_calls_subprocess(self):
-        """Test that trigger_start executes the command"""
+    async def test_trigger_start_submits_in_process(self):
+        """Test that trigger_start uses an in-process run function, not subprocess."""
         group = SetupCMPVGroup(prefix="TEST:", cm_name="CM01")
 
         with patch(
-            "sc_linac_physics.utils.simulation.launcher_service.create_subprocess_exec"
-        ) as mock_exec:
-            mock_exec.return_value = AsyncMock()
+            "sc_linac_physics.utils.simulation.launcher_service._run_setup_cm"
+        ) as mock_run:
+            mock_run.return_value = None
             await group.trigger_start()
-
-            mock_exec.assert_called_once_with("sc-setup-cm", "-cm=CM01")
+            await asyncio.sleep(0.05)  # let the executor thread call the fn
+            mock_run.assert_called_once_with("CM01")
 
 
 class TestLinacPVGroups:
@@ -291,13 +292,12 @@ class TestStartStopPVs:
         assert hasattr(group, "trigger_start")
         assert callable(group.trigger_start)
 
-        # Test that it can be called (with mocked subprocess)
+        # Test that it can be called (in-process run fn mocked to no-op)
         with patch(
-            "sc_linac_physics.utils.simulation.launcher_service.create_subprocess_exec"
-        ) as mock_exec:
-            mock_exec.return_value = AsyncMock()
+            "sc_linac_physics.utils.simulation.launcher_service._run_setup_cm"
+        ) as mock_run:
+            mock_run.return_value = None
             await group.trigger_start()
-            mock_exec.assert_called_once_with("sc-setup-cm", "-cm=CM01")
 
 
 class TestCommonPVs:


### PR DESCRIPTION
## Summary

This PR makes the auto-setup GUI responsive under EPICS I/O, hardens shared RF-station access for concurrent cavity setups, and reworks the simulation launcher services to run setups **in-process** on a thread pool instead of spawning subprocesses. It also fixes several simulation-fidelity bugs (tuner detune direction, quench-latch behavior, Q/scale initialization) and replaces ad-hoc debug prints with proper diagnostics.

## Motivation

- **GUI freezes:** Setup/shutdown/abort handlers performed blocking EPICS reads and writes directly on the Qt main thread, freezing the UI whenever a PV was slow or disconnected.
- **Concurrency hazards:** Running SSA calibration on multiple cavities in parallel meant several threads could lazily initialize and write to the *same* `RFStation` DAC amplitude PV simultaneously.
- **Simulation scalability:** The launcher services spawned a subprocess per cavity/CM/linac/global action, which does not scale to hundreds of cavities and made failures hard to diagnose.
- **Simulation correctness:** The tuner, quench latch, and cavity Q/scale startup values did not faithfully reflect HL vs. regular cavity behavior.

## Changes

### Frontend — responsive GUI (`gui_cavity.py`, `gui_cryomodule.py`, `gui_linac.py`, `setup_gui.py`, `style.py`)
- Moved EPICS I/O off the Qt main thread. `trigger_setup`, `trigger_shutdown`, and `request_abort` now read checkbox state **on the main thread** and submit the actual PV work to a shared `ThreadPoolExecutor`.
- Each `_run()` closure calls `epics.ca.use_initial_context()` so executor threads share the main CA context rather than creating per-thread contexts that hit TLS cleanup on teardown.
- Wrapped the off-thread work in handlers for `PVConnectionError`, `PVGetError`, and `PVPutError`, surfacing failures via `status_message` instead of crashing/hanging.
- Introduced reusable `abort_button_stylesheet()` and `checkbox_stylesheet()` helpers and replaced inline `color: #e08090;` abort-button styling across all four GUI modules.
- Added muted, consistent styling for the `ACON`/`AACT` field labels.

### Backend — diagnostics (`setup_cavity.py`)
- On setup failure, print the exception and traceback to `stderr` (in addition to the existing status-message/logging path) to aid debugging.

### Concurrency safety (`rfstation.py`)
- Added a per-instance `RLock` guarding both the lazy `PV` initialization and `dac_amp` puts, since multiple cavity threads can share the same `RFStation` when running SSA cal in parallel on the same rack.

### Simulation launchers — in-process execution (`launcher_service.py`)
- Replaced per-action subprocess spawning with **in-process** run functions executed on dedicated thread pools:
  - `_CAVITY_EXECUTOR` (capped at `cpu_count`) for long-running cavity setups.
  - `_ORCHESTRATOR_EXECUTOR` (16 workers) for fast CM/Rack/Linac/Global flag-propagation + `STRT` writes.
- Added the `_epics_thread` decorator + `_ca_init_lock` to safely attach the shared EPICS CA context in worker threads and detach on exit, avoiding libCom TLS panics and `ca_attach_context` races.
- Generalized `BaseScriptPVGroup` with `_get_run_fn()` / `_get_executor()` and a future-based path (`_monitor_future`) that coexists with the legacy subprocess path when `_get_run_fn()` returns `None`.
- Added `_run_setup_*` / `_run_shutdown_*` functions for cavity, CM, rack, linac, and global scopes.

### Simulation fidelity
- **`tuner_service.py`:** Snapshot `speed`/`step_des` once per move to avoid mid-coroutine mutation by `restore_defaults()`; corrected detune/voltage sign handling for HL cavities (tuner moves opposite direction).
- **`cavity_service.py`:** Added a `qloaded_new` startup that initializes `QLOADED`/`scale` per HL vs. regular tolerances; quench latch now only drops amplitude on an actual fault; removed noisy `DEBUG` prints; corrected the heater `ADES` adjustment to apply in MANUAL mode only.
- **`ssa_service.py`:** Added `PSVoltSetpt1` / `PSVoltSetpt2` PVs.
- **`sc_linac_physics_service.py`:** Enabled `faulthandler` (guarded against pytest's captured stderr) for crash diagnostics.

### Tests
- Added `tests/applications/auto_setup/conftest.py` with an autouse `_SyncExecutor` fixture so GUI tests run the submitted callables synchronously and can assert results.
- Updated `test_launcher_service.py` to assert **in-process** run functions are invoked rather than `create_subprocess_exec`; replaced `asyncio.sleep` polling with deterministic `await group._future` before asserting mock calls.

## Impact / Behavioral Notes
- The GUI no longer blocks on EPICS I/O; setup/shutdown/abort dispatch immediately and report errors via status messages.
- Simulation launchers no longer spawn subprocesses, enabling many concurrent cavity setups on a single caproto event loop.
- The legacy subprocess path remains available for any `PVGroup` whose `_get_run_fn()` returns `None`.

## Testing
- [ ] Unit tests pass (`test_launcher_service.py` updated; GUI handler tests via sync executor).
- [ ] Manual GUI check: setup/shutdown/abort remain responsive with a slow/disconnected PV.
- [ ] Simulation: full CM (8 cavities) runs concurrently without CA context panics; HL tuner/quench behavior verified.


https://github.com/user-attachments/assets/ee797bdb-1a62-47da-94fd-10c75c407a71