### PR TITLE
fix(ci): pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  # Keep GitHub Actions current. The org requires actions to be pinned to a
+  # full commit SHA (no moving @vN tags), so Dependabot opens PRs that bump the
+  # pinned SHA and its "# vN" comment when a new release ships.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/_get-versions.yml
+++ b/.github/workflows/_get-versions.yml
@@ -22,7 +22,7 @@ jobs:
       required: ${{ steps.versions.outputs.required }}
       experimental: ${{ steps.versions.outputs.experimental }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Compute Python version matrix
         id: versions

--- a/.github/workflows/_package.yml
+++ b/.github/workflows/_package.yml
@@ -7,11 +7,11 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
           cache: pip
@@ -48,7 +48,7 @@ jobs:
           sc-linac --help > /dev/null 2>&1 && echo "CLI OK" || echo "CLI skipped (may require display)"
           deactivate
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: package-dist
           path: dist/*

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -23,11 +23,11 @@ jobs:
       matrix:
         python-version: ${{ fromJSON(inputs.python-versions) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -59,7 +59,7 @@ jobs:
             --cov-report=xml \
             --cov-fail-under=80
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage-${{ matrix.python-version }}
           path: coverage.xml

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -33,8 +33,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
           cache: pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,13 +39,13 @@ jobs:
     needs: [test, package]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           fetch-tags: true
           token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
           cache: pip


### PR DESCRIPTION
## Problem

The org enabled a policy requiring all GitHub Actions to be pinned to a full-length commit SHA. The workflows still referenced moving `@vN` tags, so **every job on `main` and all open PRs fails at setup**:

> The actions actions/checkout@v4 and actions/setup-python@v5 are not allowed in slaclab/sc_linac_physics because all actions must be pinned to a full-length commit SHA.

This is unrelated to any feature work — it blocks CI repo-wide, so it's split out as its own PR to merge fast and unblock everyone.

## Fix

**1. Pin every action to a commit SHA** (keeping the version as a trailing comment):

| Action | SHA | |
|---|---|---|
| `actions/checkout` | `34e114876b0b11c390a56381ad16ebd13914f8d5` | v4 |
| `actions/setup-python` | `a26af69be951a213d495a4c3e4e4022e16d87065` | v5 |
| `actions/upload-artifact` | `ea165f8d65b6e75b540449e92b4886f43607fa02` | v4 |

Files touched: `_get-versions.yml`, `_package.yml`, `_test.yml`, `python-app.yml`, `release.yml`. After the change, `grep -rn "uses:.*@v[0-9]" .github/workflows/` returns nothing.

**2. Add Dependabot to keep the pins current.** The policy forbids moving refs (`@v4`, `@latest`), so actions can't float to the newest release on their own. `.github/dependabot.yml` enables the `github-actions` ecosystem (weekly, grouped into a single PR), which opens a PR bumping the pinned SHA **and** its `# vN` comment whenever an action releases — staying up to date while remaining compliant.

## Verification

CI jobs now get past the setup step and run (previously they failed in ~2s). No source or test changes.

Generated with AI