### PR TITLE
feat: add fault heatmap to CLI infrastructure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,6 +166,7 @@ sc-srf-home = "sc_linac_physics.cli.launchers:launch_srf_home"
 sc-cavity = "sc_linac_physics.cli.launchers:launch_cavity_display"
 sc-faults = "sc_linac_physics.cli.launchers:launch_fault_decoder"
 sc-fcount = "sc_linac_physics.cli.launchers:launch_fault_count"
+sc-fheatmap = "sc_linac_physics.cli.launchers:launch_fault_heatmap"
 
 # ============================================================================
 # Application Launchers

--- a/src/sc_linac_physics/cli/launchers.py
+++ b/src/sc_linac_physics/cli/launchers.py
@@ -186,6 +186,18 @@ def launch_plotter(standalone=True):
 
 
 @display
+def launch_fault_heatmap(standalone=True):
+    """Launch the fault heatmap display."""
+    from sc_linac_physics.displays.cavity_display.frontend.heatmap.fault_heatmap_display import (
+        FaultHeatmapDisplay,
+    )
+
+    return launch_python_display(
+        FaultHeatmapDisplay, *sys.argv[1:], standalone=standalone
+    )
+
+
+@display
 def launch_cryo_signals(standalone=True):
     from sc_linac_physics.displays.plot.cryo_signals import (
         LinacGroupedCryomodulePlotDisplay,

--- a/tests/cli/test_launchers.py
+++ b/tests/cli/test_launchers.py
@@ -264,6 +264,20 @@ class TestDisplayLaunchers:
             assert call_args.args[0] == mock_display
             assert call_args.kwargs["standalone"] is True
 
+    def test_launch_fault_heatmap(self):
+        """Test fault heatmap launcher."""
+        from sc_linac_physics.cli.launchers import launch_fault_heatmap
+
+        with patch(
+            "sc_linac_physics.displays.cavity_display.frontend.heatmap.fault_heatmap_display.FaultHeatmapDisplay"
+        ) as mock_display:
+            launch_fault_heatmap(standalone=True)
+
+            assert self.mock_launch.called
+            call_args = self.mock_launch.call_args
+            assert call_args.args[0] == mock_display
+            assert call_args.kwargs["standalone"] is True
+
 
 class TestApplicationLaunchers:
     """Test application launchers."""


### PR DESCRIPTION
## Summary
- Wire up the fault heatmap display to the CLI so it shows up in `sc-linac list` and can be launched with `sc-linac fault-heatmap`
- Add `sc-fheatmap` shortcut in pyproject.toml
- Add launcher test